### PR TITLE
feat: add 'homebutler config validate' command (#17)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -109,6 +109,8 @@ func Execute(version, buildDate string) error {
 	case "mcp":
 		demo := hasFlag("--demo")
 		return mcp.NewServer(cfg, version, demo).Run()
+	case "config":
+		return runConfig(cfg)
 	case "version", "-v", "--version":
 		fmt.Printf("homebutler %s (built %s, %s)\n", version, buildDate, runtime.Version())
 		return nil
@@ -329,6 +331,27 @@ func runBackup(cfg *config.Config, jsonOut bool) error {
 		return err
 	}
 	return output(result, jsonOut)
+}
+
+func runConfig(cfg *config.Config) error {
+	if len(os.Args) < 3 {
+		return fmt.Errorf("usage: homebutler config <validate>")
+	}
+	switch os.Args[2] {
+	case "validate":
+		errs := cfg.Validate()
+		if len(errs) == 0 {
+			fmt.Println("✅ Config is valid")
+			return nil
+		}
+		fmt.Fprintf(os.Stderr, "❌ Config has %d error(s):\n", len(errs))
+		for _, e := range errs {
+			fmt.Fprintf(os.Stderr, "   • %s\n", e)
+		}
+		return fmt.Errorf("config validation failed")
+	default:
+		return fmt.Errorf("unknown config subcommand: %s (available: validate)", os.Args[2])
+	}
 }
 
 func runRestore(jsonOut bool) error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -169,6 +169,70 @@ func (s *ServerConfig) SSHBinPath() string {
 	return "homebutler"
 }
 
