### PR TITLE
test: add fixture tests for inventory port parsing

### DIFF
--- a/internal/inventory/portparse_fixture_test.go
+++ b/internal/inventory/portparse_fixture_test.go
@@ -1,0 +1,106 @@
+package inventory
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Higangssh/homebutler/internal/ports"
+)
+
+// portExpect captures the fields the fixture tests assert on for a single port.
+type portExpect struct {
+	port    string
+	process string
+	address string
+	public  bool
+}
+
+func TestParseLinuxSSFixture(t *testing.T) {
+	out := mustReadFixture(t, "ss-linux.txt")
+	parsed := ports.ParseLinuxOutput(string(out))
+
+	if len(parsed) != 5 {
+		t.Fatalf("expected 5 parsed ports from ss fixture, got %d", len(parsed))
+	}
+
+	expects := []portExpect{
+		{port: "8080", process: "app-api", address: "0.0.0.0", public: true},
+		{port: "443", process: "demo-service", address: "[::]", public: true},
+		{port: "9090", process: "metrics-agent", address: "127.0.0.1", public: false},
+		{port: "8443", process: "edge-router", address: "0.0.0.0", public: true},
+		{port: "22", process: "ssh-relay", address: "0.0.0.0", public: true},
+	}
+
+	for _, e := range expects {
+		p, ok := findPortByNumber(parsed, e.port)
+		if !ok {
+			t.Errorf("port %s: not found in parsed output", e.port)
+			continue
+		}
+		assertPort(t, e, p)
+	}
+}
+
+func TestParseDarwinLsofFixture(t *testing.T) {
+	out := mustReadFixture(t, "lsof-macos.txt")
+	parsed := ports.ParseDarwinOutput(string(out))
+
+	// 5 input lines, but the IPv4/IPv6 *:8080 pair for app-api is deduped to 1.
+	if len(parsed) != 4 {
+		t.Fatalf("expected 4 parsed ports from lsof fixture (after IPv4/IPv6 dedup), got %d", len(parsed))
+	}
+
+	expects := []portExpect{
+		{port: "8080", process: "app-api", address: "*", public: true},
+		{port: "443", process: "demo-service", address: "*", public: true},
+		{port: "9090", process: "metrics-agent", address: "127.0.0.1", public: false},
+		{port: "8443", process: "edge-router", address: "*", public: true},
+	}
+
+	for _, e := range expects {
+		p, ok := findPortByNumber(parsed, e.port)
+		if !ok {
+			t.Errorf("port %s: not found in parsed output", e.port)
+			continue
+		}
+		assertPort(t, e, p)
+	}
+}
+
+func mustReadFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("read fixture %s: %v", name, err)
+	}
+	return data
+}
+
+func findPortByNumber(list []ports.PortInfo, port string) (ports.PortInfo, bool) {
+	for _, p := range list {
+		if p.Port == port {
+			return p, true
+		}
+	}
+	return ports.PortInfo{}, false
+}
+
+func assertPort(t *testing.T, e portExpect, p ports.PortInfo) {
+	t.Helper()
+	if p.Protocol != "tcp" {
+		t.Errorf("port %s: protocol = %q, want tcp", e.port, p.Protocol)
+	}
+	if p.Port != e.port {
+		t.Errorf("port %s: port number = %q, want %q", e.port, p.Port, e.port)
+	}
+	if p.Process != e.process {
+		t.Errorf("port %s: process = %q, want %q", e.port, p.Process, e.process)
+	}
+	if p.Address != e.address {
+		t.Errorf("port %s: address = %q, want %q", e.port, p.Address, e.address)
+	}
+	if got := isPublicBind(p.Address); got != e.public {
+		t.Errorf("port %s: exposure public = %v, want %v (address %q)", e.port, got, e.public, p.Address)
+	}
+}

