### PR TITLE
fix: add --dry-run flag to install command

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -37,6 +37,7 @@ Usage:
 
 	installCmd.Flags().String("port", "", "Custom host port")
 	installCmd.Flags().String("media", "", "Media directory to mount (jellyfin)")
+	installCmd.Flags().Bool("dry-run", false, "Do not actually install, just show what would happen")
 
 	installCmd.AddCommand(
 		newInstallListCmd(),
@@ -140,6 +141,7 @@ func runInstallApp(appName string, cmd *cobra.Command) error {
 	// Parse flags from the parent command
 	portFlag, _ := cmd.Flags().GetString("port")
 	mediaFlag, _ := cmd.Flags().GetString("media")
+	dryRunFlag, _ := cmd.Flags().GetBool("dry-run")
 
 	// Validate custom port early
 	if portFlag != "" {
@@ -151,6 +153,7 @@ func runInstallApp(appName string, cmd *cobra.Command) error {
 	opts := install.InstallOptions{
 		Port:     portFlag,
 		MediaDir: mediaFlag,
+		DryRun:   dryRunFlag,
 	}
 
 	port := app.DefaultPort
@@ -186,6 +189,10 @@ func runInstallApp(appName string, cmd *cobra.Command) error {
 	// Install
 	if err := install.Install(app, opts); err != nil {
 		return err
+	}
+
+	if opts.DryRun {
+		return nil
 	}
 
 	// Verify

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -612,6 +612,20 @@ func Install(app App, opts InstallOptions) error {
 		return fmt.Errorf("invalid compose template: %w", err)
 	}
 
+	if opts.DryRun {
+		fmt.Printf("✨ [Dry Run] Rendered docker-compose.yml for %s:\n\n", app.Name)
+		if err := tmpl.Execute(os.Stdout, ctx); err != nil {
+			return fmt.Errorf("failed to render compose file to stdout: %w", err)
+		}
+		fmt.Printf("\n✨ [Dry Run] Would run: docker compose -f %s up -d\n", filepath.Join(appDir, "docker-compose.yml"))
+		return nil
+	}
+
+	// Create directories
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		return fmt.Errorf("failed to create directory %s: %w", dataDir, err)
+	}
+
 	composeFile := filepath.Join(appDir, "docker-compose.yml")
 	f, err := os.Create(composeFile)
 	if err != nil {
@@ -621,12 +635,6 @@ func Install(app App, opts InstallOptions) error {
 
 	if err := tmpl.Execute(f, ctx); err != nil {
 		return fmt.Errorf("failed to render compose file: %w", err)
-	}
-
-	// Dry run: stop after rendering compose file
-	if opts.DryRun {
-		fmt.Fprintf(os.Stderr, "✨ [Dry Run] Would run: docker compose -f %s up -d\n", composeFile)
-		return nil
 	}
 
 	// Run docker compose up

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -89,6 +89,7 @@ type App struct {
 type InstallOptions struct {
 	Port     string // custom host port
 	MediaDir string // media directory (jellyfin)
+	DryRun   bool   // do not actually install, just show what would happen
 }
 
 // composeContext is passed to the compose template.
@@ -620,6 +621,12 @@ func Install(app App, opts InstallOptions) error {
 
 	if err := tmpl.Execute(f, ctx); err != nil {
 		return fmt.Errorf("failed to render compose file: %w", err)
+	}
+
+	// Dry run: stop after rendering compose file
+	if opts.DryRun {
+		fmt.Fprintf(os.Stderr, "✨ [Dry Run] Would run: docker compose -f %s up -d\n", composeFile)
+		return nil
 	}
 
 	// Run docker compose up

--- a/internal/install/install_test.go
+++ b/internal/install/install_test.go
@@ -1,6 +1,7 @@
 package install
 
 import (
+	"io"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -766,5 +767,48 @@ func TestValidatePort(t *testing.T) {
 				t.Errorf("ValidatePort(%q) error=%v, wantErr=%v", tt.port, err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestInstallDryRun(t *testing.T) {
+	tmpDir, _ := os.MkdirTemp("", "homebutler-dryrun-*")
+	defer os.RemoveAll(tmpDir)
+
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+
+	app := Registry["uptime-kuma"]
+	opts := InstallOptions{DryRun: true}
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	err := Install(app, opts)
+	
+	w.Close()
+	os.Stdout = oldStdout
+
+	if err != nil {
+		t.Fatalf("Install dry-run failed: %v", err)
+	}
+
+	var buf strings.Builder
+	_, _ = io.Copy(&buf, r)
+	output := buf.String()
+
+	if !strings.Contains(output, "[Dry Run]") {
+		t.Error("Dry run output should contain '[Dry Run]'")
+	}
+	if !strings.Contains(output, "image: louislam/uptime-kuma:1") {
+		t.Error("Dry run output should contain rendered compose content")
+	}
+
+	// Verify no files/directories created
+	appDir := AppDir(app.Name)
+	if _, err := os.Stat(appDir); !os.IsNotExist(err) {
+		t.Errorf("App directory %s should not exist after dry-run", appDir)
 	}
 }


### PR DESCRIPTION
This PR adds a `--dry-run` flag to the `install` command, allowing users to see what would happen before actually performing the installation. Fixes #23.