### PR TITLE
refactor: consolidate isPublicBind into internal/ports (#37)

### DIFF
--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -177,7 +177,7 @@ func checkPublicPorts(r *Result, pp []ports.PortInfo) {
 	var exposed []string
 	seen := map[string]bool{}
 	for _, p := range pp {
-		if !isPublicBind(p.Address) {
+		if !ports.IsPublicBind(p.Address) {
 			continue
 		}
 		label := strings.TrimSpace(fmt.Sprintf("%s/%s %s", p.Port, p.Protocol, p.Process))
@@ -275,16 +275,6 @@ func overallStatus(s Summary) string {
 		return SeverityWarn
 	}
 	return SeverityPass
-}
-
-func isPublicBind(addr string) bool {
-	addr = strings.Trim(addr, "[]")
-	switch addr {
-	case "*", "0.0.0.0", "::", "":
-		return true
-	default:
-		return false
-	}
 }
 
 func latestBackup(entries []backup.ListEntry) (time.Time, bool) {

--- a/internal/inventory/portparse_fixture_test.go
+++ b/internal/inventory/portparse_fixture_test.go
@@ -104,7 +104,7 @@ func assertPort(t *testing.T, e portExpect, p ports.PortInfo) {
 	if p.Address != e.address {
 		t.Errorf("port %s: address = %q, want %q", e.port, p.Address, e.address)
 	}
-	if got := isPublicBind(p.Address); got != e.public {
+	if got := ports.IsPublicBind(p.Address); got != e.public {
 		t.Errorf("port %s: exposure public = %v, want %v (address %q)", e.port, got, e.public, p.Address)
 	}
 }

--- a/internal/inventory/render.go
+++ b/internal/inventory/render.go
@@ -137,7 +137,7 @@ func inventorySummary(inv *Inventory, appPorts, systemPorts []ports.PortInfo) st
 	}
 	public, local := 0, 0
 	for _, p := range append(append([]ports.PortInfo{}, appPorts...), systemPorts...) {
-		if isPublicBind(p.Address) {
+		if ports.IsPublicBind(p.Address) {
 			public++
 		} else {
 			local++
@@ -240,19 +240,10 @@ func isForwarderProcess(process string) bool {
 }
 
 func exposureIcon(p ports.PortInfo) string {
-	if isPublicBind(p.Address) {
+	if ports.IsPublicBind(p.Address) {
 		return "🌍"
 	}
 	return "🔒"
-}
-
-func isPublicBind(address string) bool {
-	switch address {
-	case "*", "0.0.0.0", "::", "[::]", "":
-		return true
-	default:
-		return false
-	}
 }
 
 var mappedPortRe = regexp.MustCompile(`(?:^|[\s,])(?:[\d.:\[\]]+:)?(\d+)->(\d+)/(tcp|udp)`)

--- a/internal/ports/ports.go
+++ b/internal/ports/ports.go
@@ -16,6 +16,27 @@ type PortInfo struct {
 	Process  string `json:"process,omitempty"`
 }
 
+// IsPublicBind reports whether a listener's bind address covers every
+// interface rather than loopback or one specific address.
+//
+// The address comes straight from the platform tool, which spells the wildcard
+// several ways: ss prints 0.0.0.0 for IPv4, [::] for an IPv6-only socket and *
+// for a dual-stack one, lsof prints * for all of them, and netstat prints ::.
+// An empty address means the parser could not read the column — treated as
+// public so an unreadable listener is flagged rather than quietly cleared.
+//
+// This is the single predicate behind exposure reporting in both `inventory
+// scan` and `doctor`. Keep it that way: two copies would let those commands
+// disagree about what "public" means.
+func IsPublicBind(addr string) bool {
+	switch strings.Trim(addr, "[]") {
+	case "*", "0.0.0.0", "::", "":
+		return true
+	default:
+		return false
+	}
+}
+
 // Result holds the port list and metadata about the scan.
 type Result struct {
 	Ports          []PortInfo `json:"ports"`

--- a/internal/ports/ports_test.go
+++ b/internal/ports/ports_test.go
@@ -215,3 +215,51 @@ func TestPortInfoStruct(t *testing.T) {
 		t.Errorf("Port = %q, want 8080", p.Port)
 	}
 }
+
+func TestIsPublicBind(t *testing.T) {
+	tests := []struct {
+		name string
+		addr string
+		want bool
+	}{
+		{"lsof wildcard", "*", true},
+		{"ipv4 wildcard", "0.0.0.0", true},
+		{"ipv6 wildcard", "::", true},
+		{"ipv6 wildcard bracketed", "[::]", true},
+		{"empty address parses as wildcard", "", true},
+		{"ipv4 loopback", "127.0.0.1", false},
+		{"ipv6 loopback", "::1", false},
+		{"ipv6 loopback bracketed", "[::1]", false},
+		{"routable address", "172.31.11.103", false},
+		{"routable ipv6 bracketed", "[2001:db8::1]", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := IsPublicBind(tc.addr); got != tc.want {
+				t.Errorf("IsPublicBind(%q) = %v, want %v", tc.addr, got, tc.want)
+			}
+		})
+	}
+}
+
+// splitAddrPort is what feeds IsPublicBind in practice, so the two must agree
+// on the forms ss and lsof actually emit.
+func TestIsPublicBind_MatchesSplitAddrPortOutput(t *testing.T) {
+	tests := []struct {
+		local string
+		want  bool
+	}{
+		{"0.0.0.0:22", true}, // ss, ipv4 wildcard
+		{"[::]:22", true},    // ss, ipv6-only wildcard
+		{"*:8080", true},     // ss dual-stack socket, and lsof
+		{"127.0.0.1:8080", false},
+		{"[::1]:3000", false},
+		{":::22", true}, // netstat-style ipv6 wildcard
+	}
+	for _, tc := range tests {
+		addr, _ := splitAddrPort(tc.local)
+		if got := IsPublicBind(addr); got != tc.want {
+			t.Errorf("%q -> addr %q: IsPublicBind = %v, want %v", tc.local, addr, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #37.

Implements the scope in the issue as written.

## What moved

`isPublicBind` existed twice. `internal/inventory/render.go` matched `"[::]"` literally;
`internal/doctor/doctor.go` stripped brackets with `strings.Trim(addr, "[]")` first. Both
copies are gone; one exported `ports.IsPublicBind` remains in `internal/ports`, next to the
`PortInfo.Address` it classifies. Both callers already imported the package, so no new
dependency.

Kept doctor's bracket handling, per the issue — `strings.Trim(addr, "[]")` covers any
bracketed form instead of enumerating one of them.

Call sites updated: `internal/inventory/render.go:140`, `:243`, `internal/doctor/doctor.go:180`.

## Why it was worth doing

The two copies agreed on every address our parsers emit today, so this fixes no live bug.
The risk is drift: this predicate decides whether a listener is reported as publicly
exposed, and it feeds two different commands — the 🌍/🔒 icon and the public-port count in
`inventory scan`, and the exposure warning in `doctor`. Changing one copy and not the other
would have split what those commands mean by "public", and nothing would have caught it
until a report was wrong.

## Tests

`TestIsPublicBind` — table test over the forms the platform tools actually produce, which
is more than the obvious two:

| form | source |
|---|---|
| `0.0.0.0` | `ss`, IPv4 wildcard |
| `[::]` | `ss`, IPv6-only socket (`IPV6_V6ONLY=1`) |
| `*` | `ss` for a dual-stack socket; `lsof` for everything |
| `::` | `netstat`-style, and what `splitAddrPort` returns for `:::22` |
| `""` | parser could not read the column |

plus `127.0.0.1`, `::1`, `[::1]`, `172.31.11.103`, `[2001:db8::1]` on the not-public side.

`TestIsPublicBind_MatchesSplitAddrPortOutput` feeds `splitAddrPort` output straight into
`IsPublicBind`, so the parser and the predicate cannot drift apart either — the same class
of bug one level down.

The empty-address case is deliberate and now documented on the function: an unreadable
address is treated as public so a listener we failed to parse gets flagged rather than
quietly cleared.

The #35 fixture assertions in `internal/inventory/portparse_fixture_test.go` are unchanged;
only the function name they call moved.

`go build ./...` and `go vet ./...` clean. `internal/ports`, `internal/inventory`,
`internal/doctor` pass.

## Note on #38

The issue says this blocks #38. That one wants the port parser tests consolidated into
`internal/ports` and the parsers un-exported — this PR does not touch the parsers, so #38
is still open work.