+// ValidationError describes a single configuration validation failure.
+type ValidationError struct {
+	Field   string
+	Message string
+}
+
+func (e ValidationError) Error() string {
+	return fmt.Sprintf("%s: %s", e.Field, e.Message)
+}
+
+// Validate checks the config for missing required fields and invalid values.
+// It returns all validation errors found (not just the first).
+func (c *Config) Validate() []ValidationError {
+	var errs []ValidationError
+
+	for i, s := range c.Servers {
+		prefix := fmt.Sprintf("servers[%d]", i)
+		if s.Name == "" {
+			errs = append(errs, ValidationError{
+				Field:   prefix + ".name",
+				Message: "required field is missing",
+			})
+		}
+		if !s.Local && s.Host == "" {
+			errs = append(errs, ValidationError{
+				Field:   prefix + ".host",
+				Message: "required for remote servers",
+			})
+		}
+		if s.Port != 0 && (s.Port < 1 || s.Port > 65535) {
+			errs = append(errs, ValidationError{
+				Field:   prefix + ".port",
+				Message: fmt.Sprintf("must be between 1 and 65535, got %d", s.Port),
+			})
+		}
+		if s.KeyFile != "" {
+			if _, err := os.Stat(s.KeyFile); os.IsNotExist(err) {
+				errs = append(errs, ValidationError{
+					Field:   prefix + ".key",
+					Message: fmt.Sprintf("file not found: %s", s.KeyFile),
+				})
+			}
+		}
+	}
+
+	for i, w := range c.Wake {
+		prefix := fmt.Sprintf("wake[%d]", i)
+		if w.Name == "" {
+			errs = append(errs, ValidationError{
+				Field:   prefix + ".name",
+				Message: "required field is missing",
+			})
+		}
+		if w.MAC == "" {
+			errs = append(errs, ValidationError{
+				Field:   prefix + ".mac",
+				Message: "required field is missing",
+			})
+		}
+	}
+
+	return errs
+}
+
 func (c *Config) FindWakeTarget(name string) *WakeTarget {
 	for _, t := range c.Wake {
 		if t.Name == name {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -150,3 +150,117 @@ func TestLoadInvalidYaml(t *testing.T) {
 		t.Error("expected error for invalid yaml")
 	}
 }
+
+func TestValidateValid(t *testing.T) {
+	cfg := &Config{
+		Servers: []ServerConfig{
+			{Name: "web", Host: "192.168.1.10", User: "admin"},
+		},
+		Wake: []WakeTarget{
+			{Name: "nas", MAC: "AA:BB:CC:DD:EE:FF"},
+		},
+	}
+	errs := cfg.Validate()
+	if len(errs) != 0 {
+		t.Errorf("expected no errors, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestValidateLocalServerNoHost(t *testing.T) {
+	// Local servers don't need a host
+	cfg := &Config{
+		Servers: []ServerConfig{
+			{Name: "local", Local: true},
+		},
+	}
+	errs := cfg.Validate()
+	if len(errs) != 0 {
+		t.Errorf("expected no errors for local server without host, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestValidateMissingServerName(t *testing.T) {
+	cfg := &Config{
+		Servers: []ServerConfig{
+			{Host: "192.168.1.10"},
+		},
+	}
+	errs := cfg.Validate()
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+	}
+	if errs[0].Field != "servers[0].name" {
+		t.Errorf("expected field servers[0].name, got %q", errs[0].Field)
+	}
+}
+
+func TestValidateMissingRemoteHost(t *testing.T) {
+	cfg := &Config{
+		Servers: []ServerConfig{
+			{Name: "web"},
+		},
+	}
+	errs := cfg.Validate()
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+	}
+	if errs[0].Field != "servers[0].host" {
+		t.Errorf("expected field servers[0].host, got %q", errs[0].Field)
+	}
+}
+
+func TestValidateInvalidPort(t *testing.T) {
+	cfg := &Config{
+		Servers: []ServerConfig{
+			{Name: "web", Host: "10.0.0.1", Port: 99999},
+		},
+	}
+	errs := cfg.Validate()
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+	}
+	if errs[0].Field != "servers[0].port" {
+		t.Errorf("expected field servers[0].port, got %q", errs[0].Field)
+	}
+}
+
+func TestValidateMissingKeyFile(t *testing.T) {
+	cfg := &Config{
+		Servers: []ServerConfig{
+			{Name: "web", Host: "10.0.0.1", KeyFile: "/nonexistent/key.pem"},
+		},
+	}
+	errs := cfg.Validate()
+	if len(errs) != 1 {
+		t.Fatalf("expected 1 error, got %d: %v", len(errs), errs)
+	}
+	if errs[0].Field != "servers[0].key" {
+		t.Errorf("expected field servers[0].key, got %q", errs[0].Field)
+	}
+}
+
+func TestValidateMissingWakeFields(t *testing.T) {
+	cfg := &Config{
+		Wake: []WakeTarget{
+			{Name: "nas"},    // missing MAC
+			{MAC: "AA:BB:CC:DD:EE:FF"}, // missing Name
+		},
+	}
+	errs := cfg.Validate()
+	if len(errs) != 2 {
+		t.Fatalf("expected 2 errors, got %d: %v", len(errs), errs)
+	}
+}
+
+func TestValidateMultipleErrors(t *testing.T) {
+	cfg := &Config{
+		Servers: []ServerConfig{
+			{},               // missing name and host
+			{Name: "valid", Host: "10.0.0.1"}, // fine
+		},
+	}
+	errs := cfg.Validate()
+	if len(errs) != 2 {
+		t.Fatalf("expected 2 errors (name+host missing), got %d: %v", len(errs), errs)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #17

Adds a `homebutler config validate` command that checks the config file for required fields and invalid values without performing any operations.

## Usage

```
$ homebutler config validate
✅ Config is valid

$ homebutler config validate
❌ Config has 2 error(s):
   • servers[0].name: required field is missing
   • servers[1].host: required for remote servers
```

## Changes

### `internal/config/config.go`
- Added `ValidationError` struct with `Field` and `Message`
- Added `Validate() []ValidationError` method on `*Config`

**Checks performed:**
- `servers[i].name` — required
- `servers[i].host` — required for non-local servers
- `servers[i].port` — must be 1–65535 when specified
- `servers[i].key` — file must exist on disk when specified
- `wake[i].name` — required
- `wake[i].mac` — required

All errors are collected before returning (not fail-fast), so the user sees every problem at once.

### `cmd/root.go`
- Added `case "config":` dispatch to `runConfig(cfg)`
- Added `runConfig()` handler with `validate` subcommand

### `internal/config/config_test.go`
- `TestValidateValid` — happy path
- `TestValidateLocalServerNoHost` — local servers don't need a host
- `TestValidateMissingServerName`
- `TestValidateMissingRemoteHost`
- `TestValidateInvalidPort`
- `TestValidateMissingKeyFile`
- `TestValidateMissingWakeFields`
- `TestValidateMultipleErrors` — all errors are returned at once