### PR TITLE
fix: watch check called systemd and pm2 targets clean without checking them

### DIFF
--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -284,30 +284,37 @@ func newWatchCheckCmd() *cobra.Command {
 				return err
 			}
 			if len(targets) == 0 {
-				fmt.Println("No containers being watched.")
+				fmt.Println("No targets being watched.")
 				return nil
 			}
 
-			incidents, err := watch.CheckTargets(dir)
+			result, err := watch.CheckTargets(dir)
 			if err != nil {
 				return err
 			}
 
-			result := watch.RunResult{
-				Checked:   len(targets),
-				Incidents: incidents,
-			}
 			if jsonOutput {
 				return output(result, true)
 			}
-			fmt.Printf("Checked %d container(s).\n", result.Checked)
-			if len(incidents) == 0 {
+
+			fmt.Printf("Checked %d docker target(s).\n", result.Checked)
+			if len(result.Incidents) == 0 {
 				fmt.Println("No restarts detected.")
 			} else {
-				fmt.Printf("%d restart(s) detected:\n", len(incidents))
-				for _, inc := range incidents {
+				fmt.Printf("%d restart(s) detected:\n", len(result.Incidents))
+				for _, inc := range result.Incidents {
 					fmt.Printf("  %s: %s (%s)\n", inc.Container, inc.ID, restartLabel(inc.RestartCount))
 				}
+			}
+
+			// Without this, a watch list of only systemd/pm2 targets prints
+			// "No restarts detected" without having looked at anything.
+			if len(result.Skipped) > 0 {
+				fmt.Printf("\n⚠️  Skipped %d target(s) that check cannot inspect:\n", len(result.Skipped))
+				for _, s := range result.Skipped {
+					fmt.Printf("  %s (%s)\n", s.Name, s.Kind)
+				}
+				fmt.Println("  → These are only monitored while running: homebutler watch start")
 			}
 			return nil
 		},

--- a/internal/watch/detector.go
+++ b/internal/watch/detector.go
@@ -72,28 +72,42 @@ func CaptureLogs(container string, lines string) string {
 	return out
 }
 
-func CheckTargets(dir string) ([]Incident, error) {
+// CheckTargets runs a one-shot restart check over the watch list.
+//
+// Only docker targets expose their restart state without a running monitor, so
+// systemd and pm2 targets cannot be inspected here. They are reported in
+// RunResult.Skipped rather than dropped silently — a caller that printed only
+// "no restarts detected" would be claiming those targets are healthy when they
+// were never looked at.
+func CheckTargets(dir string) (RunResult, error) {
+	var result RunResult
+
 	targets, err := LoadTargets(dir)
 	if err != nil {
-		return nil, err
+		return result, err
 	}
 	if len(targets) == 0 {
-		return nil, nil
+		return result, nil
 	}
 
 	states, err := LoadState(dir)
 	if err != nil {
-		return nil, err
+		return result, err
 	}
 
 	var incidents []Incident
 	now := time.Now()
 
 	for _, t := range targets {
-		// CheckTargets only handles docker targets; skip others
-		if t.EffectiveKind() != "docker" {
+		if !t.CheckSupported() {
+			result.Skipped = append(result.Skipped, SkippedTarget{
+				Name: t.Container,
+				Kind: t.EffectiveKind(),
+			})
 			continue
 		}
+		result.Checked++
+
 		curr, err := inspectContainerFunc(t.Container)
 		if err != nil {
 			fmt.Fprintf(defaultStderr, "warning: %v\n", err)
@@ -127,13 +141,25 @@ func CheckTargets(dir string) ([]Incident, error) {
 		}
 	}
 
+	result.Incidents = incidents
+
 	if err := SaveState(dir, states); err != nil {
-		return incidents, fmt.Errorf("save state: %w", err)
+		return result, fmt.Errorf("save state: %w", err)
 	}
-	return incidents, nil
+	return result, nil
+}
+
+// SkippedTarget is a watch target that a one-shot check could not inspect,
+// because its kind needs a running monitor rather than a point-in-time lookup.
+type SkippedTarget struct {
+	Name string `json:"name"`
+	Kind string `json:"kind"`
 }
 
 type RunResult struct {
-	Checked   int        `json:"checked"`
-	Incidents []Incident `json:"incidents,omitempty"`
+	// Checked counts the targets that were actually inspected, not every target
+	// on the watch list.
+	Checked   int             `json:"checked"`
+	Skipped   []SkippedTarget `json:"skipped,omitempty"`
+	Incidents []Incident      `json:"incidents,omitempty"`
 }

--- a/internal/watch/detector_test.go
+++ b/internal/watch/detector_test.go
@@ -169,12 +169,12 @@ func TestRunResultStruct(t *testing.T) {
 
 func TestCheckTargets_NoTargets(t *testing.T) {
 	dir := t.TempDir()
-	incidents, err := CheckTargets(dir)
+	res, err := CheckTargets(dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if incidents != nil {
-		t.Errorf("expected nil incidents, got %v", incidents)
+	if res.Incidents != nil {
+		t.Errorf("expected nil incidents, got %v", res.Incidents)
 	}
 }
 
@@ -196,12 +196,12 @@ func TestCheckTargets_SkipsNonDocker(t *testing.T) {
 		return nil, fmt.Errorf("should not be called")
 	}
 
-	incidents, err := CheckTargets(dir)
+	res, err := CheckTargets(dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(incidents) != 0 {
-		t.Errorf("expected 0 incidents, got %d", len(incidents))
+	if len(res.Incidents) != 0 {
+		t.Errorf("expected 0 incidents, got %d", len(res.Incidents))
 	}
 }
 
@@ -245,18 +245,18 @@ func TestCheckTargets_DetectsRestart(t *testing.T) {
 		return "captured log lines"
 	}
 
-	incidents, err := CheckTargets(dir)
+	res, err := CheckTargets(dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(incidents) != 1 {
-		t.Fatalf("expected 1 incident, got %d", len(incidents))
+	if len(res.Incidents) != 1 {
+		t.Fatalf("expected 1 incident, got %d", len(res.Incidents))
 	}
-	if incidents[0].Container != "nginx" {
-		t.Errorf("expected nginx, got %s", incidents[0].Container)
+	if res.Incidents[0].Container != "nginx" {
+		t.Errorf("expected nginx, got %s", res.Incidents[0].Container)
 	}
-	if incidents[0].RestartCount != 5 {
-		t.Errorf("expected RestartCount=5, got %d", incidents[0].RestartCount)
+	if res.Incidents[0].RestartCount != 5 {
+		t.Errorf("expected RestartCount=5, got %d", res.Incidents[0].RestartCount)
 	}
 }
 
@@ -288,12 +288,12 @@ func TestCheckTargets_NoRestart(t *testing.T) {
 		}, nil
 	}
 
-	incidents, err := CheckTargets(dir)
+	res, err := CheckTargets(dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(incidents) != 0 {
-		t.Errorf("expected 0 incidents, got %d", len(incidents))
+	if len(res.Incidents) != 0 {
+		t.Errorf("expected 0 incidents, got %d", len(res.Incidents))
 	}
 }
 
@@ -317,12 +317,12 @@ func TestCheckTargets_InspectError(t *testing.T) {
 		return nil, fmt.Errorf("container not found")
 	}
 
-	incidents, err := CheckTargets(dir)
+	res, err := CheckTargets(dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(incidents) != 0 {
-		t.Errorf("expected 0 incidents when inspect fails, got %d", len(incidents))
+	if len(res.Incidents) != 0 {
+		t.Errorf("expected 0 incidents when inspect fails, got %d", len(res.Incidents))
 	}
 }
 
@@ -344,13 +344,13 @@ func TestCheckTargets_NoPrevState(t *testing.T) {
 	}
 
 	// No previous state exists
-	incidents, err := CheckTargets(dir)
+	res, err := CheckTargets(dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	// First observation, no restart detected
-	if len(incidents) != 0 {
-		t.Errorf("expected 0 incidents for first observation, got %d", len(incidents))
+	if len(res.Incidents) != 0 {
+		t.Errorf("expected 0 incidents for first observation, got %d", len(res.Incidents))
 	}
 
 	// Verify state was saved
@@ -394,6 +394,106 @@ func TestCheckTargets_MixedDockerAndOther(t *testing.T) {
 	// Should only inspect docker targets (nginx and api, not svc)
 	if len(inspectedContainers) != 2 {
 		t.Errorf("expected 2 inspected containers, got %d: %v", len(inspectedContainers), inspectedContainers)
+	}
+}
+
+func TestCheckTargets_ReportsSkippedTargets(t *testing.T) {
+	dir := t.TempDir()
+	targets := []Target{
+		{Container: "nginx", Kind: "docker"},
+		{Container: "lh-elsa-monitor.service", Kind: "systemd", Unit: "lh-elsa-monitor.service"},
+		{Container: "api", Kind: "pm2", Unit: "api"},
+	}
+	if err := SaveTargets(dir, targets); err != nil {
+		t.Fatal(err)
+	}
+
+	origInspect := inspectContainerFunc
+	defer func() { inspectContainerFunc = origInspect }()
+	inspectContainerFunc = func(name string) (*InspectResult, error) {
+		return &InspectResult{RestartCount: 0, StartedAt: "ts1", Running: true}, nil
+	}
+
+	res, err := CheckTargets(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Checked must count what was actually inspected, not every registered target.
+	if res.Checked != 1 {
+		t.Errorf("expected Checked=1 (docker only), got %d", res.Checked)
+	}
+	if len(res.Skipped) != 2 {
+		t.Fatalf("expected 2 skipped targets, got %d: %+v", len(res.Skipped), res.Skipped)
+	}
+
+	kinds := map[string]string{}
+	for _, s := range res.Skipped {
+		kinds[s.Name] = s.Kind
+	}
+	if kinds["lh-elsa-monitor.service"] != "systemd" {
+		t.Errorf("expected the systemd target reported as skipped, got %+v", res.Skipped)
+	}
+	if kinds["api"] != "pm2" {
+		t.Errorf("expected the pm2 target reported as skipped, got %+v", res.Skipped)
+	}
+}
+
+func TestCheckTargets_DockerOnlyReportsNoSkips(t *testing.T) {
+	dir := t.TempDir()
+	targets := []Target{
+		{Container: "nginx", Kind: "docker"},
+		{Container: "api", Kind: ""}, // empty kind defaults to docker
+	}
+	if err := SaveTargets(dir, targets); err != nil {
+		t.Fatal(err)
+	}
+
+	origInspect := inspectContainerFunc
+	defer func() { inspectContainerFunc = origInspect }()
+	inspectContainerFunc = func(name string) (*InspectResult, error) {
+		return &InspectResult{RestartCount: 0, StartedAt: "ts1", Running: true}, nil
+	}
+
+	res, err := CheckTargets(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Checked != 2 {
+		t.Errorf("expected Checked=2, got %d", res.Checked)
+	}
+	if len(res.Skipped) != 0 {
+		t.Errorf("expected no skipped targets, got %+v", res.Skipped)
+	}
+}
+
+func TestCheckTargets_InspectErrorStillCountsAsChecked(t *testing.T) {
+	// A docker target that fails to inspect was still attempted — it must not be
+	// reported as "skipped", which is reserved for kinds check cannot handle at all.
+	dir := t.TempDir()
+	targets := []Target{
+		{Container: "gone", Kind: "docker"},
+		{Container: "svc", Kind: "systemd", Unit: "svc.service"},
+	}
+	if err := SaveTargets(dir, targets); err != nil {
+		t.Fatal(err)
+	}
+
+	origInspect := inspectContainerFunc
+	defer func() { inspectContainerFunc = origInspect }()
+	inspectContainerFunc = func(name string) (*InspectResult, error) {
+		return nil, fmt.Errorf("no such container: %s", name)
+	}
+
+	res, err := CheckTargets(dir)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Checked != 1 {
+		t.Errorf("expected Checked=1 (the docker target was attempted), got %d", res.Checked)
+	}
+	if len(res.Skipped) != 1 || res.Skipped[0].Kind != "systemd" {
+		t.Errorf("expected only the systemd target skipped, got %+v", res.Skipped)
 	}
 }
 
@@ -449,16 +549,16 @@ func TestCheckTargets_SavesIncident(t *testing.T) {
 		return "post logs"
 	}
 
-	incidents, err := CheckTargets(dir)
+	res, err := CheckTargets(dir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(incidents) != 1 {
-		t.Fatalf("expected 1 incident, got %d", len(incidents))
+	if len(res.Incidents) != 1 {
+		t.Fatalf("expected 1 incident, got %d", len(res.Incidents))
 	}
 
 	// Verify incident was saved to disk
-	loaded, lerr := LoadIncident(dir, incidents[0].ID)
+	loaded, lerr := LoadIncident(dir, res.Incidents[0].ID)
 	if lerr != nil {
 		t.Errorf("failed to load saved incident: %v", lerr)
 	}

--- a/internal/watch/store.go
+++ b/internal/watch/store.go
@@ -27,6 +27,15 @@ func (t Target) EffectiveKind() string {
 	return t.Kind
 }
 
+// CheckSupported reports whether a one-shot check can inspect this target.
+//
+// Docker records restart count and start time on the container itself, so a
+// single inspect call is enough. Systemd and pm2 state is only meaningful when
+// compared against a previous poll, which is what `watch start` does.
+func (t Target) CheckSupported() bool {
+	return t.EffectiveKind() == "docker"
+}
+
 // EffectiveUnit returns the unit name, defaulting to Container.
 func (t Target) EffectiveUnit() string {
 	if t.Unit == "" {


### PR DESCRIPTION
## The bug

`watch check` reports that systemd and pm2 targets are fine without ever looking at them.

`CheckTargets` skips every non-docker target (`detector.go`), which is correct on its own —
systemd and pm2 state only means something when compared against a previous poll, and that
is `watch start`'s job. The problem is that the skip was silent, and the command built its
summary from `len(targets)`, counting every registered target whether or not it was
inspected.

Registering a systemd unit and running check produced:

```text
Checked 1 container(s).
No restarts detected.
```

Nothing was inspected. For a monitoring tool this is worse than an error — it hands back a
clean bill of health for a target it never examined, and there is no way to tell the
difference from the output.

Found while watching a real systemd service (a Go binary under
`/etc/systemd/system/`) on an EC2 host with no Docker installed. The whole watch list was
invisible to `check` and the output gave no hint of it.

## The fix

`CheckTargets` now returns a `RunResult` describing what it actually did:

- `Checked` counts inspected targets only, not the whole watch list.
- `Skipped` collects the targets whose kind check cannot handle, with their kind.
- A docker target that fails to inspect still counts as checked — it was attempted, and
  the error already goes to stderr. `Skipped` is reserved for kinds check cannot handle at
  all, so the two stay distinguishable.

The command prints skips and points at the command that does monitor them:

```text
Checked 0 docker target(s).
No restarts detected.

⚠️  Skipped 1 target(s) that check cannot inspect:
  lh-elsa-monitor.service (systemd)
  → These are only monitored while running: homebutler watch start
```

Two smaller things came along:

- The docker-only rule moved into `Target.CheckSupported()` next to `EffectiveKind` and
  `EffectiveUnit`. It had been an inline comparison inside the loop, and the alternative
  fix — computing skips in `cmd/` — would have meant `cmd/` keeping its own copy of which
  kinds `check` supports. That is exactly the kind of rule that drifts.
- `No containers being watched.` → `No targets being watched.` The watch list has held
  systemd units and pm2 apps since those kinds landed.

## JSON output

`RunResult` gained `skipped` (omitempty), so existing consumers reading `checked` and
`incidents` still parse. `checked` does change meaning — it now reports what was inspected
rather than what was registered. That is the bug being fixed, so the old number was not
worth preserving.

## Tests

Three new tests in `detector_test.go`:

- `TestCheckTargets_ReportsSkippedTargets` — a mixed list reports `Checked=1` and both the
  systemd and pm2 targets in `Skipped`, with kinds.
- `TestCheckTargets_DockerOnlyReportsNoSkips` — no false skips, including for a target with
  an empty kind that defaults to docker.
- `TestCheckTargets_InspectErrorStillCountsAsChecked` — locks the checked/skipped
  distinction described above.

Existing `CheckTargets` tests were updated to the new return shape; their assertions are
unchanged.

`go build ./...`, `go vet ./...` clean. `internal/watch` and `cmd` pass.

## Not in this PR

Making `check` genuinely support systemd and pm2 is a separate change — it needs a
one-shot `systemctl show` comparison against stored state, and the same for pm2. This PR
is only about not lying when it cannot.
