### PR TITLE
docs: replace the README report block with a terminal card

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,31 +27,9 @@
   <img src="assets/mascot.png" alt="HomeButler mascot holding a tiny server" width="220">
 </p>
 
-```console
-$ homebutler report
-🏠 Homebutler Report — homelab
-   2026-08-20T09:14:03Z
-
-── Current Status ────────────────────────────────────────────
-   Host          homelab (linux/arm64), uptime 42d 7h
-   CPU           23.5% (4 cores), Memory: 3.2/8.0 GB (40%)
-   Disk /        47.0/128.0 GB (37%)
-   Containers    6 running, 1 stopped
-   Public ports  2
-
-── Needs Attention ───────────────────────────────────────────
-   ⚠️  1 container(s) stopped
-
-── Notable Changes ───────────────────────────────────────────
-   Disk /              +2.4 GB since last report
-   Running containers  7 → 6
-   Stopped containers  0 → 1
-   Public ports        1 → 2
-
-── Suggested Actions ─────────────────────────────────────────
-   → New public port(s) detected — verify these are intentional.
-   → Container(s) stopped since last report — check logs with 'homebutler docker logs'.
-```
+<p align="center">
+  <img src="assets/report-card.svg" alt="homebutler report output: current status, needs attention, notable changes, and suggested actions" width="620">
+</p>
 
 Section rules, labels, and severities are colour-coded in a terminal. Colour is
 dropped automatically when output is piped, redirected, or run from cron.

--- a/README.md
+++ b/README.md
@@ -130,28 +130,9 @@ homebutler doctor --strict          # non-zero exit if warnings/failures are fou
 homebutler doctor --json            # automation / MCP friendly
 ```
 
-```console
-$ homebutler doctor
-🩺 Homebutler Doctor — homelab
-   2026-08-20T09:14:11Z
-
-⚠️ Status: WARN  · pass 4 / warn 3 / fail 0
-
-⚠️ [docker] 1 container(s) are stopped
-   vaultwarden
-   → Check the logs before restarting; some stopped containers may be intentional.
-   $ homebutler docker logs vaultwarden
-
-⚠️ [exposure] 2 port(s) are listening on all interfaces
-   :8080/tcp, :32400/tcp
-   → Make sure each one is intentional and protected by firewall, reverse proxy, or login where needed.
-   $ homebutler inventory scan
-
-⚠️ [backup] Latest backup is older than expected
-   Latest backup is 12d old; expected within 7d.
-   → Run a fresh backup. If this app matters, follow up with a backup drill.
-   $ homebutler backup
-```
+<p align="center">
+  <img src="assets/doctor-card.svg" alt="homebutler doctor reporting a full disk, a stopped container, and a missing report baseline, each with the command to run next" width="700">
+</p>
 
 `doctor` is a read-only preflight for the problems homelab users usually discover too late: high disk or memory usage, stopped containers, public bind ports, stale or missing backups, missing notifications, and whether `report` has a baseline for change detection. Every finding names the next command to run, so `--strict` makes it usable from cron or CI.
 

--- a/assets/README.md
+++ b/assets/README.md
@@ -1,0 +1,31 @@
+# assets
+
+Images referenced by the README. Nothing here ships in the binary.
+
+## report-card.svg
+
+The terminal card at the top of the README. Hand-written SVG rather than a
+screenshot, so it stays sharp at any size, weighs a few kilobytes, and shows a
+readable diff when the report format changes.
+
+Two constraints to know before editing it:
+
+- **Inline attributes only.** GitHub sanitises SVG in Markdown and may drop
+  `<style>` blocks, so every fill, font, and size is set as an attribute on the
+  element itself.
+- **Columns use explicit `x` coordinates, not runs of spaces.** SVG renderers
+  collapse whitespace unless `xml:space="preserve"` is honoured, and Chromium
+  does not do so reliably. A card built from padded strings loses its alignment
+  as soon as it is rendered — the first version of this file did exactly that.
+
+Preview it the way GitHub will render it before committing:
+
+```bash
+python -m http.server 8901 --bind 127.0.0.1
+
+# in another shell
+npx playwright screenshot --viewport-size=640,610 \
+  http://127.0.0.1:8901/assets/report-card.svg /tmp/card.png
+```
+
+Keep the content in sync with `FormatHuman` in `internal/report`.

--- a/assets/README.md
+++ b/assets/README.md
@@ -2,9 +2,9 @@
 
 Images referenced by the README. Nothing here ships in the binary.
 
-## report-card.svg
+## report-card.svg / doctor-card.svg
 
-The terminal card at the top of the README. Hand-written SVG rather than a
+The terminal cards in the README. Hand-written SVG rather than a
 screenshot, so it stays sharp at any size, weighs a few kilobytes, and shows a
 readable diff when the report format changes.
 
@@ -28,4 +28,5 @@ npx playwright screenshot --viewport-size=640,610 \
   http://127.0.0.1:8901/assets/report-card.svg /tmp/card.png
 ```
 
-Keep the content in sync with `FormatHuman` in `internal/report`.
+Keep the content in sync with `FormatHuman` in `internal/report` and
+`internal/doctor`.