--- a/internal/inventory/testdata/lsof-macos.txt
+++ b/internal/inventory/testdata/lsof-macos.txt
@@ -1,0 +1,6 @@
+COMMAND       PID    USER     FD   TYPE  DEVICE     SIZE/OFF  NODE NAME
+app-api       1001  appuser   3u   IPv4 0xabc123    0t0       TCP *:8080 (LISTEN)
+app-api       1001  appuser   4u   IPv6 0xabc124    0t0       TCP *:8080 (LISTEN)
+demo-service  1002  appuser   6u   IPv4 0xabc125    0t0       TCP *:443 (LISTEN)
+metrics-agent 1003  appuser  22u   IPv4 0xabc126    0t0       TCP 127.0.0.1:9090 (LISTEN)
+edge-router   1004  appuser   3u   IPv4 0xabc127    0t0       TCP *:8443 (LISTEN)

--- a/internal/inventory/testdata/ss-linux.txt
+++ b/internal/inventory/testdata/ss-linux.txt
@@ -1,0 +1,6 @@
+State    Recv-Q   Send-Q    Local Address:Port    Peer Address:Port   Process
+LISTEN   0        128        0.0.0.0:8080          0.0.0.0:*           users:(("app-api",pid=1001,fd=3))
+LISTEN   0        511        [::]:443              [::]:*              users:(("demo-service",pid=1002,fd=4))
+LISTEN   0        128        127.0.0.1:9090        0.0.0.0:*           users:(("metrics-agent",pid=1003,fd=5))
+LISTEN   0        128        0.0.0.0:8443          0.0.0.0:*           users:(("edge-router",pid=1004,fd=3))
+LISTEN   0        128        0.0.0.0:22            0.0.0.0:*           users:(("ssh-relay",pid=1005,fd=3))

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -54,11 +54,11 @@ func listDarwin() ([]PortInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to list ports: %w", err)
 	}
-	return parseDarwinOutput(out), nil
+	return ParseDarwinOutput(out), nil
 }
 
