### PR TITLE
feat: align and colour the report and doctor output

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,26 +32,29 @@ $ homebutler report
 🏠 Homebutler Report — homelab
    2026-08-20T09:14:03Z
 
-── Current Status ──
-   Host: homelab (linux/arm64), uptime 42d 7h
-   CPU: 23.5% (4 cores), Memory: 3.2/8.0 GB (40%)
-   Disk /: 47.0/128.0 GB (37%)
-   Containers: 6 running, 1 stopped
-   Public ports: 2
+── Current Status ────────────────────────────────────────────
+   Host          homelab (linux/arm64), uptime 42d 7h
+   CPU           23.5% (4 cores), Memory: 3.2/8.0 GB (40%)
+   Disk /        47.0/128.0 GB (37%)
+   Containers    6 running, 1 stopped
+   Public ports  2
 
-── Needs Attention ──
+── Needs Attention ───────────────────────────────────────────
    ⚠️  1 container(s) stopped
 
-── Notable Changes ──
-   Disk /: +2.4 GB since last report
-   Running containers: 7 → 6
-   Stopped containers: 0 → 1
-   Public ports: 1 → 2
+── Notable Changes ───────────────────────────────────────────
+   Disk /              +2.4 GB since last report
+   Running containers  7 → 6
+   Stopped containers  0 → 1
+   Public ports        1 → 2
 
