### PR TITLE
feat: add `homebutler config validate` (#17)

### DIFF
--- a/README.md
+++ b/README.md
@@ -333,6 +333,22 @@ Legacy `~/.homebutler/watch/config.json` is still read as a fallback for watch-s
 - `watch.cooldown: 5m` — suppress duplicate notifications for the same event fingerprint during the cooldown window
 - `watch.flapping` — optional advanced tuning for restart-loop detection
 
+These settings can also be written under a `watch.notify:` block, which is the
+canonical form:
+
+```yaml
+watch:
+  notify:
+    enabled: true
+    notify_on: flapping
+    cooldown: 5m
+  flapping:
+    short_window: 10m
+```
+
+Both spellings are read, so either layout works. If a file contains both, the
+`notify:` block wins and `homebutler config validate` says so.
+
 #### Manage targets
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -122,6 +122,32 @@ homebutler doctor --json            # automation / MCP friendly
 
 `doctor` is a read-only preflight for the problems homelab users usually discover too late: high disk or memory usage, stopped containers, public bind ports, stale or missing backups, missing notifications, and whether `report` has a baseline for change detection.
 
+### 🗂 Config Validation
+
+```bash
+homebutler config validate
+homebutler config validate --strict   # exit non-zero on warnings too
+homebutler config validate --json
+```
+
+`config validate` reads your config without starting anything and tells you
+which file was used, which of the four resolution rules picked it, and what
+homebutler actually made of each section. It exists because the two ways config
+goes wrong are both silent: a key homebutler does not recognise is dropped
+without a word, and a `--config` path that does not exist falls back to
+built-in defaults rather than failing.
+
+```text
+Sections
+   ✓ servers     2 servers (homelab, nas)
+   · notify      not set
+   ✓ alerts      cpu 95% · memory 85% · disk 90%
+
+Findings
+   ⚠️ Line 5: field notifiy not found in the homebutler config
+      → Did you mean "notify"? Unrecognised keys are ignored silently.
+```
+
 ### 📦 One-Command App Install
 
 <p align="center">
@@ -427,6 +453,7 @@ homebutler <command> [flags]
 Commands:
   status              System status (CPU, memory, disk, uptime)
   doctor              Diagnose health, exposure, backups, and readiness
+  config validate     Check the config file and report what is ignored
   docker list         List running containers
   install <app>       Install a self-hosted app (docker compose)
   alerts              Show current alert status
@@ -452,6 +479,7 @@ Run `homebutler --help` for all commands.
 ```
 Commands:
   init                Interactive setup wizard
+  config validate     Check the config file and report what is ignored
   status              System status (CPU, memory, disk, uptime)
   doctor              Diagnose health, exposure, backups, and readiness
   watch tui           TUI dashboard (monitors all configured servers)

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/Higangssh/homebutler/internal/config"
+	"github.com/spf13/cobra"
+)
+
+func newConfigCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Inspect homebutler configuration",
+	}
+	cmd.AddCommand(newConfigValidateCmd())
+	return cmd
+}
+
+func newConfigValidateCmd() *cobra.Command {
+	var strict bool
+
+	cmd := &cobra.Command{
+		Use:   "validate",
+		Short: "Check the config file and report what homebutler makes of it",
+		Long: `Validate the config file without starting a server, watcher, install, or
+remote connection.
+
+Reports which file was used and which rule selected it, what homebutler read
+from each section, and anything that is wrong or silently ignored — including
+keys that do not match the schema, which are otherwise dropped without a word.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			// Deliberately not loadConfig(): it treats an unreadable or
+			// missing file as "use defaults", which is exactly the failure
+			// this command exists to surface. Validate resolves the path
+			// itself. For the same reason there is no remote routing —
+			// the file being checked is the local one.
+			result := config.Validate(cfgPath)
+
+			if jsonOutput {
+				if err := output(result, true); err != nil {
+					return err
+				}
+			} else {
+				fmt.Print(config.FormatValidation(result))
+			}
+
+			if errs := result.Errors(); errs > 0 {
+				return fmt.Errorf("config has %d error(s)", errs)
+			}
+			if strict && result.Warnings() > 0 {
+				return fmt.Errorf("config has %d warning(s)", result.Warnings())
+			}
+			return nil
+		},
+	}
+
+	cmd.Flags().BoolVar(&strict, "strict", false, "Exit non-zero when warnings are found, not just errors")
+
+	return cmd
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -56,6 +56,7 @@ func init() {
 		newInventoryCmd(),
 		newReportCmd(),
 		newDoctorCmd(),
+		newConfigCmd(),
 	)
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,6 +41,45 @@ cp homebutler.example.yaml homebutler.yaml
 
 See [homebutler.example.yaml](../homebutler.example.yaml) for all options.
 
+## Validating Your Config
+
+```bash
+homebutler config validate
+homebutler config validate --config ./homebutler.yaml
+homebutler config validate --strict   # exit non-zero on warnings too
+homebutler config validate --json
+```
+
+`config validate` is read-only: it starts no server, watcher, or install, and
+never connects to a remote host. It reports three things.
+
+**Which file was used, and which rule selected it.** With four resolution rules,
+editing the wrong file is an easy mistake to make.
+
+**What homebutler read from each section.** A section the file never set is
+listed as `not set`, which is usually the answer to "why is my notify config
+being ignored?".
+
+**What is wrong or silently ignored.** Errors mean something will not work;
+warnings mean the config parses but probably does not do what you intended:
+
+```text
+Findings
+   ⚠️ Line 5: field notifiy not found in the homebutler config
+      → Did you mean "notify"? Unrecognised keys are ignored silently, so this
+        line currently has no effect.
+   ❌ servers[0].host: Host is required for remote servers.
+      → Set host, or set local: true if this entry is the machine homebutler runs on.
+```
+
+Two cases are worth calling out because nothing else surfaces them:
+
+- **A key homebutler does not recognise is dropped without a word.** A typo
+  such as `notifiy:` leaves notifications switched off with no error anywhere.
+- **A `--config` path that does not exist falls back to built-in defaults**
+  rather than failing, so commands run and succeed against a config that was
+  never read. `config validate` reports this as an error.
+
 ## Alert Thresholds
 
 **Default thresholds** (no config needed):
@@ -60,11 +99,13 @@ alerts:
 ## Backup Directory
 
 ```yaml
-backup:
-  dir: /mnt/nas/backups/homebutler
+backup_dir: /mnt/nas/backups/homebutler
 ```
 
 Default: `~/.homebutler/backups/`
+
+Run `homebutler config validate` after changing this — a mistyped key here is
+dropped silently, and backups keep going to the default location.
 
 ## Output Format
 

--- a/homebutler.example.yaml
+++ b/homebutler.example.yaml
@@ -33,5 +33,9 @@ alerts:
   memory: 85    # percent
   disk: 90      # percent
 
-# Output format: text, json
-output: json
+# Backup directory (optional)
+# backup_dir: /mnt/nas/backups/homebutler
+
+# Output format is a per-command flag, not a config key: homebutler <cmd> --json
+
+# Check this file with: homebutler config validate

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -62,35 +62,74 @@ type AlertConfig struct {
 	Disk   float64 `yaml:"disk"`
 }
 
-// Resolve finds the config file path using the following priority:
+// Source identifies which resolution rule produced the config path.
+type Source string
+
+const (
+	SourceFlag Source = "flag" // --config
+	SourceEnv  Source = "env"  // $HOMEBUTLER_CONFIG
+	SourceXDG  Source = "xdg"  // ~/.config/homebutler/config.yaml
+	SourceCwd  Source = "cwd"  // ./homebutler.yaml
+	SourceNone Source = "none" // nothing found; built-in defaults apply
+)
+
+// Describe returns a human-readable form of the rule that produced the path.
+func (s Source) Describe() string {
+	switch s {
+	case SourceFlag:
+		return "--config flag"
+	case SourceEnv:
+		return "$HOMEBUTLER_CONFIG"
+	case SourceXDG:
+		return "~/.config/homebutler/config.yaml (XDG)"
+	case SourceCwd:
+		return "./homebutler.yaml"
+	default:
+		return "no config file found (using defaults)"
+	}
+}
+
+// ResolveWithSource finds the config file path using the following priority:
 //  1. Explicit path (--config flag)
 //  2. $HOMEBUTLER_CONFIG environment variable
 //  3. ~/.config/homebutler/config.yaml (XDG standard)
 //  4. ./homebutler.yaml (current directory)
 //
