### PR TITLE
fix: don't blame the host key when the TOFU connection fails (#41)

### DIFF
--- a/internal/remote/ssh.go
+++ b/internal/remote/ssh.go
@@ -94,7 +94,8 @@ func connect(server *config.ServerConfig) (*ssh.Client, error) {
 					"  → If unexpected: do NOT connect and investigate", server.Name, addr, server.Name)
 			}
 			// Unknown host — TOFU: auto-add to known_hosts and retry
-			if tofuErr := tofuConnect(addr, cfg); tofuErr == nil {
+			tofuErr := tofuConnect(addr, cfg)
+			if tofuErr == nil {
 				// Reload known_hosts and retry
 				newCb, cbErr := newKnownHostsCallback()
 				if cbErr == nil {
@@ -107,8 +108,7 @@ func connect(server *config.ServerConfig) (*ssh.Client, error) {
 					return retryClient, nil
 				}
 			}
-			return nil, fmt.Errorf("[%s] failed to auto-register host key for %s\n  → Register manually: homebutler trust %s\n  → Check SSH connectivity: ssh %s@%s -p %d",
-				server.Name, addr, server.Name, server.SSHUser(), server.Host, server.SSHPort())
+			return nil, tofuFailureError(server, addr, tofuErr)
 		}
 		// Generic SSH error
 		return nil, fmt.Errorf("[%s] SSH connection failed (%s): %w\n  → Check: server online? correct host/port? firewall rules?\n  → Config: ~/.config/homebutler/config.yaml", server.Name, addr, err)
@@ -169,7 +169,7 @@ func tofuConnect(addr string, cfg *ssh.ClientConfig) error {
 
 	client, err := ssh.Dial("tcp", addr, &captureCfg)
 	if err != nil {
-		return fmt.Errorf("TOFU dial failed: %w", err)
+		return &tofuDialError{err: err}
 	}
 	client.Close()
 
@@ -338,4 +338,28 @@ func readKey(path string) (ssh.Signer, error) {
 		return nil, err
 	}
 	return ssh.ParsePrivateKey(data)
+}
+
+// tofuDialError marks a TOFU failure whose cause was the SSH connection itself
+// (network or authentication) rather than host key registration.
+type tofuDialError struct{ err error }
+
+func (e *tofuDialError) Error() string { return e.err.Error() }
+func (e *tofuDialError) Unwrap() error { return e.err }
+
+// tofuFailureError builds the error returned when TOFU auto-registration fails.
+func tofuFailureError(server *config.ServerConfig, addr string, tofuErr error) error {
+	connHint := fmt.Sprintf("→ Check SSH connectivity: ssh %s@%s -p %d",
+		server.SSHUser(), server.Host, server.SSHPort())
+
+	// The connection itself failed, so the host key never came into play.
+	// Pointing at `homebutler trust` here would send the user down the wrong path.
+	var dialErr *tofuDialError
+	if errors.As(tofuErr, &dialErr) {
+		return fmt.Errorf("[%s] SSH connection failed while registering a new host key (%s): %w\n  %s",
+			server.Name, addr, tofuErr, connHint)
+	}
+
+	return fmt.Errorf("[%s] failed to auto-register host key for %s: %w\n  → Register manually: homebutler trust %s\n  %s",
+		server.Name, addr, tofuErr, server.Name, connHint)
 }

--- a/internal/remote/ssh_test.go
+++ b/internal/remote/ssh_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -215,21 +216,6 @@ func TestErrorMessages_KeyMismatch(t *testing.T) {
 	}
 	if !strings.Contains(msg, "--reset") {
 		t.Error("key mismatch error should contain '--reset' flag")
-	}
-}
-
-// TestErrorMessages_UnknownHost verifies the unknown-host error contains actionable hints.
-func TestErrorMessages_UnknownHost(t *testing.T) {
-	serverName := "newserver"
-	addr := "10.0.0.2:22"
-	msg := fmt.Sprintf("[%s] failed to auto-register host key for %s\n  → Register manually: homebutler trust %s\n  → Check SSH connectivity: ssh %s@%s -p %d",
-		serverName, addr, serverName, "root", "10.0.0.2", 22)
-
-	if !strings.Contains(msg, "homebutler trust") {
-		t.Error("unknown host error should contain 'homebutler trust'")
-	}
-	if !strings.Contains(msg, "ssh root@") {
-		t.Error("unknown host error should contain ssh connection hint")
 	}
 }
 