-── Suggested Actions ──
+── Suggested Actions ─────────────────────────────────────────
    → New public port(s) detected — verify these are intentional.
    → Container(s) stopped since last report — check logs with 'homebutler docker logs'.
 ```
+
+Section rules, labels, and severities are colour-coded in a terminal. Colour is
+dropped automatically when output is piped, redirected, or run from cron.
 
 That is the whole idea. Most homelab tools show you a graph of right now. HomeButler
 remembers what your server looked like last time and tells you what moved.
@@ -154,7 +157,7 @@ $ homebutler doctor
 🩺 Homebutler Doctor — homelab
    2026-08-20T09:14:11Z
 
-⚠️ Status: WARN  ·  pass 4 / warn 3 / fail 0
+⚠️ Status: WARN  · pass 4 / warn 3 / fail 0
 
 ⚠️ [docker] 1 container(s) are stopped
    vaultwarden

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -12,6 +12,8 @@ import (
 	"github.com/Higangssh/homebutler/internal/config"
 	"github.com/Higangssh/homebutler/internal/inventory"
 	"github.com/Higangssh/homebutler/internal/ports"
+	"github.com/Higangssh/homebutler/internal/style"
+	"github.com/charmbracelet/lipgloss"
 )
 
 const (
@@ -332,6 +334,21 @@ func defaultSnapshotDir() string {
 }
 
 // FormatHuman renders the doctor result as a concise CLI report.
+// severityStyle maps a severity onto the shared palette. Unknown values fall
+// back to the plain label style rather than picking an arbitrary colour.
+func severityStyle(severity string) lipgloss.Style {
+	switch severity {
+	case SeverityPass:
+		return style.OK
+	case SeverityWarn:
+		return style.Warn
+	case SeverityFail:
+		return style.Fail
+	default:
+		return style.Label
+	}
+}
+
 func FormatHuman(r *Result) string {
 	var b strings.Builder
 	statusIcon := map[string]string{SeverityPass: "✅", SeverityWarn: "⚠️", SeverityFail: "❌"}[r.Status]
@@ -339,21 +356,28 @@ func FormatHuman(r *Result) string {
 		statusIcon = "•"
 	}
 
-	fmt.Fprintf(&b, "🩺 Homebutler Doctor — %s\n", r.ServerName)
-	fmt.Fprintf(&b, "   %s\n\n", r.Timestamp)
-	fmt.Fprintf(&b, "%s Status: %s  ·  pass %d / warn %d / fail %d\n\n", statusIcon, strings.ToUpper(r.Status), r.Summary.Pass, r.Summary.Warn, r.Summary.Fail)
+	fmt.Fprintf(&b, "🩺 %s\n", style.Title.Render("Homebutler Doctor — "+r.ServerName))
+	fmt.Fprintf(&b, "   %s\n\n", style.Dim.Render(r.Timestamp))
+	fmt.Fprintf(&b, "%s %s  %s\n\n",
+		statusIcon,
+		severityStyle(r.Status).Bold(true).Render("Status: "+strings.ToUpper(r.Status)),
+		style.Dim.Render(fmt.Sprintf("· pass %d / warn %d / fail %d", r.Summary.Pass, r.Summary.Warn, r.Summary.Fail)),
+	)
 
 	for _, f := range r.Findings {
 		icon := map[string]string{SeverityPass: "✅", SeverityWarn: "⚠️", SeverityFail: "❌"}[f.Severity]
-		fmt.Fprintf(&b, "%s [%s] %s\n", icon, f.Category, f.Title)
+		fmt.Fprintf(&b, "%s %s %s\n",
+			icon,
+			style.Accent.Render("["+f.Category+"]"),
+			style.Title.Render(f.Title))
 		if f.Detail != "" {
-			fmt.Fprintf(&b, "   %s\n", f.Detail)
+			fmt.Fprintf(&b, "   %s\n", style.Dim.Render(f.Detail))
 		}
 		if f.Action != "" {
-			fmt.Fprintf(&b, "   → %s\n", f.Action)
+			fmt.Fprintf(&b, "   %s %s\n", style.Accent.Render("→"), f.Action)
 		}
 		if f.Command != "" {
-			fmt.Fprintf(&b, "   $ %s\n", f.Command)
+			fmt.Fprintf(&b, "   %s\n", style.Label.Render("$ "+f.Command))
 		}
 		fmt.Fprintln(&b)
 	}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -13,6 +13,7 @@ import (
 	"github.com/Higangssh/homebutler/internal/docker"
 	"github.com/Higangssh/homebutler/internal/inventory"
 	"github.com/Higangssh/homebutler/internal/ports"
+	"github.com/Higangssh/homebutler/internal/style"
 	"github.com/Higangssh/homebutler/internal/system"
 )
 
@@ -244,8 +245,8 @@ func buildReport(snap *Snapshot, prev *Snapshot) *Report {
 func FormatHuman(r *Report) string {
 	var b strings.Builder
 
-	fmt.Fprintf(&b, "🏠 Homebutler Report — %s\n", r.ServerName)
-	fmt.Fprintf(&b, "   %s\n\n", r.Timestamp)
+	fmt.Fprintf(&b, "🏠 %s\n", style.Title.Render("Homebutler Report — "+r.ServerName))
+	fmt.Fprintf(&b, "   %s\n\n", style.Dim.Render(r.Timestamp))
 
 	if r.IsBaseline {
 		if r.SnapshotSaved {
@@ -255,37 +256,33 @@ func FormatHuman(r *Report) string {
 		}
 	}
 
-	fmt.Fprintf(&b, "── Current Status ──\n")
-	for _, s := range r.Status {
-		fmt.Fprintf(&b, "   %s\n", s)
-	}
+	fmt.Fprintf(&b, "%s\n", style.Section("Current Status"))
+	b.WriteString(style.LabelledBlock(r.Status, "   "))
 	fmt.Fprintln(&b)
 
 	if len(r.NeedsAttention) > 0 {
-		fmt.Fprintf(&b, "── Needs Attention ──\n")
+		fmt.Fprintf(&b, "%s\n", style.Section("Needs Attention"))
 		for _, s := range r.NeedsAttention {
-			fmt.Fprintf(&b, "   ⚠️  %s\n", s)
+			fmt.Fprintf(&b, "   ⚠️  %s\n", style.Warn.Render(s))
 		}
 		fmt.Fprintln(&b)
 	}
 
-	fmt.Fprintf(&b, "── Notable Changes ──\n")
-	for _, s := range r.NotableChanges {
-		fmt.Fprintf(&b, "   %s\n", s)
-	}
+	fmt.Fprintf(&b, "%s\n", style.Section("Notable Changes"))
+	b.WriteString(style.LabelledBlock(r.NotableChanges, "   "))
 	fmt.Fprintln(&b)
 
 	if len(r.SuggestedActions) > 0 {
-		fmt.Fprintf(&b, "── Suggested Actions ──\n")
+		fmt.Fprintf(&b, "%s\n", style.Section("Suggested Actions"))
 		for _, s := range r.SuggestedActions {
-			fmt.Fprintf(&b, "   → %s\n", s)
+			fmt.Fprintf(&b, "   %s %s\n", style.Accent.Render("→"), s)
 		}
 		fmt.Fprintln(&b)
 	}
 
 	if len(r.Warnings) > 0 {
 		for _, w := range r.Warnings {
-			fmt.Fprintf(&b, "   ⚠️  %s\n", w)
+			fmt.Fprintf(&b, "   ⚠️  %s\n", style.Warn.Render(w))
 		}
 		fmt.Fprintln(&b)
 	}

--- a/internal/style/style.go
+++ b/internal/style/style.go
@@ -1,0 +1,80 @@
+// Package style holds the shared terminal palette used by homebutler's
+// human-readable command output.
+//
+// Colour is handled by lipgloss, which resolves the terminal's capabilities
+// once at startup: it degrades truecolour to the nearest 256- or 16-colour
+// match, honours NO_COLOR, and emits no escape sequences at all when stdout
+// is not a terminal. Output piped to a file, a cron job, or CI therefore
+// stays plain text without any explicit check here.
+package style
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+// The accent is the project's brand colour, the same one used by the logo
+// and the website.
+var (
+	Accent = lipgloss.NewStyle().Foreground(lipgloss.Color("#00ADD8"))
+	Title  = lipgloss.NewStyle().Bold(true)
+	Label  = lipgloss.NewStyle().Foreground(lipgloss.Color("245"))
+	Dim    = lipgloss.NewStyle().Foreground(lipgloss.Color("241"))
+	OK     = lipgloss.NewStyle().Foreground(lipgloss.Color("82"))
+	Warn   = lipgloss.NewStyle().Foreground(lipgloss.Color("226"))
+	Fail   = lipgloss.NewStyle().Foreground(lipgloss.Color("196"))
+)
+
+// RuleWidth is the total width of a section rule. It stays inside an 80
+// column terminal with room to spare.
+const RuleWidth = 62
+
+// Section renders a titled horizontal rule:
+//
+//	── Current Status ────────────────────────────
+func Section(title string) string {
+	head := "── " + title + " "
+	pad := RuleWidth - lipgloss.Width(head)
+	if pad < 3 {
+		pad = 3
+	}
+	return Accent.Render(head + strings.Repeat("─", pad))
+}
+
+// LabelledBlock renders "Label: value" lines with their labels padded to a
+// common width, so the values line up in a column. Lines with no ": "
+// separator are printed unchanged, which keeps prose entries such as
+// "No significant changes since last report." readable alongside them.
+//
+// Padding is measured on the unstyled label and appended after rendering,
+// since escape sequences would otherwise be counted as visible width.
+func LabelledBlock(lines []string, indent string) string {
+	type row struct{ label, value string }
+
+	rows := make([]row, 0, len(lines))
+	width := 0
+	for _, line := range lines {
+		label, value, ok := strings.Cut(line, ": ")
+		if !ok {
+			rows = append(rows, row{value: line})
+			continue
+		}
+		rows = append(rows, row{label: label, value: value})
+		if w := lipgloss.Width(label); w > width {
+			width = w
+		}
+	}
+
+	var b strings.Builder
+	for _, r := range rows {
+		if r.label == "" {
+			fmt.Fprintf(&b, "%s%s\n", indent, r.value)
+			continue
+		}
+		pad := strings.Repeat(" ", width-lipgloss.Width(r.label))
+		fmt.Fprintf(&b, "%s%s%s  %s\n", indent, Label.Render(r.label), pad, r.value)
+	}
+	return b.String()
+}

--- a/internal/style/style_test.go
+++ b/internal/style/style_test.go
@@ -1,0 +1,92 @@
+package style
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/charmbracelet/lipgloss"
+)
+
+func TestLabelledBlockAlignsValues(t *testing.T) {
+	out := LabelledBlock([]string{
+		"CPU: 23.5% (4 cores)",
+		"Public ports: 2",
+		"Disk /: 47.0/128.0 GB (37%)",
+	}, "   ")
+
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d: %q", len(lines), out)
+	}
+
+	// Every value should start at the same column, set by the widest label
+	// ("Public ports") plus the two-space gutter.
+	want := -1
+	for _, line := range lines {
+		col := strings.Index(line, strings.TrimLeft(strings.SplitN(line, "  ", 2)[1], " "))
+		if want == -1 {
+			want = col
+		}
+		if col != want {
+			t.Errorf("value column = %d, want %d, in %q", col, want, line)
+		}
+	}
+}
+
+// Lines with no "Label: value" shape are prose and must survive untouched.
+func TestLabelledBlockPassesThroughProse(t *testing.T) {
+	out := LabelledBlock([]string{
+		"Containers: 6 running",
+		"No significant changes since last report.",
+	}, "   ")
+
+	if !strings.Contains(out, "   No significant changes since last report.\n") {
+		t.Errorf("prose line was reformatted:\n%s", out)
+	}
+	if !strings.Contains(out, "Containers") {
+		t.Errorf("labelled line missing:\n%s", out)
+	}
+}
+
+// Only the first ": " separates label from value; later ones belong to the
+// value, as in "CPU: 23.5%, Memory: 3.2 GB".
+func TestLabelledBlockSplitsOnFirstSeparatorOnly(t *testing.T) {
+	out := LabelledBlock([]string{"CPU: 23.5% (4 cores), Memory: 3.2/8.0 GB (40%)"}, "")
+
+	if !strings.HasPrefix(out, "CPU") {
+		t.Errorf("expected CPU label first, got %q", out)
+	}
+	if !strings.Contains(out, "Memory: 3.2/8.0 GB (40%)") {
+		t.Errorf("second separator should stay in the value, got %q", out)
+	}
+}
+
+func TestLabelledBlockEmpty(t *testing.T) {
+	if got := LabelledBlock(nil, "   "); got != "" {
+		t.Errorf("expected empty output, got %q", got)
+	}
+}
+
+func TestSectionPadsToRuleWidth(t *testing.T) {
+	out := Section("Current Status")
+
+	if !strings.Contains(out, "Current Status") {
+		t.Errorf("title missing from %q", out)
+	}
+	if w := lipgloss.Width(out); w != RuleWidth {
+		t.Errorf("width = %d, want %d", w, RuleWidth)
+	}
+}
+
+// A title wider than the rule must still produce a usable line rather than
+// attempting a negative amount of padding.
+func TestSectionHandlesOverlongTitle(t *testing.T) {
+	out := Section(strings.Repeat("x", RuleWidth*2))
+
+	if lipgloss.Width(out) <= RuleWidth {
+		t.Errorf("expected the rule to grow with the title, got width %d", lipgloss.Width(out))
+	}
+	if !strings.HasSuffix(out, "───") {
+		t.Errorf("expected a minimum trailing rule, got %q", out)
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Makes `homebutler report` and `homebutler doctor` readable at a glance. Presentation only — no builder, no JSON, no behaviour change.

### Before

```console
── Current Status ──
   Host: homelab (linux/arm64), uptime 42d 7h
   CPU: 23.5% (4 cores), Memory: 3.2/8.0 GB (40%)
   Disk /: 47.0/128.0 GB (37%)
   Containers: 6 running, 1 stopped
   Public ports: 2