-// Returns empty string if no config file is found (defaults will be used).
-func Resolve(explicit string) string {
+// Returns an empty path and SourceNone if no config file is found (defaults
+// will be used). Note that the first two rules do not check that the file
+// exists: a path the user named explicitly is returned as-is, so that a
+// mistyped one can be reported rather than silently falling through to the
+// next rule.
+func ResolveWithSource(explicit string) (string, Source) {
 	if explicit != "" {
-		return explicit
+		return explicit, SourceFlag
 	}
 	if env := os.Getenv("HOMEBUTLER_CONFIG"); env != "" {
-		return env
+		return env, SourceEnv
 	}
 	if home, err := os.UserHomeDir(); err == nil {
 		xdg := filepath.Join(home, ".config", "homebutler", "config.yaml")
 		if _, err := os.Stat(xdg); err == nil {
-			return xdg
+			return xdg, SourceXDG
 		}
 	}
 	if _, err := os.Stat("homebutler.yaml"); err == nil {
-		return "homebutler.yaml"
+		return "homebutler.yaml", SourceCwd
 	}
-	return ""
+	return "", SourceNone
 }
 
-func Load(path string) (*Config, error) {
+// Resolve finds the config file path. See ResolveWithSource for the priority.
+func Resolve(explicit string) string {
+	path, _ := ResolveWithSource(explicit)
+	return path
+}
+
+// newDefaultConfig returns the config Load starts from before a file is
+// applied. Validate uses it too, so both see the same baseline.
+func newDefaultConfig() *Config {
 	defaultWatch := watch.DefaultWatchConfig()
-	cfg := &Config{
+	return &Config{
 		Alerts: AlertConfig{
 			CPU:    90,
 			Memory: 85,
@@ -101,6 +140,10 @@ func Load(path string) (*Config, error) {
 			Flapping: defaultWatch.Flapping,
 		},
 	}
+}
+
+func Load(path string) (*Config, error) {
+	cfg := newDefaultConfig()
 
 	if path == "" {
 		return cfg, nil // no config file, use defaults

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -26,6 +26,80 @@ type WatchRuntimeConfig struct {
 	Flapping watch.FlappingConfig `yaml:"flapping,omitempty"`
 }
 
+// watchRuntimeYAML is the decode target for WatchRuntimeConfig. It carries the
+// canonical nested shape plus the flat keys, as pointers so that "absent" and
+// "set to the zero value" stay distinguishable.
+type watchRuntimeYAML struct {
+	Notify   watch.NotifySettings `yaml:"notify,omitempty"`
+	Flapping watch.FlappingConfig `yaml:"flapping,omitempty"`
+
+	Enabled    *bool   `yaml:"enabled,omitempty"`
+	NotifyOn   *string `yaml:"notify_on,omitempty"`
+	OnIncident *bool   `yaml:"on_incident,omitempty"`
+	OnFlapping *bool   `yaml:"on_flapping,omitempty"`
+	Cooldown   *string `yaml:"cooldown,omitempty"`
+}
+
+// UnmarshalYAML accepts both spellings of the watch notification settings:
+//
+//	watch:            # canonical
+//	  notify:
+//	    enabled: true
+//
+//	watch:            # flat, as the README documented it
+//	  enabled: true
+//
+// The flat keys were never part of the schema, so a config copied from the
+// README parsed without complaint and then ran with notifications off — the
+// same symptom as #31, from a different cause. Correcting only the docs would
+// have left those configs silently broken, so both spellings are read.
+//
+// A file containing both forms gets the nested block; the flat keys are a
+// compatibility path, not an override.
+func (w *WatchRuntimeConfig) UnmarshalYAML(node *yaml.Node) error {
+	// Seeded with the current value so that defaults applied before decoding
+	// survive keys the file does not mention.
+	raw := watchRuntimeYAML{Notify: w.Notify, Flapping: w.Flapping}
+	if err := node.Decode(&raw); err != nil {
+		return err
+	}
+	w.Notify = raw.Notify
+	w.Flapping = raw.Flapping
+
+	if hasMappingKey(node, "notify") {
+		return nil
+	}
+	if raw.Enabled != nil {
+		w.Notify.Enabled = *raw.Enabled
+	}
+	if raw.NotifyOn != nil {
+		w.Notify.NotifyOn = *raw.NotifyOn
+	}
+	if raw.OnIncident != nil {
+		w.Notify.OnIncident = *raw.OnIncident
+	}
+	if raw.OnFlapping != nil {
+		w.Notify.OnFlapping = *raw.OnFlapping
+	}
+	if raw.Cooldown != nil {
+		w.Notify.Cooldown = *raw.Cooldown
+	}
+	return nil
+}
+
+// hasMappingKey reports whether a YAML mapping contains the given key.
+func hasMappingKey(node *yaml.Node, key string) bool {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return false
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return true
+		}
+	}
+	return false
+}
+
 // ResolveBackupDir returns the backup directory from config or the default ~/.homebutler/backups/.
 func (c *Config) ResolveBackupDir() string {
 	if c.BackupDir != "" {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -420,3 +420,100 @@ func findSubstr(s, substr string) bool {
 	}
 	return false
 }
+
+// The README documented the flat form long before watch.notify existed, so
+// configs written from it must keep working. See WatchRuntimeConfig.UnmarshalYAML.
+func TestLoadFlatWatchForm(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "flat.yaml")
+	content := `
+watch:
+  enabled: true
+  notify_on: incident
+  cooldown: 9m
+  flapping:
+    short_threshold: 7
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if !cfg.Watch.Notify.Enabled {
+		t.Error("watch.enabled should reach Notify.Enabled")
+	}
+	if cfg.Watch.Notify.NotifyOn != "incident" {
+		t.Errorf("notify_on = %q, want incident", cfg.Watch.Notify.NotifyOn)
+	}
+	if cfg.Watch.Notify.Cooldown != "9m" {
+		t.Errorf("cooldown = %q, want 9m", cfg.Watch.Notify.Cooldown)
+	}
+	if cfg.Watch.Flapping.ShortThreshold != 7 {
+		t.Errorf("flapping short_threshold = %d, want 7", cfg.Watch.Flapping.ShortThreshold)
+	}
+	// Normalize still runs, so the derived booleans follow notify_on.
+	if !cfg.Watch.Notify.OnIncident || cfg.Watch.Notify.OnFlapping {
+		t.Errorf("notify_on=incident should set OnIncident only, got %+v", cfg.Watch.Notify)
+	}
+}
+
+func TestLoadNestedWatchFormWinsOverFlat(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "both.yaml")
+	content := `
+watch:
+  enabled: true
+  cooldown: 9m
+  notify:
+    enabled: false
+    cooldown: 1m
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if cfg.Watch.Notify.Enabled {
+		t.Error("the nested block should win over the flat key")
+	}
+	if cfg.Watch.Notify.Cooldown != "1m" {
+		t.Errorf("cooldown = %q, want 1m from the nested block", cfg.Watch.Notify.Cooldown)
+	}
+}
+
+// Keys the file does not mention must keep the defaults Load seeded.
+func TestLoadWatchDefaultsSurvivePartialSpec(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "partial.yaml")
+	content := `
+watch:
+  flapping:
+    short_threshold: 7
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+
+	if cfg.Watch.Notify.Cooldown != "5m" {
+		t.Errorf("cooldown = %q, want the 5m default", cfg.Watch.Notify.Cooldown)
+	}
+	if cfg.Watch.Flapping.LongThreshold != 5 {
+		t.Errorf("long_threshold = %d, want the default 5", cfg.Watch.Flapping.LongThreshold)
+	}
+	if cfg.Watch.Flapping.ShortThreshold != 7 {
+		t.Errorf("short_threshold = %d, want the configured 7", cfg.Watch.Flapping.ShortThreshold)
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"sort"
 	"strings"
 	"time"
@@ -131,8 +132,14 @@ func Validate(explicit string) *ValidationResult {
 	}
 	cfg.Path = path
 
+	// Shape errors were already reported by the decode above; anything that
+	// fails here just yields an empty map and no presence information.
+	var rawTop map[string]yaml.Node
+	_ = yaml.Unmarshal(data, &rawTop)
+
 	r.checkUnknownKeys(data)
-	r.Sections = describeSections(data, cfg)
+	r.checkWatchKeys(rawTop)
+	r.Sections = describeSections(rawTop, cfg)
 	r.checkPermissions(path, cfg)
 	r.checkServers(cfg)
 	r.checkWake(cfg)
@@ -251,15 +258,74 @@ func editDistance(a, b string) int {
 	return prev[len(b)]
 }
 
+// Keys accepted under watch:. The flat spellings are the compatibility path
+// described on WatchRuntimeConfig.UnmarshalYAML.
+var (
+	watchKeys       = []string{"notify", "flapping", "enabled", "notify_on", "on_incident", "on_flapping", "cooldown"}
+	watchNotifyKeys = []string{"enabled", "notify_on", "on_incident", "on_flapping", "cooldown"}
+	watchFlapKeys   = []string{"short_window", "short_threshold", "long_window", "long_threshold"}
+)
+
+// checkWatchKeys inspects the watch subtree by hand.
+//
+// WatchRuntimeConfig has a custom unmarshaler, and a custom unmarshaler
+// decodes its own node without inheriting the parent decoder's KnownFields
+// setting. Unknown keys under watch: would therefore pass unreported, which
+// is the failure this whole command exists to prevent.
+func (r *ValidationResult) checkWatchKeys(rawTop map[string]yaml.Node) {
+	node, ok := rawTop["watch"]
+	if !ok || node.Kind != yaml.MappingNode {
+		return
+	}
+
+	r.reportUnknownKeys(&node, "watch", watchKeys)
+
+	var flat []string
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		switch key := node.Content[i].Value; key {
+		case "notify":
+			r.reportUnknownKeys(node.Content[i+1], "watch.notify", watchNotifyKeys)
+		case "flapping":
+			r.reportUnknownKeys(node.Content[i+1], "watch.flapping", watchFlapKeys)
+		default:
+			if slices.Contains(watchKeys, key) {
+				flat = append(flat, key)
+			}
+		}
+	}
+
+	if len(flat) > 0 && hasMappingKey(&node, "notify") {
+		r.add(SeverityWarning, "watch",
+			fmt.Sprintf("Both watch.notify and the flat form (%s) are set.", strings.Join(flat, ", ")),
+			"The watch.notify block wins and the flat keys are ignored. Keep one form.")
+	}
+}
+
+// reportUnknownKeys flags mapping keys that are not in the accepted set.
+func (r *ValidationResult) reportUnknownKeys(node *yaml.Node, prefix string, known []string) {
+	if node == nil || node.Kind != yaml.MappingNode {
+		return
+	}
+	for i := 0; i+1 < len(node.Content); i += 2 {
+		key := node.Content[i].Value
+		if slices.Contains(known, key) {
+			continue
+		}
+		hint := "Unrecognised keys are ignored silently, so this line currently has no effect."
+		if best, ok := closestKey(key, known); ok {
+			hint = fmt.Sprintf("Did you mean %q? %s", best, hint)
+		}
+		r.add(SeverityWarning, prefix+"."+key,
+			fmt.Sprintf("Line %d: field %s not found in %s", node.Content[i].Line, key, prefix), hint)
+	}
+}
+
 // describeSections reports, for each top-level key, whether the file set it
 // and what the resulting configuration is.
-func describeSections(data []byte, cfg *Config) []Section {
+func describeSections(rawTop map[string]yaml.Node, cfg *Config) []Section {
 	present := map[string]bool{}
-	var raw map[string]yaml.Node
-	if err := yaml.Unmarshal(data, &raw); err == nil {
-		for k := range raw {
-			present[k] = true
-		}
+	for k := range rawTop {
+		present[k] = true
 	}
 
 	sections := make([]Section, 0, len(topLevelKeys))

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -429,18 +429,15 @@ func (r *ValidationResult) checkServers(cfg *Config) {
 	for i, s := range cfg.Servers {
 		field := fmt.Sprintf("servers[%d]", i)
 
-		switch {
-		case s.Name == "":
+		if s.Name == "" {
 			r.add(SeverityError, field+".name", "Server name is required.",
 				"Names are how --server and the web dashboard refer to this entry.")
-		default:
-			if first, dup := seen[s.Name]; dup {
-				r.add(SeverityError, field+".name",
-					fmt.Sprintf("Duplicate server name %q (first defined at servers[%d]).", s.Name, first),
-					"--server picks the first match, so the later entry is unreachable.")
-			} else {
-				seen[s.Name] = i
-			}
+		} else if first, dup := seen[s.Name]; dup {
+			r.add(SeverityError, field+".name",
+				fmt.Sprintf("Duplicate server name %q (first defined at servers[%d]).", s.Name, first),
+				"--server picks the first match, so the later entry is unreachable.")
+		} else {
+			seen[s.Name] = i
 		}
 
 		if s.Host == "" && !s.Local {
@@ -486,14 +483,11 @@ func (r *ValidationResult) checkWake(cfg *Config) {
 		if t.Name == "" {
 			r.add(SeverityError, field+".name", "Wake target name is required.", "")
 		}
-		switch {
-		case t.MAC == "":
+		if t.MAC == "" {
 			r.add(SeverityError, field+".mac", "MAC address is required.", "")
-		default:
-			if _, err := net.ParseMAC(t.MAC); err != nil {
-				r.add(SeverityError, field+".mac",
-					fmt.Sprintf("Invalid MAC address %q.", t.MAC), "Expected format: AA:BB:CC:DD:EE:FF")
-			}
+		} else if _, err := net.ParseMAC(t.MAC); err != nil {
+			r.add(SeverityError, field+".mac",
+				fmt.Sprintf("Invalid MAC address %q.", t.MAC), "Expected format: AA:BB:CC:DD:EE:FF")
 		}
 	}
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -1,0 +1,613 @@
+package config
+
+import (
+	"bytes"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Severity ranks a validation finding. Errors mean the config is wrong and
+// something will not work; warnings mean it parses but probably does not do
+// what the user intended.
+const (
+	SeverityError   = "error"
+	SeverityWarning = "warning"
+)
+
+// Finding is one problem found in the config.
+type Finding struct {
+	Severity string `json:"severity"`
+	Field    string `json:"field,omitempty"`
+	Message  string `json:"message"`
+	Hint     string `json:"hint,omitempty"`
+}
+
+// Section reports what homebutler made of one top-level config key.
+//
+// This is the half of the output that answers "why is my notify config being
+// ignored?". A key the file never set reads as "not set", and a key that was
+// set but did not match the schema shows up in Findings instead of here — so
+// the two together account for every line of the file.
+type Section struct {
+	Name    string `json:"name"`
+	Present bool   `json:"present"`
+	Summary string `json:"summary"`
+}
+
+// ValidationResult is the outcome of checking a config file.
+type ValidationResult struct {
+	Path     string    `json:"path"`
+	Source   string    `json:"source"`
+	Exists   bool      `json:"exists"`
+	Sections []Section `json:"sections,omitempty"`
+	Findings []Finding `json:"findings,omitempty"`
+	Valid    bool      `json:"valid"`
+}
+
+// Errors returns the number of error-severity findings.
+func (r *ValidationResult) Errors() int { return r.count(SeverityError) }
+
+// Warnings returns the number of warning-severity findings.
+func (r *ValidationResult) Warnings() int { return r.count(SeverityWarning) }
+
+func (r *ValidationResult) count(severity string) int {
+	n := 0
+	for _, f := range r.Findings {
+		if f.Severity == severity {
+			n++
+		}
+	}
+	return n
+}
+
+func (r *ValidationResult) add(severity, field, message, hint string) {
+	r.Findings = append(r.Findings, Finding{
+		Severity: severity,
+		Field:    field,
+		Message:  message,
+		Hint:     hint,
+	})
+}
+
+// topLevelKeys mirrors the yaml tags on Config, in the order they are reported.
+var topLevelKeys = []string{"servers", "wake", "alerts", "notify", "watch", "backup_dir"}
+
+// Validate resolves the config the same way every other command does, then
+// reports what it found without applying it. It never contacts a remote
+// server and never writes anything.
+//
+// Validate deliberately does not go through Load: Load treats a missing file
+// as "use defaults" so that running without a config works, which also means
+// it cannot distinguish that from a path the user typed wrong.
+func Validate(explicit string) *ValidationResult {
+	path, source := ResolveWithSource(explicit)
+	r := &ValidationResult{Path: path, Source: string(source)}
+
+	if source == SourceNone {
+		r.Valid = true
+		r.add(SeverityWarning, "", "No config file found; built-in defaults are in use.",
+			"Run `homebutler init` to create one, or pass --config <path>.")
+		return r
+	}
+
+	info, err := os.Stat(path)
+	switch {
+	case err != nil && os.IsNotExist(err):
+		// Load() swallows this and returns defaults, so commands run and
+		// succeed against a config that was never read. Report it loudly.
+		r.add(SeverityError, "", fmt.Sprintf("Config file %s does not exist.", path),
+			fmt.Sprintf("It was selected by %s. Commands fall back to built-in defaults rather than failing, so this is easy to miss.", source.Describe()))
+		return r
+	case err != nil:
+		r.add(SeverityError, "", fmt.Sprintf("Cannot read %s: %v", path, err), "")
+		return r
+	case info.IsDir():
+		r.add(SeverityError, "", fmt.Sprintf("%s is a directory, not a config file.", path), "")
+		return r
+	}
+	r.Exists = true
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		r.add(SeverityError, "", fmt.Sprintf("Cannot read %s: %v", path, err), "")
+		return r
+	}
+
+	// Lenient decode: exactly what Load() ends up with at runtime, so the
+	// value checks below judge the config the commands will actually use.
+	cfg := newDefaultConfig()
+	if err := yaml.Unmarshal(data, cfg); err != nil {
+		r.add(SeverityError, "", fmt.Sprintf("Invalid YAML: %v", err),
+			"Fix the syntax error above; nothing else can be checked until the file parses.")
+		return r
+	}
+	cfg.Path = path
+
+	r.checkUnknownKeys(data)
+	r.Sections = describeSections(data, cfg)
+	r.checkPermissions(path, cfg)
+	r.checkServers(cfg)
+	r.checkWake(cfg)
+	r.checkAlerts(cfg)
+	r.checkNotify(cfg)
+	r.checkWatch(cfg)
+	r.checkBackupDir(cfg)
+
+	r.Valid = r.Errors() == 0
+	return r
+}
+
+// checkUnknownKeys re-decodes with KnownFields so that keys homebutler does
+// not recognise are reported. yaml.Unmarshal drops them without a word, which
+// is how a typo like `notifiy:` disables notifications with no visible error.
+func (r *ValidationResult) checkUnknownKeys(data []byte) {
+	strict := newDefaultConfig()
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+
+	err := dec.Decode(strict)
+	if err == nil {
+		return
+	}
+	typeErr, ok := err.(*yaml.TypeError)
+	if !ok {
+		return // syntax errors are already reported by the lenient decode
+	}
+
+	for _, msg := range typeErr.Errors {
+		field, hint := unknownFieldHint(msg)
+		r.add(SeverityWarning, field, cleanYAMLError(msg), hint)
+	}
+}
+
+// unknownFieldHint pulls the offending key out of a yaml "field X not found"
+// message and suggests the closest key homebutler does know, when the key is
+// at the top level.
+func unknownFieldHint(msg string) (field, hint string) {
+	const marker = "field "
+	i := strings.Index(msg, marker)
+	if i < 0 || !strings.Contains(msg, "not found") {
+		return "", ""
+	}
+	rest := msg[i+len(marker):]
+	j := strings.Index(rest, " ")
+	if j < 0 {
+		return "", ""
+	}
+	field = rest[:j]
+
+	hint = "Unrecognised keys are ignored silently, so this line currently has no effect."
+	if !strings.Contains(msg, "type config.Config") {
+		return field, hint
+	}
+	if best, ok := closestKey(field, topLevelKeys); ok {
+		hint = fmt.Sprintf("Did you mean %q? Unrecognised keys are ignored silently, so this line currently has no effect.", best)
+	}
+	return field, hint
+}
+
+// cleanYAMLError rewrites yaml's Go type names into config paths, so the
+// message reads as configuration rather than as internals.
+func cleanYAMLError(msg string) string {
+	replacements := []struct{ from, to string }{
+		{"type config.Config", "the homebutler config"},
+		{"type config.ServerConfig", "a servers[] entry"},
+		{"type config.WakeTarget", "a wake[] entry"},
+		{"type config.AlertConfig", "alerts"},
+		{"type config.WatchRuntimeConfig", "watch"},
+		{"type notify.ProviderConfig", "notify"},
+		{"type notify.TelegramConfig", "notify.telegram"},
+		{"type notify.SlackConfig", "notify.slack"},
+		{"type notify.DiscordConfig", "notify.discord"},
+		{"type notify.WebhookConfig", "notify.webhook"},
+		{"type watch.NotifySettings", "watch.notify"},
+		{"type watch.FlappingConfig", "watch.flapping"},
+	}
+	for _, rep := range replacements {
+		msg = strings.ReplaceAll(msg, rep.from, rep.to)
+	}
+	if msg == "" {
+		return ""
+	}
+	return strings.ToUpper(msg[:1]) + msg[1:]
+}
+
+// closestKey returns the candidate within edit distance 2 of key, if any.
+func closestKey(key string, candidates []string) (string, bool) {
+	best, bestDist := "", 3
+	for _, c := range candidates {
+		if d := editDistance(strings.ToLower(key), c); d < bestDist {
+			best, bestDist = c, d
+		}
+	}
+	return best, best != ""
+}
+
+func editDistance(a, b string) int {
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 1
+			if a[i-1] == b[j-1] {
+				cost = 0
+			}
+			curr[j] = min(min(curr[j-1]+1, prev[j]+1), prev[j-1]+cost)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
+}
+
+// describeSections reports, for each top-level key, whether the file set it
+// and what the resulting configuration is.
+func describeSections(data []byte, cfg *Config) []Section {
+	present := map[string]bool{}
+	var raw map[string]yaml.Node
+	if err := yaml.Unmarshal(data, &raw); err == nil {
+		for k := range raw {
+			present[k] = true
+		}
+	}
+
+	sections := make([]Section, 0, len(topLevelKeys))
+	for _, name := range topLevelKeys {
+		sections = append(sections, Section{
+			Name:    name,
+			Present: present[name],
+			Summary: sectionSummary(name, present[name], cfg),
+		})
+	}
+	return sections
+}
+
+func sectionSummary(name string, present bool, cfg *Config) string {
+	switch name {
+	case "servers":
+		if len(cfg.Servers) == 0 {
+			return "not set"
+		}
+		names := make([]string, 0, len(cfg.Servers))
+		for _, s := range cfg.Servers {
+			names = append(names, s.Name)
+		}
+		return fmt.Sprintf("%s (%s)", plural(len(cfg.Servers), "server"), strings.Join(names, ", "))
+
+	case "wake":
+		if len(cfg.Wake) == 0 {
+			return "not set"
+		}
+		return plural(len(cfg.Wake), "target")
+
+	case "alerts":
+		s := fmt.Sprintf("cpu %g%% · memory %g%% · disk %g%%", cfg.Alerts.CPU, cfg.Alerts.Memory, cfg.Alerts.Disk)
+		if !present {
+			return s + " (defaults)"
+		}
+		return s
+
+	case "notify":
+		channels := cfg.Notify.EnabledChannels()
+		if len(channels) == 0 {
+			if present {
+				return "configured, but no channel is complete"
+			}
+			return "not set"
+		}
+		names := make([]string, 0, len(channels))
+		for _, c := range channels {
+			names = append(names, string(c))
+		}
+		sort.Strings(names)
+		return strings.Join(names, ", ")
+
+	case "watch":
+		n := cfg.Watch.Notify
+		notifyOn := n.NotifyOn
+		if notifyOn == "" {
+			notifyOn = "flapping"
+		}
+		s := fmt.Sprintf("enabled=%t · notify_on=%s · cooldown=%s", n.Enabled, notifyOn, n.Cooldown)
+		if !present {
+			return s + " (defaults)"
+		}
+		return s
+
+	case "backup_dir":
+		if cfg.BackupDir == "" {
+			return cfg.ResolveBackupDir() + " (default)"
+		}
+		return cfg.BackupDir
+	}
+	return ""
+}
+
+func plural(n int, noun string) string {
+	if n == 1 {
+		return fmt.Sprintf("1 %s", noun)
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
+}
+
+// checkPermissions mirrors the guard in Load so that validate reports the
+// same refusal instead of the user meeting it later mid-command.
+func (r *ValidationResult) checkPermissions(path string, cfg *Config) {
+	if runtime.GOOS == "windows" || !hasSecrets(cfg) {
+		return
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return
+	}
+	if perm := info.Mode().Perm(); perm&0o077 != 0 {
+		r.add(SeverityError, "",
+			fmt.Sprintf("Config contains plaintext passwords but permissions are too open (%04o).", perm),
+			fmt.Sprintf("Run: chmod 600 %s", path))
+	}
+}
+
+func (r *ValidationResult) checkServers(cfg *Config) {
+	seen := map[string]int{}
+	for i, s := range cfg.Servers {
+		field := fmt.Sprintf("servers[%d]", i)
+
+		switch {
+		case s.Name == "":
+			r.add(SeverityError, field+".name", "Server name is required.",
+				"Names are how --server and the web dashboard refer to this entry.")
+		default:
+			if first, dup := seen[s.Name]; dup {
+				r.add(SeverityError, field+".name",
+					fmt.Sprintf("Duplicate server name %q (first defined at servers[%d]).", s.Name, first),
+					"--server picks the first match, so the later entry is unreachable.")
+			} else {
+				seen[s.Name] = i
+			}
+		}
+
+		if s.Host == "" && !s.Local {
+			r.add(SeverityError, field+".host", "Host is required for remote servers.",
+				"Set host, or set local: true if this entry is the machine homebutler runs on.")
+		}
+
+		if s.Port < 0 || s.Port > 65535 {
+			r.add(SeverityError, field+".port",
+				fmt.Sprintf("Port %d is out of range.", s.Port), "Valid ports are 1-65535; omit the key to use 22.")
+		}
+
+		switch s.AuthMode {
+		case "", "key", "password":
+		default:
+			r.add(SeverityError, field+".auth",
+				fmt.Sprintf("Unknown auth mode %q.", s.AuthMode), `Valid values are "key" (default) or "password".`)
+		}
+
+		if s.AuthMode == "password" && s.Password == "" {
+			r.add(SeverityError, field+".password", `Auth mode is "password" but no password is set.`, "")
+		}
+		if s.Password != "" && s.AuthMode != "password" {
+			r.add(SeverityWarning, field+".password",
+				"A password is set but this server uses key auth, so the password is ignored.",
+				`Set auth: password to use it, or remove the key.`)
+		}
+
+		if s.KeyFile != "" && !s.Local {
+			expanded := expandHome(s.KeyFile)
+			if _, err := os.Stat(expanded); os.IsNotExist(err) {
+				r.add(SeverityWarning, field+".key",
+					fmt.Sprintf("Key file %s does not exist.", s.KeyFile),
+					"Connections to this server will fail when they are attempted.")
+			}
+		}
+	}
+}
+
+func (r *ValidationResult) checkWake(cfg *Config) {
+	for i, t := range cfg.Wake {
+		field := fmt.Sprintf("wake[%d]", i)
+		if t.Name == "" {
+			r.add(SeverityError, field+".name", "Wake target name is required.", "")
+		}
+		switch {
+		case t.MAC == "":
+			r.add(SeverityError, field+".mac", "MAC address is required.", "")
+		default:
+			if _, err := net.ParseMAC(t.MAC); err != nil {
+				r.add(SeverityError, field+".mac",
+					fmt.Sprintf("Invalid MAC address %q.", t.MAC), "Expected format: AA:BB:CC:DD:EE:FF")
+			}
+		}
+	}
+}
+
+func (r *ValidationResult) checkAlerts(cfg *Config) {
+	thresholds := []struct {
+		name  string
+		value float64
+	}{
+		{"cpu", cfg.Alerts.CPU},
+		{"memory", cfg.Alerts.Memory},
+		{"disk", cfg.Alerts.Disk},
+	}
+	for _, t := range thresholds {
+		field := "alerts." + t.name
+		switch {
+		case t.value < 0 || t.value > 100:
+			r.add(SeverityError, field,
+				fmt.Sprintf("Threshold %g is out of range.", t.value), "Thresholds are percentages between 0 and 100.")
+		case t.value == 0:
+			r.add(SeverityWarning, field, "Threshold is 0, which alerts on every check.",
+				"Omit the key to use the default instead.")
+		}
+	}
+}
+
+func (r *ValidationResult) checkNotify(cfg *Config) {
+	if cfg.Notify.IsEmpty() {
+		return
+	}
+
+	if t := cfg.Notify.Telegram; t != nil {
+		switch {
+		case t.BotToken == "" && t.ChatID == "":
+			r.add(SeverityWarning, "notify.telegram", "Telegram block is empty, so Telegram stays disabled.", "")
+		case t.BotToken == "":
+			r.add(SeverityWarning, "notify.telegram.bot_token", "chat_id is set but bot_token is missing, so Telegram stays disabled.", "")
+		case t.ChatID == "":
+			r.add(SeverityWarning, "notify.telegram.chat_id", "bot_token is set but chat_id is missing, so Telegram stays disabled.", "")
+		}
+	}
+
+	urls := []struct{ field, url string }{}
+	if s := cfg.Notify.Slack; s != nil {
+		urls = append(urls, struct{ field, url string }{"notify.slack.webhook_url", s.WebhookURL})
+	}
+	if d := cfg.Notify.Discord; d != nil {
+		urls = append(urls, struct{ field, url string }{"notify.discord.webhook_url", d.WebhookURL})
+	}
+	if w := cfg.Notify.Webhook; w != nil {
+		urls = append(urls, struct{ field, url string }{"notify.webhook.url", w.URL})
+	}
+	for _, u := range urls {
+		provider := strings.Split(u.field, ".")[1]
+		switch {
+		case u.url == "":
+			r.add(SeverityWarning, u.field,
+				fmt.Sprintf("URL is missing, so %s stays disabled.", provider), "")
+		case !strings.HasPrefix(u.url, "http://") && !strings.HasPrefix(u.url, "https://"):
+			r.add(SeverityWarning, u.field,
+				fmt.Sprintf("URL %q does not start with http:// or https://.", u.url), "")
+		}
+	}
+}
+
+func (r *ValidationResult) checkWatch(cfg *Config) {
+	n := cfg.Watch.Notify
+
+	switch n.NotifyOn {
+	case "", "all", "incident", "flapping", "off":
+	default:
+		r.add(SeverityError, "watch.notify_on",
+			fmt.Sprintf("Unknown value %q.", n.NotifyOn), `Valid values are "all", "incident", "flapping", or "off".`)
+	}
+
+	if n.Cooldown != "" {
+		if _, err := time.ParseDuration(n.Cooldown); err != nil {
+			r.add(SeverityError, "watch.cooldown",
+				fmt.Sprintf("Invalid duration %q.", n.Cooldown), `Use a Go duration such as "5m" or "30s".`)
+		}
+	}
+
+	// The #31 shape: watch is switched on, but nothing can deliver.
+	if n.Enabled && n.NotifyOn != "off" && cfg.Notify.IsEmpty() {
+		r.add(SeverityWarning, "watch.enabled",
+			"Watch notifications are enabled but no notify provider is configured.",
+			"Add a notify: block, or set watch.enabled: false to silence this.")
+	}
+
+	f := cfg.Watch.Flapping
+	if f.ShortThreshold < 0 || f.LongThreshold < 0 {
+		r.add(SeverityError, "watch.flapping", "Flapping thresholds cannot be negative.", "")
+	}
+	if f.ShortWindow < 0 || f.LongWindow < 0 {
+		r.add(SeverityError, "watch.flapping", "Flapping windows cannot be negative.", "")
+	}
+}
+
+func (r *ValidationResult) checkBackupDir(cfg *Config) {
+	if cfg.BackupDir == "" {
+		return
+	}
+	dir := expandHome(cfg.BackupDir)
+	if _, err := os.Stat(dir); os.IsNotExist(err) {
+		parent := filepath.Dir(dir)
+		if _, err := os.Stat(parent); os.IsNotExist(err) {
+			r.add(SeverityWarning, "backup_dir",
+				fmt.Sprintf("Neither %s nor its parent exists.", cfg.BackupDir),
+				"Backups will fail until the parent directory is created.")
+		}
+	}
+}
+
+// expandHome resolves a leading ~ so that paths written the way users write
+// them in YAML can actually be checked.
+func expandHome(path string) string {
+	if !strings.HasPrefix(path, "~") {
+		return path
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return path
+	}
+	return filepath.Join(home, strings.TrimPrefix(path, "~"))
+}
+
+// FormatValidation renders a validation result for a terminal.
+func FormatValidation(r *ValidationResult) string {
+	var b strings.Builder
+
+	fmt.Fprintf(&b, "🗂  Config validation\n")
+	if r.Path == "" {
+		fmt.Fprintf(&b, "   Source  %s\n\n", Source(r.Source).Describe())
+	} else {
+		fmt.Fprintf(&b, "   File    %s\n", r.Path)
+		fmt.Fprintf(&b, "   Source  %s\n\n", Source(r.Source).Describe())
+	}
+
+	if len(r.Sections) > 0 {
+		fmt.Fprintf(&b, "Sections\n")
+		for _, s := range r.Sections {
+			marker := "·"
+			if s.Present {
+				marker = "✓"
+			}
+			fmt.Fprintf(&b, "   %s %-11s %s\n", marker, s.Name, s.Summary)
+		}
+		fmt.Fprintln(&b)
+	}
+
+	if len(r.Findings) > 0 {
+		fmt.Fprintf(&b, "Findings\n")
+		for _, f := range r.Findings {
+			icon := "⚠️"
+			if f.Severity == SeverityError {
+				icon = "❌"
+			}
+			// Unknown-key messages already name the field and carry a line
+			// number, so prefixing them again just reads as a stutter.
+			if f.Field != "" && !strings.Contains(f.Message, f.Field) {
+				fmt.Fprintf(&b, "   %s %s: %s\n", icon, f.Field, f.Message)
+			} else {
+				fmt.Fprintf(&b, "   %s %s\n", icon, f.Message)
+			}
+			if f.Hint != "" {
+				fmt.Fprintf(&b, "      → %s\n", f.Hint)
+			}
+		}
+		fmt.Fprintln(&b)
+	}
+
+	errs, warns := r.Errors(), r.Warnings()
+	switch {
+	case errs > 0:
+		fmt.Fprintf(&b, "❌ Config is invalid — %s, %s\n", plural(errs, "error"), plural(warns, "warning"))
+	case warns > 0:
+		fmt.Fprintf(&b, "⚠️  Config is valid — %s\n", plural(warns, "warning"))
+	default:
+		fmt.Fprintf(&b, "✅ Config is valid\n")
+	}
+
+	return b.String()
+}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,0 +1,462 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// writeConfig writes content to a temp file and returns its path.
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+	return path
+}
+
+// findingFor returns the first finding whose field or message matches substr.
+func findingFor(r *ValidationResult, substr string) (Finding, bool) {
+	for _, f := range r.Findings {
+		if strings.Contains(f.Field, substr) || strings.Contains(f.Message, substr) {
+			return f, true
+		}
+	}
+	return Finding{}, false
+}
+
+func requireFinding(t *testing.T, r *ValidationResult, substr, severity string) Finding {
+	t.Helper()
+	f, ok := findingFor(r, substr)
+	if !ok {
+		t.Fatalf("expected a finding matching %q, got %+v", substr, r.Findings)
+	}
+	if f.Severity != severity {
+		t.Errorf("finding %q: severity = %q, want %q", substr, f.Severity, severity)
+	}
+	return f
+}
+
+// isolateResolution points config resolution at an empty directory so tests
+// never pick up the developer's real ~/.config/homebutler/config.yaml.
+func isolateResolution(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOMEBUTLER_CONFIG", "")
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir) // os.UserHomeDir on Windows
+	t.Chdir(dir)
+}
+
+func TestValidateValidConfig(t *testing.T) {
+	path := writeConfig(t, `
+servers:
+  - name: local
+    host: 127.0.0.1
+    local: true
+  - name: pve1
+    host: 192.168.1.10
+    user: root
+    port: 22
+wake:
+  - name: desktop
+    mac: "AA:BB:CC:DD:EE:FF"
+alerts:
+  cpu: 90
+  memory: 85
+  disk: 90
+notify:
+  telegram:
+    bot_token: "token"
+    chat_id: "123"
+`)
+
+	r := Validate(path)
+
+	if !r.Valid {
+		t.Errorf("expected valid config, got findings: %+v", r.Findings)
+	}
+	if r.Errors() != 0 {
+		t.Errorf("expected 0 errors, got %d: %+v", r.Errors(), r.Findings)
+	}
+	if r.Warnings() != 0 {
+		t.Errorf("expected 0 warnings, got %d: %+v", r.Warnings(), r.Findings)
+	}
+	if !r.Exists {
+		t.Error("expected Exists=true")
+	}
+	if r.Source != string(SourceFlag) {
+		t.Errorf("source = %q, want %q", r.Source, SourceFlag)
+	}
+}
+
+// A path the user named explicitly must be an error when it is missing.
+// Load() returns defaults in this case, so commands succeed against a config
+// that was never read — the failure this command exists to surface.
+func TestValidateMissingExplicitFileIsAnError(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "nope.yaml")
+
+	r := Validate(path)
+
+	if r.Valid {
+		t.Error("expected invalid result for a missing explicit path")
+	}
+	if r.Exists {
+		t.Error("expected Exists=false")
+	}
+	requireFinding(t, r, "does not exist", SeverityError)
+
+	// Load() must still tolerate it, so existing behavior is unchanged.
+	if _, err := Load(path); err != nil {
+		t.Errorf("Load should still fall back to defaults, got %v", err)
+	}
+}
+
+func TestValidateNoConfigFound(t *testing.T) {
+	isolateResolution(t)
+
+	r := Validate("")
+
+	if !r.Valid {
+		t.Errorf("running on defaults is valid, got findings: %+v", r.Findings)
+	}
+	if r.Source != string(SourceNone) {
+		t.Errorf("source = %q, want %q", r.Source, SourceNone)
+	}
+	requireFinding(t, r, "No config file found", SeverityWarning)
+}
+
+// The notifiy/notify typo: yaml.Unmarshal drops unknown keys without a word.
+func TestValidateUnknownTopLevelKeySuggestsTheRealOne(t *testing.T) {
+	path := writeConfig(t, `
+notifiy:
+  telegram:
+    bot_token: "token"
+    chat_id: "123"
+`)
+
+	r := Validate(path)
+
+	f := requireFinding(t, r, "notifiy", SeverityWarning)
+	if !strings.Contains(f.Hint, `"notify"`) {
+		t.Errorf("expected a did-you-mean hint naming notify, got %q", f.Hint)
+	}
+	// An ignored key is not an error: the file still parses and runs.
+	if !r.Valid {
+		t.Error("unknown keys are warnings, not errors")
+	}
+}
+
+func TestValidateUnknownNestedKey(t *testing.T) {
+	path := writeConfig(t, `
+servers:
+  - name: pve1
+    host: 192.168.1.10
+    usr: root
+`)
+
+	r := Validate(path)
+
+	f := requireFinding(t, r, "usr", SeverityWarning)
+	if strings.Contains(f.Message, "config.ServerConfig") {
+		t.Errorf("message should not leak Go type names: %q", f.Message)
+	}
+	if !strings.Contains(f.Message, "servers[] entry") {
+		t.Errorf("message should locate the key in the config, got %q", f.Message)
+	}
+}
+
+func TestValidateServerErrors(t *testing.T) {
+	path := writeConfig(t, `
+servers:
+  - name: pve1
+    port: 99999
+    auth: publickey
+  - name: pve1
+    host: 192.168.1.11
+  - host: 192.168.1.12
+`)
+
+	r := Validate(path)
+
+	if r.Valid {
+		t.Fatal("expected invalid config")
+	}
+	requireFinding(t, r, "servers[0].host", SeverityError)
+	requireFinding(t, r, "servers[0].port", SeverityError)
+	requireFinding(t, r, "servers[0].auth", SeverityError)
+	requireFinding(t, r, "servers[1].name", SeverityError) // duplicate
+	requireFinding(t, r, "servers[2].name", SeverityError) // missing
+}
+
+// local: true means "the machine homebutler runs on", so host is optional.
+func TestValidateLocalServerNeedsNoHost(t *testing.T) {
+	path := writeConfig(t, `
+servers:
+  - name: here
+    local: true
+`)
+
+	r := Validate(path)
+
+	if _, found := findingFor(r, "host"); found {
+		t.Errorf("local servers should not require a host: %+v", r.Findings)
+	}
+}
+
+// A password under key auth is silently ignored at connection time.
+func TestValidatePasswordIgnoredUnderKeyAuth(t *testing.T) {
+	path := writeConfig(t, `
+servers:
+  - name: pve1
+    host: 192.168.1.10
+    password: "hunter2"
+`)
+
+	r := Validate(path)
+
+	f := requireFinding(t, r, "servers[0].password", SeverityWarning)
+	if !strings.Contains(f.Message, "ignored") {
+		t.Errorf("expected the message to say the password is ignored, got %q", f.Message)
+	}
+}
+
+func TestValidateWakeMAC(t *testing.T) {
+	path := writeConfig(t, `
+wake:
+  - name: nas
+    mac: "ZZ:GG:not-a-mac"
+  - name: desktop
+`)
+
+	r := Validate(path)
+
+	if r.Valid {
+		t.Fatal("expected invalid config")
+	}
+	requireFinding(t, r, "wake[0].mac", SeverityError)
+	requireFinding(t, r, "wake[1].mac", SeverityError) // missing entirely
+}
+
+func TestValidateAlertThresholds(t *testing.T) {
+	path := writeConfig(t, `
+alerts:
+  cpu: 150
+  memory: -1
+  disk: 0
+`)
+
+	r := Validate(path)
+
+	if r.Valid {
+		t.Fatal("expected invalid config")
+	}
+	requireFinding(t, r, "alerts.cpu", SeverityError)
+	requireFinding(t, r, "alerts.memory", SeverityError)
+	requireFinding(t, r, "alerts.disk", SeverityWarning) // 0 alerts on everything
+}
+
+func TestValidateWatchSettings(t *testing.T) {
+	path := writeConfig(t, `
+watch:
+  notify:
+    notify_on: sometimes
+    cooldown: 5minutes
+`)
+
+	r := Validate(path)
+
+	if r.Valid {
+		t.Fatal("expected invalid config")
+	}
+	requireFinding(t, r, "watch.notify_on", SeverityError)
+	requireFinding(t, r, "watch.cooldown", SeverityError)
+}
+
+// The #31 shape: watch notifications on, nothing configured to deliver them.
+func TestValidateWatchEnabledWithoutProvider(t *testing.T) {
+	path := writeConfig(t, `
+watch:
+  notify:
+    enabled: true
+    notify_on: flapping
+`)
+
+	r := Validate(path)
+
+	f := requireFinding(t, r, "watch.enabled", SeverityWarning)
+	if !strings.Contains(f.Message, "no notify provider") {
+		t.Errorf("unexpected message: %q", f.Message)
+	}
+}
+
+func TestValidateWatchEnabledWithProviderIsClean(t *testing.T) {
+	path := writeConfig(t, `
+notify:
+  telegram:
+    bot_token: "token"
+    chat_id: "123"
+watch:
+  notify:
+    enabled: true
+`)
+
+	r := Validate(path)
+
+	if _, found := findingFor(r, "no notify provider"); found {
+		t.Errorf("provider is configured, should not warn: %+v", r.Findings)
+	}
+}
+
+func TestValidateIncompleteNotifyProvider(t *testing.T) {
+	path := writeConfig(t, `
+notify:
+  telegram:
+    bot_token: "token"
+  slack:
+    webhook_url: "not-a-url"
+`)
+
+	r := Validate(path)
+
+	requireFinding(t, r, "notify.telegram.chat_id", SeverityWarning)
+	requireFinding(t, r, "notify.slack.webhook_url", SeverityWarning)
+	if !r.Valid {
+		t.Error("an incomplete provider is a warning, not an error")
+	}
+}
+
+func TestValidateInvalidYAML(t *testing.T) {
+	path := writeConfig(t, "servers: [unclosed\n")
+
+	r := Validate(path)
+
+	if r.Valid {
+		t.Fatal("expected invalid config")
+	}
+	requireFinding(t, r, "Invalid YAML", SeverityError)
+	if len(r.Sections) != 0 {
+		t.Error("sections should be omitted when the file does not parse")
+	}
+}
+
+func TestValidateSectionsReportPresenceAndContent(t *testing.T) {
+	path := writeConfig(t, `
+servers:
+  - name: pve1
+    host: 192.168.1.10
+alerts:
+  cpu: 95
+`)
+
+	r := Validate(path)
+
+	byName := map[string]Section{}
+	for _, s := range r.Sections {
+		byName[s.Name] = s
+	}
+
+	for _, name := range topLevelKeys {
+		if _, ok := byName[name]; !ok {
+			t.Errorf("section %q missing from result", name)
+		}
+	}
+
+	if s := byName["servers"]; !s.Present || !strings.Contains(s.Summary, "pve1") {
+		t.Errorf("servers section = %+v, want present and naming pve1", s)
+	}
+	if s := byName["alerts"]; !s.Present || !strings.Contains(s.Summary, "95") {
+		t.Errorf("alerts section = %+v, want present with cpu 95", s)
+	}
+	// A section the file never set must read as unset, which is what explains
+	// "my notify config is being ignored".
+	if s := byName["notify"]; s.Present || s.Summary != "not set" {
+		t.Errorf("notify section = %+v, want absent and 'not set'", s)
+	}
+	if s := byName["watch"]; s.Present || !strings.Contains(s.Summary, "defaults") {
+		t.Errorf("watch section = %+v, want absent and marked as defaults", s)
+	}
+}
+
+func TestValidateIsADirectory(t *testing.T) {
+	r := Validate(t.TempDir())
+
+	if r.Valid {
+		t.Fatal("expected invalid config")
+	}
+	requireFinding(t, r, "is a directory", SeverityError)
+}
+
+func TestResolveWithSource(t *testing.T) {
+	isolateResolution(t)
+
+	if path, src := ResolveWithSource("/explicit/path.yaml"); src != SourceFlag || path != "/explicit/path.yaml" {
+		t.Errorf("explicit: got (%q, %q), want (/explicit/path.yaml, %q)", path, src, SourceFlag)
+	}
+
+	t.Setenv("HOMEBUTLER_CONFIG", "/from/env.yaml")
+	if path, src := ResolveWithSource(""); src != SourceEnv || path != "/from/env.yaml" {
+		t.Errorf("env: got (%q, %q), want (/from/env.yaml, %q)", path, src, SourceEnv)
+	}
+	// The flag still wins over the environment.
+	if _, src := ResolveWithSource("/explicit/path.yaml"); src != SourceFlag {
+		t.Errorf("flag should outrank env, got %q", src)
+	}
+
+	t.Setenv("HOMEBUTLER_CONFIG", "")
+	if _, src := ResolveWithSource(""); src != SourceNone {
+		t.Errorf("nothing configured: got %q, want %q", src, SourceNone)
+	}
+
+	// Resolve stays a thin wrapper, so existing callers are unaffected.
+	if got := Resolve("/explicit/path.yaml"); got != "/explicit/path.yaml" {
+		t.Errorf("Resolve() = %q", got)
+	}
+}
+
+func TestResolveWithSourceFindsCwdConfig(t *testing.T) {
+	isolateResolution(t)
+
+	if err := os.WriteFile("homebutler.yaml", []byte("alerts:\n  cpu: 80\n"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	path, src := ResolveWithSource("")
+	if src != SourceCwd || path != "homebutler.yaml" {
+		t.Errorf("got (%q, %q), want (homebutler.yaml, %q)", path, src, SourceCwd)
+	}
+}
+
+func TestFormatValidationOutput(t *testing.T) {
+	path := writeConfig(t, `
+servers:
+  - name: pve1
+`)
+
+	out := FormatValidation(Validate(path))
+
+	for _, want := range []string{"Config validation", "Sections", "Findings", "servers[0].host", "Config is invalid"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestFormatValidationValidConfig(t *testing.T) {
+	path := writeConfig(t, `
+servers:
+  - name: pve1
+    host: 192.168.1.10
+`)
+
+	out := FormatValidation(Validate(path))
+
+	if !strings.Contains(out, "Config is valid") {
+		t.Errorf("expected a valid verdict:\n%s", out)
+	}
+	if strings.Contains(out, "Findings") {
+		t.Errorf("clean config should print no findings section:\n%s", out)
+	}
+}

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -460,3 +460,73 @@ servers:
 		t.Errorf("clean config should print no findings section:\n%s", out)
 	}
 }
+
+// WatchRuntimeConfig has a custom unmarshaler, which bypasses KnownFields —
+// so the watch subtree needs its own unknown-key check.
+func TestValidateWatchUnknownKeys(t *testing.T) {
+	path := writeConfig(t, `
+watch:
+  enabld: true
+  notify:
+    cooldwn: 5m
+  flapping:
+    short_windo: 10m
+`)
+
+	r := Validate(path)
+
+	f := requireFinding(t, r, "watch.enabld", SeverityWarning)
+	if !strings.Contains(f.Hint, `"enabled"`) {
+		t.Errorf("expected a did-you-mean hint, got %q", f.Hint)
+	}
+	requireFinding(t, r, "watch.notify.cooldwn", SeverityWarning)
+	requireFinding(t, r, "watch.flapping.short_windo", SeverityWarning)
+}
+
+func TestValidateWatchAcceptsBothForms(t *testing.T) {
+	for name, body := range map[string]string{
+		"flat": `
+watch:
+  enabled: true
+  notify_on: flapping
+  cooldown: 5m
+`,
+		"nested": `
+watch:
+  notify:
+    enabled: true
+    notify_on: flapping
+    cooldown: 5m
+`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			r := Validate(writeConfig(t, body))
+
+			if _, found := findingFor(r, "not found in watch"); found {
+				t.Errorf("%s form should be accepted: %+v", name, r.Findings)
+			}
+			for _, s := range r.Sections {
+				if s.Name == "watch" && !strings.Contains(s.Summary, "enabled=true") {
+					t.Errorf("%s form did not reach the runtime config: %q", name, s.Summary)
+				}
+			}
+		})
+	}
+}
+
+func TestValidateWatchBothFormsWarns(t *testing.T) {
+	path := writeConfig(t, `
+watch:
+  enabled: true
+  cooldown: 9m
+  notify:
+    enabled: false
+`)
+
+	r := Validate(path)
+
+	f := requireFinding(t, r, "Both watch.notify and the flat form", SeverityWarning)
+	if !strings.Contains(f.Message, "enabled") || !strings.Contains(f.Message, "cooldown") {
+		t.Errorf("message should name the flat keys in play, got %q", f.Message)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Adds `homebutler config validate`, and fixes a silently-broken config path it found.

### The problem

Config goes wrong in two ways, and both are silent.

**Unknown keys are dropped without a word.** `yaml.Unmarshal` ignores anything that does not match the schema, so a typo like `notifiy:` leaves notifications switched off with no error anywhere.

**A missing `--config` path falls back to defaults.** `Resolve()` returns an explicit path without checking it exists, then `Load()` treats the missing file as "use defaults" — so `--config /typo/path.yaml` runs happily against a config that was never read, and exits 0.

Neither produces any output today.

### The command

```bash
homebutler config validate
homebutler config validate --strict   # exit non-zero on warnings too
homebutler config validate --json
```

Read-only: no server, watcher, install, or remote connection. It reports which file was used and which of the four resolution rules picked it, what homebutler made of each top-level section, and every finding.

```text
🗂  Config validation
   File    /home/u/.config/homebutler/config.yaml
   Source  ~/.config/homebutler/config.yaml (XDG)

Sections
   ✓ servers     1 server (pve1)
   · notify      not set
   ✓ alerts      cpu 95% · memory 85% · disk 90%

Findings
   ⚠️ Line 5: field notifiy not found in the homebutler config
      → Did you mean "notify"? Unrecognised keys are ignored silently, so this
        line currently has no effect.

⚠️  Config is valid — 1 warning
```

Sections and findings together account for every line of the file, so `notify: not set` sitting next to a warning about `notifiy` explains the whole problem in one screen.

Errors mean something will not work; warnings mean the config parses but probably does not do what was intended. Checks cover unknown keys at any depth, server name/host/port/auth and duplicate names, passwords that key auth will ignore, missing key files, wake MAC addresses, alert thresholds, incomplete notify providers, watch `notify_on` and `cooldown`, negative flapping windows, and the #31 shape where watch notifications are enabled with no provider configured to deliver them.

`Validate` deliberately does not go through `Load`, since `Load`'s tolerance of a missing file is the behaviour being surfaced. **`Load` is unchanged**, so every existing command still runs without a config.

### What running it against our own files turned up

Three documented config shapes did not match the schema. Two are documentation errors with a single correct answer, fixed here:

- `homebutler.example.yaml` documented `output: json`, which is not a config key at all — JSON is a per-command flag
- `docs/configuration.md` documented `backup:` / `dir:`, but the schema key is `backup_dir`

The third was a real functional bug, in the second commit:

The README has always documented watch settings as flat keys (`watch.enabled`, `watch.notify_on`, `watch.cooldown`), but `WatchRuntimeConfig` nests them under `notify:`. All three were dropped, `Notify` kept its defaults, and `if watchCfg.Notify.Enabled` in watch start stayed false — the notifier was never constructed. **Anyone who configured watch by copying the README got no notifications and no error.** Same symptom as #31, different cause: #31 fixed the missing `loadConfig()` call, this fixes the half where the config loads correctly and then has nowhere to land.

Correcting only the docs would have left every config already written from them silently broken, so both spellings are now read. The flat keys apply only when the file has no `notify:` block; a file with both gets the nested values and `config validate` says the flat ones are being ignored.

One consequence worth naming for review: a custom unmarshaler decodes its own node without inheriting the parent decoder's `KnownFields` setting, so the strict pass no longer sees inside `watch:`. Unknown keys there would have gone unreported — precisely what this command exists to prevent — so the watch subtree is checked explicitly, including `watch.notify` and `watch.flapping`.

## Checklist

- [x] `gofmt -w .` — code is formatted
- [x] `go build ./...` — builds without errors
- [x] `go test ./...` — all tests pass
- [x] Tests added for new functionality
- [x] README updated (if user-facing change)

27 tests added. Verified with `go vet`, gofmt on the LF-normalised staged content, `linux/amd64`, `linux/arm64` and `darwin/arm64` cross-compiles, and live runs against fixtures reproducing both silent failures. The pre-existing Windows path-separator failures in `TestResolveBackupDir` and `internal/install` are unrelated and also fail on `main`.

Closes #17