--- a/assets/doctor-card.svg
+++ b/assets/doctor-card.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="760" height="562" viewBox="0 0 760 562" role="img" aria-label="Terminal showing homebutler doctor output: a disk failure, a stopped container, and a missing report baseline, each with the command to run next">
+  <!--
+    Terminal card used in README.md. See assets/README.md.
+
+    Every style is an inline attribute, since GitHub's SVG sanitiser may drop
+    <style> blocks. Columns are positioned with explicit x coordinates rather
+    than runs of spaces: SVG renderers collapse whitespace unless xml:space is
+    honoured, which Chromium does not do reliably, so spacing alone would not
+    survive.
+  -->
+  <rect x="0" y="0" width="760" height="562" rx="10" fill="#11151c"/>
+  <path d="M0 10a10 10 0 0 1 10-10h740a10 10 0 0 1 10 10v30H0z" fill="#1b212a"/>
+  <line x1="0" y1="40" x2="760" y2="40" stroke="#2a323d" stroke-width="1"/>
+  <circle cx="22" cy="20" r="6" fill="#ff5f56"/>
+  <circle cx="42" cy="20" r="6" fill="#ffbd2e"/>
+  <circle cx="62" cy="20" r="6" fill="#27c93f"/>
+  <text x="380" y="25" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" fill="#6e7681" text-anchor="middle">homebutler — doctor</text>
+
+  <g font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace" font-size="14">
+    <text x="22" y="74" fill="#7ee787">$</text>
+    <text x="39" y="74" fill="#c9d1d9">homebutler doctor</text>
+
+    <text x="22" y="120" fill="#c9d1d9">🩺</text>
+    <text x="47" y="120" fill="#e6edf3" font-weight="bold">Homebutler Doctor — homelab</text>
+    <text x="47" y="143" fill="#6e7681">2026-08-20T09:14:11Z</text>
+
+    <text x="22" y="189" fill="#f85149">✕</text>
+    <text x="47" y="189" fill="#f85149" font-weight="bold">Status: FAIL</text>
+    <text x="170" y="189" fill="#6e7681">· pass 4 / warn 2 / fail 1</text>
+
+    <text x="22" y="235" fill="#f85149">✕</text>
+    <text x="47" y="235" fill="#00add8">[system]</text>
+    <text x="122" y="235" fill="#e6edf3" font-weight="bold">Disk is almost full</text>
+    <text x="47" y="258" fill="#6e7681">Disk / is 94% full, threshold is 90%.</text>
+    <text x="47" y="281" fill="#00add8">→</text>
+    <text x="72" y="281" fill="#c9d1d9">Free space before apps, databases, or backups start failing.</text>
+    <text x="47" y="304" fill="#8b949e">$ homebutler status</text>
+
+    <text x="22" y="350" fill="#e3b341">⚠</text>
+    <text x="47" y="350" fill="#00add8">[docker]</text>
+    <text x="122" y="350" fill="#e6edf3" font-weight="bold">1 container(s) are stopped</text>
+    <text x="47" y="373" fill="#6e7681">vaultwarden</text>
+    <text x="47" y="396" fill="#00add8">→</text>
+    <text x="72" y="396" fill="#c9d1d9">Check the logs before restarting; some stopped containers may be intentional.</text>
+    <text x="47" y="419" fill="#8b949e">$ homebutler docker logs vaultwarden</text>
+
+    <text x="22" y="465" fill="#e3b341">⚠</text>
+    <text x="47" y="465" fill="#00add8">[report]</text>
+    <text x="122" y="465" fill="#e6edf3" font-weight="bold">No report baseline yet</text>
+    <text x="47" y="488" fill="#6e7681">Doctor did not find previous report snapshots.</text>
+    <text x="47" y="511" fill="#00add8">→</text>
+    <text x="72" y="511" fill="#c9d1d9">Run report once so homebutler can notice what changes later.</text>
+    <text x="47" y="534" fill="#8b949e">$ homebutler report</text>
+  </g>
+</svg>