@@ -1089,4 +1075,49 @@ type testTransport struct {
 func (t *testTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	newReq := t.override(req)
 	return t.wrapped.RoundTrip(newReq)
+}
+
+// TestTofuFailureError_ConnectionCauseNotHostKey verifies that when TOFU
+// registration fails because the SSH connection itself failed (network or auth),
+// the error reports that underlying cause and does NOT point at `homebutler trust`.
+// Regression test for #41.
+func TestTofuFailureError_ConnectionCauseNotHostKey(t *testing.T) {
+	server := &config.ServerConfig{Name: "lenny-remote", Host: "192.168.1.100", User: "lenny", Port: 24}
+	authErr := errors.New("ssh: unable to authenticate, attempted methods [none publickey]")
+
+	err := tofuFailureError(server, "192.168.1.100:24", &tofuDialError{err: authErr})
+	msg := err.Error()
+
+	if strings.Contains(msg, "homebutler trust") {
+		t.Errorf("connection failure must not suggest `homebutler trust`; got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "unable to authenticate") {
+		t.Errorf("underlying cause must be reported; got:\n%s", msg)
+	}
+	if !errors.Is(err, authErr) {
+		t.Error("underlying cause must stay unwrappable via errors.Is")
+	}
+	if !strings.Contains(msg, "ssh lenny@192.168.1.100 -p 24") {
+		t.Errorf("connectivity hint must use the configured user and port; got:\n%s", msg)
+	}
+}
+
+// TestTofuFailureError_HostKeyCause verifies that when registration genuinely
+// failed at the host-key step, the `homebutler trust` hint is still shown.
+func TestTofuFailureError_HostKeyCause(t *testing.T) {
+	server := &config.ServerConfig{Name: "newserver", Host: "10.0.0.2"}
+	cause := errors.New("cannot write known_hosts: permission denied")
+
+	err := tofuFailureError(server, "10.0.0.2:22", cause)
+	msg := err.Error()
+
+	if !strings.Contains(msg, "homebutler trust newserver") {
+		t.Errorf("host key failure should suggest `homebutler trust`; got:\n%s", msg)
+	}
+	if !strings.Contains(msg, "cannot write known_hosts") {
+		t.Errorf("underlying cause must be reported; got:\n%s", msg)
+	}
+	if !errors.Is(err, cause) {
+		t.Error("underlying cause must stay unwrappable via errors.Is")
+	}
 }


### PR DESCRIPTION
Fixes #41 (the remote half).

### Problem

`tofuConnect` re-dials the server to capture and register a new host key. That dial can
fail for reasons that have nothing to do with the host key — network, auth — but the
call site threw `tofuErr` away and reported every failure as:

```
failed to auto-register host key for ...
  → Register manually: homebutler trust ...
```

So an SSH auth failure was presented as a host key problem, sending the user to
`homebutler trust`, which could not have helped. That is what the reporter hit.

### Fix

- `tofuConnect` marks dial failures with a `*tofuDialError` instead of a string prefix
- `tofuErr` is hoisted out of the `if` scope so it reaches the failure path
- `tofuFailureError` classifies the cause with `errors.As` and only suggests
  `homebutler trust` when the host key is genuinely the problem

The cause is wrapped with `%w` in both branches, so it survives `errors.Is`. Previously
it was lost entirely.

### Output

Connection/auth cause — no more misleading hint:

```
[lenny-remote] SSH connection failed while registering a new host key (192.168.1.100:24): ssh: handshake failed: unable to authenticate, attempted methods [none publickey]
  → Check SSH connectivity: ssh lenny@192.168.1.100 -p 24
```

Genuine host key cause — hint retained:

```
[lenny-remote] failed to auto-register host key for 192.168.1.100:24: cannot write known_hosts: permission denied
  → Register manually: homebutler trust lenny-remote
  → Check SSH connectivity: ssh lenny@192.168.1.100 -p 24
```

### Tests

Two tests covering both branches, written against the real function. Verified they
reproduce the bad output before the fix.

`TestErrorMessages_UnknownHost` is removed: it rebuilt the format string inside the test
and asserted on its own copy, so it tested `fmt.Sprintf` rather than production code and
could never have caught this. The new tests supersede it.

### Not included

The local `sudo` half of #41 (raw error leading, suggestion to move it behind verbose
mode). There is no `--verbose`/`--debug` flag in the CLI today, so that is a separate
change rather than a message tweak.