-// parseDarwinOutput parses lsof -iTCP -sTCP:LISTEN -nP output into PortInfo slices.
-func parseDarwinOutput(out string) []PortInfo {
+// ParseDarwinOutput parses lsof -iTCP -sTCP:LISTEN -nP output into PortInfo slices.
+func ParseDarwinOutput(out string) []PortInfo {
 	var ports []PortInfo
 	seen := make(map[string]bool)
 
@@ -95,11 +95,11 @@ func listLinux() ([]PortInfo, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to list ports: %w", err)
 	}
-	return parseLinuxOutput(out), nil
+	return ParseLinuxOutput(out), nil
 }
 
-// parseLinuxOutput parses ss -tlnp output into PortInfo slices.
-func parseLinuxOutput(out string) []PortInfo {
+// ParseLinuxOutput parses ss -tlnp output into PortInfo slices.
+func ParseLinuxOutput(out string) []PortInfo {
 	var ports []PortInfo
 	for _, line := range strings.Split(out, "\n") {
 		fields := strings.Fields(line)

--- a/internal/ports/ports_test.go
+++ b/internal/ports/ports_test.go
@@ -34,7 +34,7 @@ node       1234 sanghee   22u  IPv4 0x123456793      0t0  TCP 127.0.0.1:3000 (LI
 nginx      5678   root     6u  IPv4 0x123456794      0t0  TCP *:80 (LISTEN)
 nginx      5678   root     7u  IPv4 0x123456795      0t0  TCP *:443 (LISTEN)`
 
-	ports := parseDarwinOutput(output)
+	ports := ParseDarwinOutput(output)
 
 	if len(ports) != 5 {
 		t.Fatalf("expected 5 ports (deduped), got %d", len(ports))
@@ -64,7 +64,7 @@ nginx      5678   root     7u  IPv4 0x123456795      0t0  TCP *:443 (LISTEN)`
 }
 
 func TestParseDarwinOutput_Empty(t *testing.T) {
-	ports := parseDarwinOutput("")
+	ports := ParseDarwinOutput("")
 	if len(ports) != 0 {
 		t.Fatalf("expected 0 ports for empty input, got %d", len(ports))
 	}
@@ -72,7 +72,7 @@ func TestParseDarwinOutput_Empty(t *testing.T) {
 
 func TestParseDarwinOutput_HeaderOnly(t *testing.T) {
 	output := "COMMAND     PID   USER   FD   TYPE             DEVICE SIZE/OFF NODE NAME"
-	ports := parseDarwinOutput(output)
+	ports := ParseDarwinOutput(output)
 	if len(ports) != 0 {
 		t.Fatalf("expected 0 ports for header-only input, got %d", len(ports))
 	}
@@ -84,7 +84,7 @@ func TestParseDarwinOutput_Deduplication(t *testing.T) {
 nginx      5678   root     6u  IPv4 0x123456794      0t0  TCP *:80 (LISTEN)
 nginx      5678   root     7u  IPv4 0x123456795      0t0  TCP *:80 (LISTEN)`
 
-	ports := parseDarwinOutput(output)
+	ports := ParseDarwinOutput(output)
 	if len(ports) != 1 {
 		t.Fatalf("expected 1 port (deduped), got %d", len(ports))
 	}
@@ -97,7 +97,7 @@ LISTEN     0      511          0.0.0.0:80          0.0.0.0:*     users:(("nginx"
 LISTEN     0      128        127.0.0.1:3000        0.0.0.0:*     users:(("node",pid=9012,fd=22))
 LISTEN     0      128             [::]:443            [::]:*     users:(("nginx",pid=5678,fd=7))`
 
-	ports := parseLinuxOutput(output)
+	ports := ParseLinuxOutput(output)
 
 	if len(ports) != 4 {
 		t.Fatalf("expected 4 ports, got %d", len(ports))
@@ -124,7 +124,7 @@ LISTEN     0      128             [::]:443            [::]:*     users:(("nginx"
 }
 
 func TestParseLinuxOutput_Empty(t *testing.T) {
-	ports := parseLinuxOutput("")
+	ports := ParseLinuxOutput("")
 	if len(ports) != 0 {
 		t.Fatalf("expected 0 ports for empty input, got %d", len(ports))
 	}
@@ -132,7 +132,7 @@ func TestParseLinuxOutput_Empty(t *testing.T) {
 
 func TestParseLinuxOutput_HeaderOnly(t *testing.T) {
 	output := "State      Recv-Q Send-Q Local Address:Port   Peer Address:Port Process"
-	ports := parseLinuxOutput(output)
+	ports := ParseLinuxOutput(output)
 	if len(ports) != 0 {
 		t.Fatalf("expected 0 ports for header-only input, got %d", len(ports))
 	}
@@ -142,7 +142,7 @@ func TestParseLinuxOutput_NoProcessInfo(t *testing.T) {
 	output := `State      Recv-Q Send-Q Local Address:Port   Peer Address:Port Process
 LISTEN     0      128          0.0.0.0:22          0.0.0.0:*`
 
-	ports := parseLinuxOutput(output)
+	ports := ParseLinuxOutput(output)
 	if len(ports) != 1 {
 		t.Fatalf("expected 1 port, got %d", len(ports))
 	}
@@ -158,7 +158,7 @@ func TestParseLinuxOutput_IPv6(t *testing.T) {
 	output := `State      Recv-Q Send-Q Local Address:Port   Peer Address:Port Process
 LISTEN     0      128             [::]:80              [::]:*     users:(("apache2",pid=999,fd=4))`
 
-	ports := parseLinuxOutput(output)
+	ports := ParseLinuxOutput(output)
 	if len(ports) != 1 {
 		t.Fatalf("expected 1 port, got %d", len(ports))
 	}


### PR DESCRIPTION
Export ParseLinuxOutput and ParseDarwinOutput from internal/ports so the inventory package can drive fixture-based tests without spawning ss/lsof. Runtime command execution is unchanged.

Add testdata fixtures for Linux ss and macOS lsof output using generic dummy processes (app-api, demo-service, metrics-agent, edge-router, ssh-relay). Tests assert protocol, port number, process name, address, and public/local exposure classification.

Closes #29