--- a/assets/report-card.svg
+++ b/assets/report-card.svg
@@ -1,0 +1,55 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="584" viewBox="0 0 600 584" role="img" aria-label="Terminal showing homebutler report output: current status, needs attention, notable changes, and suggested actions">
+  <!--
+    Terminal card used at the top of README.md. See assets/README.md.
+
+    Every style is an inline attribute, since GitHub's SVG sanitiser may drop
+    <style> blocks. Columns are positioned with explicit x coordinates rather
+    than runs of spaces: SVG renderers collapse whitespace unless xml:space is
+    honoured, which Chromium does not do reliably, so spacing alone would not
+    survive.
+  -->
+  <rect x="0" y="0" width="600" height="584" rx="10" fill="#11151c"/>
+  <path d="M0 10a10 10 0 0 1 10-10h580a10 10 0 0 1 10 10v30H0z" fill="#1b212a"/>
+  <line x1="0" y1="40" x2="600" y2="40" stroke="#2a323d" stroke-width="1"/>
+  <circle cx="22" cy="20" r="6" fill="#ff5f56"/>
+  <circle cx="42" cy="20" r="6" fill="#ffbd2e"/>
+  <circle cx="62" cy="20" r="6" fill="#27c93f"/>
+  <text x="300" y="25" font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, monospace" font-size="12" fill="#6e7681" text-anchor="middle">homebutler — report</text>
+
+  <g font-family="ui-monospace, SFMono-Regular, Menlo, Consolas, 'Liberation Mono', monospace" font-size="14">
+    <text x="22" y="74" fill="#7ee787">$</text>
+    <text x="39" y="74" fill="#c9d1d9">homebutler report</text>
+
+    <text x="22" y="120" fill="#c9d1d9">🏠</text>
+    <text x="47" y="120" fill="#e6edf3" font-weight="bold">Homebutler Report — homelab</text>
+    <text x="47" y="143" fill="#6e7681">2026-08-20T09:14:03Z</text>
+
+    <text x="22" y="189" fill="#00add8">── Current Status ────────────────────────────────────────────</text>
+    <text x="47" y="212" fill="#8b949e">Host</text>
+    <text x="170" y="212" fill="#c9d1d9">homelab (linux/arm64), uptime 42d 7h</text>
+    <text x="47" y="235" fill="#8b949e">CPU</text>
+    <text x="170" y="235" fill="#c9d1d9">23.5% (4 cores), Memory: 3.2/8.0 GB (40%)</text>
+    <text x="47" y="258" fill="#8b949e">Disk /</text>
+    <text x="170" y="258" fill="#c9d1d9">47.0/128.0 GB (37%)</text>
+    <text x="47" y="281" fill="#8b949e">Containers</text>
+    <text x="170" y="281" fill="#c9d1d9">6 running, 1 stopped</text>
+    <text x="47" y="304" fill="#8b949e">Public ports</text>
+    <text x="170" y="304" fill="#c9d1d9">2</text>
+
+    <text x="22" y="350" fill="#00add8">── Needs Attention ───────────────────────────────────────────</text>
+    <text x="47" y="373" fill="#e3b341">⚠</text>
+    <text x="72" y="373" fill="#e3b341">1 container(s) stopped</text>
+
+    <text x="22" y="419" fill="#00add8">── Notable Changes ───────────────────────────────────────────</text>
+    <text x="47" y="442" fill="#8b949e">Disk /</text>
+    <text x="222" y="442" fill="#c9d1d9">+2.4 GB since last report</text>
+    <text x="47" y="465" fill="#8b949e">Running containers</text>
+    <text x="222" y="465" fill="#c9d1d9">7 → 6</text>
+    <text x="47" y="488" fill="#8b949e">Public ports</text>
+    <text x="222" y="488" fill="#c9d1d9">1 → 2</text>
+
+    <text x="22" y="534" fill="#00add8">── Suggested Actions ─────────────────────────────────────────</text>
+    <text x="47" y="557" fill="#00add8">→</text>
+    <text x="72" y="557" fill="#c9d1d9">New public port(s) detected — verify these are intentional.</text>
+  </g>
+</svg>


### PR DESCRIPTION
## What does this PR do?

Swaps the fenced code block at the top of the README for a terminal card.

A code block cannot show colour, so the part of `report` that does the most work visually — accented section rules, dimmed labels, severity colours — was invisible on GitHub even though it renders fine in a terminal. The README was showing the least interesting half of the output.

<p align="center">
  <img src="https://raw.githubusercontent.com/Higangssh/homebutler/docs/terminal-card/assets/report-card.svg" width="620">
</p>

Hand-written SVG rather than a screenshot: it stays sharp at any size, weighs 3 kB, and shows a readable diff when the report format changes. A PNG would need re-capturing and would blur on high-DPI displays.

## Two things that had to be worked around

Both are written up in `assets/README.md` so the next edit doesn't rediscover them.

**GitHub sanitises SVG in Markdown and may drop `<style>` blocks.** Every fill, font, and size is therefore an inline attribute on the element itself.

**The first attempt lost all of its alignment.** I built the columns from padded strings and `xml:space="preserve"`, rendered it, and got this:

```
Host homelab (linux/arm64), uptime 42d 7h
CPU 23.5% (4 cores), Memory: 3.2/8.0 GB (40%)
```

SVG collapses whitespace unless `xml:space` is honoured, and Chromium does not do so reliably. Columns are now placed with explicit `x` coordinates, which is independent of both renderer and font fallback — worth knowing, because a padded-string version looks correct in an editor and only breaks once rendered.

Verified by rendering through Chromium at the size GitHub will use.

## Note on overlap with #42

Both PRs touch the same README block. #42 improves the real terminal output and updated the code block to match; this replaces that block with the card. Whichever lands second will need a trivial conflict resolution — the card supersedes the code block, and the `doctor` sample from #42 stays as a code block further down.

## Checklist

- [x] `gofmt -w .` — code is formatted
- [x] `go build ./...` — builds without errors
- [x] `go test ./...` — all tests pass
- [ ] Tests added for new functionality — n/a, no code changes
- [x] README updated (if user-facing change)
