### PR TITLE
fix: watch start never loaded config.yaml, silently disabling notify

### DIFF
--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -323,6 +323,12 @@ func newWatchStartCmd() *cobra.Command {
 		Long: `Start foreground monitoring using event-based or polling monitors.
 Docker targets use docker events (real-time). Systemd and PM2 targets use polling.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Other commands load the global config here; this one didn't,
+			// so config.yaml's notify settings were never reachable below.
+			if err := loadConfig(); err != nil {
+				return err
+			}
+
 			dur, err := time.ParseDuration(interval)
 			if err != nil {
 				return fmt.Errorf("invalid interval %q: %w", interval, err)


### PR DESCRIPTION
## Bug

`watch start`'s `RunE` never calls `loadConfig()`, unlike every other command in this codebase (`doctor`, `alerts`, `status`, etc.). That leaves the global `cfg` `nil` for the command's entire runtime, so this override a few lines further down silently never runs:

```go
if cfg != nil {
    watchCfg.Notify = cfg.Watch.Notify
    watchCfg.Flapping = cfg.Watch.Flapping
}
```

Because of that, `config.yaml`'s `notify:` / `watch.notify` settings can never reach `watch start`'s notifier construction — regardless of how they're configured. `watchCfg.Notify.Enabled` falls back to whatever `~/.homebutler/watch/config.json` says (or `DefaultWatchConfig()`, which hardcodes `Enabled: false`, if that file doesn't exist).

**Symptom**: `watch start` correctly detects and logs incidents, including flapping — but never dispatches a notification, with no error printed anywhere. I confirmed via `strace` that no network connection is even attempted at incident time; the notifier-construction code path is silently unreachable, not failing downstream.

## Fix

Add the missing `loadConfig()` call at the top of `watch start`'s `RunE`, matching the pattern already used by every other command that depends on the global config.

## Verification

Reproduced on a live host, then fixed and re-verified end-to-end:
- Confirmed the bug: `enabled: true` + a valid `notify.webhook.url` in `config.yaml`, `watch start` detects a real container restart/flapping incident, zero network calls made (via `strace`), nothing dispatched.
- Built this fix, restarted `watch start` with the same unmodified `config.yaml`, triggered fresh container restarts, and confirmed correctly formatted webhook notifications now arrive at the configured endpoint — using only the documented `config.yaml` schema, no workarounds (no `~/.homebutler/alerts.yaml`, no `watch/config.json`).

## Scope

One file, one call added, comment trimmed to explain the why. No other behavior changed.