```

Values start at a different column on every line, and there is nothing for the eye to follow down the block.

### After

```console
── Current Status ────────────────────────────────────────────
   Host          homelab (linux/arm64), uptime 42d 7h
   CPU           23.5% (4 cores), Memory: 3.2/8.0 GB (40%)
   Disk /        47.0/128.0 GB (37%)
   Containers    6 running, 1 stopped
   Public ports  2
```

`doctor` gets the same treatment: the status line takes the colour of its severity, details are dimmed, the action arrow is accented, and the suggested command is set apart so the actionable line stands out from the explanation.

### How

A new `internal/style` package holds the shared palette, so `report` and `doctor` do not each grow their own copy. Two helpers: `Section` for titled rules, `LabelledBlock` for the aligned `Label: value` blocks.

Two details worth a reviewer's attention:

**Padding is measured on the unstyled label.** `lipgloss.Width` is called on the raw label and the padding appended after rendering. Measuring the styled string would count escape sequences as visible width, and the columns would drift the moment colour was enabled — which is exactly the kind of bug that only shows up on a real terminal and never in CI.

**Colour is left entirely to lipgloss.** It resolves terminal capabilities once at startup: degrades truecolour for limited terminals, honours `NO_COLOR`, and emits no escape sequences when stdout is not a terminal. So piped, redirected and cron output stays plain with no explicit check. I verified both paths by forcing the profile and diffing the results.

**`--json` is untouched.** The builders still produce the same strings in `Status`, `NotableChanges` and the rest — only the renderer changed. Splitting those strings into structured fields would be the better long-term shape, but that belongs with the JSON schema contract rather than a formatting change.

## Checklist

- [x] `gofmt -w .` — code is formatted
- [x] `go build ./...` — builds without errors
- [x] `go test ./...` — all tests pass
- [x] Tests added for new functionality
- [x] README updated (if user-facing change)

Six tests for `internal/style` covering alignment, prose pass-through, first-separator-only splitting, and rule width including an overlong title. Verified with `go vet`, `golangci-lint` v2.12.2 (the CI version), and `linux/amd64` cross-compile. The pre-existing Windows path-separator failures in `TestResolveBackupDir` and `internal/install` are unrelated and also fail on `main`.

README sample output updated to match.
