### PR TITLE
feat: cap incident history so the watch directory stops growing forever

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ watch:
     short_threshold: 3
     long_window: 24h
     long_threshold: 5
+  retention:
+    max_incidents: 200
 
 alerts:
   cpu: 90
@@ -346,6 +348,7 @@ Legacy `~/.homebutler/watch/config.json` is still read as a fallback for watch-s
 - `watch.notify_on: off` — disable watch notifications without removing provider config
 - `watch.cooldown: 5m` — suppress duplicate notifications for the same event fingerprint during the cooldown window
 - `watch.flapping` — optional advanced tuning for restart-loop detection
+- `watch.retention.max_incidents: 200` — how many incidents to keep on disk, newest first. Each incident stores up to 100 captured log lines, so the directory grows fastest exactly when a service is restarting in a loop. Set `-1` to keep everything.
 
 These settings can also be written under a `watch.notify:` block, which is the
 canonical form:

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -275,6 +275,11 @@ func newWatchCheckCmd() *cobra.Command {
 		Use:   "check",
 		Short: "Run a one-shot restart check on all watched containers",
 		RunE: func(cmd *cobra.Command, args []string) error {
+			// Loaded so config.yaml's watch settings reach this command too;
+			// without it check and start would disagree about retention.
+			if err := loadConfig(); err != nil {
+				return err
+			}
 			dir, err := watch.WatchDir()
 			if err != nil {
 				return err
@@ -288,7 +293,7 @@ func newWatchCheckCmd() *cobra.Command {
 				return nil
 			}
 
-			result, err := watch.CheckTargets(dir)
+			result, err := watch.CheckTargets(dir, resolveIncidentCap(dir))
 			if err != nil {
 				return err
 			}
@@ -368,7 +373,9 @@ Docker targets use docker events (real-time). Systemd and PM2 targets use pollin
 			if cfg != nil {
 				watchCfg.Notify = cfg.Watch.Notify
 				watchCfg.Flapping = cfg.Watch.Flapping
+				watchCfg.Retention = cfg.Watch.Retention
 			}
+			watchCfg.Retention.Normalize()
 
 			var notifier *watch.WatchNotifier
 			if watchCfg.Notify.Enabled {
@@ -487,7 +494,7 @@ Docker targets use docker events (real-time). Systemd and PM2 targets use pollin
 						inc.Flapping = &flapResult
 					}
 
-					_ = watch.SaveIncident(dir, &inc)
+					_ = watch.SaveIncident(dir, &inc, watchCfg.Retention.MaxIncidents)
 
 					if notifier != nil {
 						_ = notifier.NotifyIncident(inc, flapResult, &summary, time.Now())
@@ -510,6 +517,22 @@ Docker targets use docker events (real-time). Systemd and PM2 targets use pollin
 
 	cmd.Flags().StringVar(&interval, "interval", "30s", "Check/poll interval (e.g. 30s, 1m, 5m)")
 	return cmd
+}
+
+// resolveIncidentCap resolves the incident retention cap the way watch start
+// does: config.yaml wins over watch/config.json, and an unset value takes the
+// default rather than reading as unlimited.
+func resolveIncidentCap(dir string) int {
+	watchCfg, err := watch.LoadWatchConfig(dir)
+	if err != nil || watchCfg == nil {
+		defaults := watch.DefaultWatchConfig()
+		watchCfg = &defaults
+	}
+	if cfg != nil {
+		watchCfg.Retention = cfg.Watch.Retention
+	}
+	watchCfg.Retention.Normalize()
+	return watchCfg.Retention.MaxIncidents
 }
 
 func newWatchHistoryCmd() *cobra.Command {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,16 +22,18 @@ type Config struct {
 }
 
 type WatchRuntimeConfig struct {
-	Notify   watch.NotifySettings `yaml:"notify,omitempty"`
-	Flapping watch.FlappingConfig `yaml:"flapping,omitempty"`
+	Notify    watch.NotifySettings  `yaml:"notify,omitempty"`
+	Flapping  watch.FlappingConfig  `yaml:"flapping,omitempty"`
+	Retention watch.RetentionConfig `yaml:"retention,omitempty"`
 }
 
 // watchRuntimeYAML is the decode target for WatchRuntimeConfig. It carries the
 // canonical nested shape plus the flat keys, as pointers so that "absent" and
 // "set to the zero value" stay distinguishable.
 type watchRuntimeYAML struct {
-	Notify   watch.NotifySettings `yaml:"notify,omitempty"`
-	Flapping watch.FlappingConfig `yaml:"flapping,omitempty"`
+	Notify    watch.NotifySettings  `yaml:"notify,omitempty"`
+	Flapping  watch.FlappingConfig  `yaml:"flapping,omitempty"`
+	Retention watch.RetentionConfig `yaml:"retention,omitempty"`
 
 	Enabled    *bool   `yaml:"enabled,omitempty"`
 	NotifyOn   *string `yaml:"notify_on,omitempty"`
@@ -59,12 +61,13 @@ type watchRuntimeYAML struct {
 func (w *WatchRuntimeConfig) UnmarshalYAML(node *yaml.Node) error {
 	// Seeded with the current value so that defaults applied before decoding
 	// survive keys the file does not mention.
-	raw := watchRuntimeYAML{Notify: w.Notify, Flapping: w.Flapping}
+	raw := watchRuntimeYAML{Notify: w.Notify, Flapping: w.Flapping, Retention: w.Retention}
 	if err := node.Decode(&raw); err != nil {
 		return err
 	}
 	w.Notify = raw.Notify
 	w.Flapping = raw.Flapping
+	w.Retention = raw.Retention
 
 	if hasMappingKey(node, "notify") {
 		return nil
@@ -210,8 +213,9 @@ func newDefaultConfig() *Config {
 			Disk:   90,
 		},
 		Watch: WatchRuntimeConfig{
-			Notify:   defaultWatch.Notify,
-			Flapping: defaultWatch.Flapping,
+			Notify:    defaultWatch.Notify,
+			Flapping:  defaultWatch.Flapping,
+			Retention: defaultWatch.Retention,
 		},
 	}
 }
@@ -236,6 +240,7 @@ func Load(path string) (*Config, error) {
 	}
 
 	cfg.Watch.Notify.Normalize()
+	cfg.Watch.Retention.Normalize()
 
 	cfg.Path = path
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -517,3 +517,73 @@ watch:
 		t.Errorf("short_threshold = %d, want the configured 7", cfg.Watch.Flapping.ShortThreshold)
 	}
 }
+
+func TestLoadWatchRetention(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "retention.yaml")
+	content := `
+watch:
+  retention:
+    max_incidents: 25
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if cfg.Watch.Retention.MaxIncidents != 25 {
+		t.Errorf("max_incidents = %d, want the configured 25", cfg.Watch.Retention.MaxIncidents)
+	}
+	// Setting retention must not disturb the neighbouring watch defaults.
+	if cfg.Watch.Notify.Cooldown != "5m" {
+		t.Errorf("cooldown = %q, want the 5m default", cfg.Watch.Notify.Cooldown)
+	}
+}
+
+func TestLoadWatchRetentionDefaultsWhenUnset(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "no-retention.yaml")
+	content := `
+watch:
+  notify:
+    enabled: true
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	// A config that predates the setting must not read as unlimited history.
+	if cfg.Watch.Retention.MaxIncidents != 200 {
+		t.Errorf("max_incidents = %d, want the default 200", cfg.Watch.Retention.MaxIncidents)
+	}
+}
+
+func TestLoadWatchRetentionNegativeMeansUnlimited(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "unlimited.yaml")
+	content := `
+watch:
+  retention:
+    max_incidents: -1
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	// Normalize turns the explicit opt-out into the "keep everything" zero that
+	// PruneIncidents understands.
+	if cfg.Watch.Retention.MaxIncidents != 0 {
+		t.Errorf("max_incidents = %d, want 0 (unlimited)", cfg.Watch.Retention.MaxIncidents)
+	}
+}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -261,9 +261,10 @@ func editDistance(a, b string) int {
 // Keys accepted under watch:. The flat spellings are the compatibility path
 // described on WatchRuntimeConfig.UnmarshalYAML.
 var (
-	watchKeys       = []string{"notify", "flapping", "enabled", "notify_on", "on_incident", "on_flapping", "cooldown"}
-	watchNotifyKeys = []string{"enabled", "notify_on", "on_incident", "on_flapping", "cooldown"}
-	watchFlapKeys   = []string{"short_window", "short_threshold", "long_window", "long_threshold"}
+	watchKeys          = []string{"notify", "flapping", "retention", "enabled", "notify_on", "on_incident", "on_flapping", "cooldown"}
+	watchNotifyKeys    = []string{"enabled", "notify_on", "on_incident", "on_flapping", "cooldown"}
+	watchFlapKeys      = []string{"short_window", "short_threshold", "long_window", "long_threshold"}
+	watchRetentionKeys = []string{"max_incidents"}
 )
 
 // checkWatchKeys inspects the watch subtree by hand.
@@ -287,6 +288,8 @@ func (r *ValidationResult) checkWatchKeys(rawTop map[string]yaml.Node) {
 			r.reportUnknownKeys(node.Content[i+1], "watch.notify", watchNotifyKeys)
 		case "flapping":
 			r.reportUnknownKeys(node.Content[i+1], "watch.flapping", watchFlapKeys)
+		case "retention":
+			r.reportUnknownKeys(node.Content[i+1], "watch.retention", watchRetentionKeys)
 		default:
 			if slices.Contains(watchKeys, key) {
 				flat = append(flat, key)

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -530,3 +530,34 @@ watch:
 		t.Errorf("message should name the flat keys in play, got %q", f.Message)
 	}
 }
+
+func TestValidateAcceptsWatchRetention(t *testing.T) {
+	path := writeConfig(t, `
+watch:
+  retention:
+    max_incidents: 50
+`)
+
+	r := Validate(path)
+
+	// watch has a custom unmarshaler, so a new subtree that nobody added to the
+	// key list gets reported as unknown even though it parses fine.
+	if _, ok := findingFor(r, "retention"); ok {
+		t.Errorf("watch.retention should be a known key, got %+v", r.Findings)
+	}
+	if !r.Valid {
+		t.Error("a config setting only watch.retention should be valid")
+	}
+}
+
+func TestValidateUnknownWatchRetentionKey(t *testing.T) {
+	path := writeConfig(t, `
+watch:
+  retention:
+    max_incident: 50
+`)
+
+	r := Validate(path)
+
+	requireFinding(t, r, "max_incident", SeverityWarning)
+}

--- a/internal/watch/detector.go
+++ b/internal/watch/detector.go
@@ -79,7 +79,8 @@ func CaptureLogs(container string, lines string) string {
 // RunResult.Skipped rather than dropped silently — a caller that printed only
 // "no restarts detected" would be claiming those targets are healthy when they
 // were never looked at.
-func CheckTargets(dir string) (RunResult, error) {
+// keep caps how many incidents are retained on disk; see SaveIncident.
+func CheckTargets(dir string, keep int) (RunResult, error) {
 	var result RunResult
 
 	targets, err := LoadTargets(dir)
@@ -127,7 +128,7 @@ func CheckTargets(dir string) (RunResult, error) {
 				PreLogs:      "(captured at detection — see post_logs for current state)",
 				PostLogs:     postLogs,
 			}
-			if err := SaveIncident(dir, &inc); err != nil {
+			if err := SaveIncident(dir, &inc, keep); err != nil {
 				fmt.Fprintf(defaultStderr, "warning: save incident: %v\n", err)
 			}
 			incidents = append(incidents, inc)

--- a/internal/watch/detector_test.go
+++ b/internal/watch/detector_test.go
@@ -169,7 +169,7 @@ func TestRunResultStruct(t *testing.T) {
 
 func TestCheckTargets_NoTargets(t *testing.T) {
 	dir := t.TempDir()
-	res, err := CheckTargets(dir)
+	res, err := CheckTargets(dir, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -196,7 +196,7 @@ func TestCheckTargets_SkipsNonDocker(t *testing.T) {
 		return nil, fmt.Errorf("should not be called")
 	}
 
-	res, err := CheckTargets(dir)
+	res, err := CheckTargets(dir, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -245,7 +245,7 @@ func TestCheckTargets_DetectsRestart(t *testing.T) {
 		return "captured log lines"
 	}
 
-	res, err := CheckTargets(dir)
+	res, err := CheckTargets(dir, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -288,7 +288,7 @@ func TestCheckTargets_NoRestart(t *testing.T) {
 		}, nil
 	}
 
-	res, err := CheckTargets(dir)
+	res, err := CheckTargets(dir, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -317,7 +317,7 @@ func TestCheckTargets_InspectError(t *testing.T) {
 		return nil, fmt.Errorf("container not found")
 	}
 
-	res, err := CheckTargets(dir)
+	res, err := CheckTargets(dir, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -344,7 +344,7 @@ func TestCheckTargets_NoPrevState(t *testing.T) {
 	}
 
 	// No previous state exists
-	res, err := CheckTargets(dir)
+	res, err := CheckTargets(dir, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -387,7 +387,7 @@ func TestCheckTargets_MixedDockerAndOther(t *testing.T) {
 		return &InspectResult{RestartCount: 0, StartedAt: "ts1", Running: true}, nil
 	}
 
-	_, err := CheckTargets(dir)
+	_, err := CheckTargets(dir, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -414,7 +414,7 @@ func TestCheckTargets_ReportsSkippedTargets(t *testing.T) {
 		return &InspectResult{RestartCount: 0, StartedAt: "ts1", Running: true}, nil
 	}
 
-	res, err := CheckTargets(dir)
+	res, err := CheckTargets(dir, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -455,7 +455,7 @@ func TestCheckTargets_DockerOnlyReportsNoSkips(t *testing.T) {
 		return &InspectResult{RestartCount: 0, StartedAt: "ts1", Running: true}, nil
 	}
 
-	res, err := CheckTargets(dir)
+	res, err := CheckTargets(dir, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -485,7 +485,7 @@ func TestCheckTargets_InspectErrorStillCountsAsChecked(t *testing.T) {
 		return nil, fmt.Errorf("no such container: %s", name)
 	}
 
-	res, err := CheckTargets(dir)
+	res, err := CheckTargets(dir, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -502,7 +502,7 @@ func TestCheckTargets_CorruptTargets(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "targets.json"), []byte("not json"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	_, err := CheckTargets(dir)
+	_, err := CheckTargets(dir, 0)
 	if err == nil {
 		t.Fatal("expected error for corrupt targets")
 	}
@@ -517,7 +517,7 @@ func TestCheckTargets_CorruptState(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(dir, "state.json"), []byte("not json"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	_, err := CheckTargets(dir)
+	_, err := CheckTargets(dir, 0)
 	if err == nil {
 		t.Fatal("expected error for corrupt state")
 	}
@@ -549,7 +549,7 @@ func TestCheckTargets_SavesIncident(t *testing.T) {
 		return "post logs"
 	}
 
-	res, err := CheckTargets(dir)
+	res, err := CheckTargets(dir, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/internal/watch/docker_monitor.go
+++ b/internal/watch/docker_monitor.go
@@ -31,6 +31,9 @@ type DockerMonitor struct {
 
 	// Events creates the docker events stream. Nil defaults to exec.CommandContext("docker", "events", ...).
 	Events EventStreamer
+
+	// Keep caps how many incidents are retained; zero or less keeps everything.
+	Keep int
 }
 
 type dockerEvent struct {
@@ -182,7 +185,7 @@ func (dm *DockerMonitor) Watch(ctx context.Context, targets []Target, incidents 
 				PostLogs:    postLogs,
 			}
 			if dm.Dir != "" {
-				if err := SaveIncident(dm.Dir, &inc); err != nil {
+				if err := SaveIncident(dm.Dir, &inc, dm.Keep); err != nil {
 					fmt.Fprintf(os.Stderr, "[docker-monitor] warning: save incident: %v\n", err)
 				}
 			}

--- a/internal/watch/pm2_monitor.go
+++ b/internal/watch/pm2_monitor.go
@@ -23,6 +23,9 @@ type PM2Monitor struct {
 
 	// ReadFile reads a file's contents. Nil defaults to os.ReadFile.
 	ReadFile func(path string) ([]byte, error)
+
+	// Keep caps how many incidents are retained; zero or less keeps everything.
+	Keep int
 }
 
 type pm2Process struct {
@@ -120,7 +123,7 @@ func (pm *PM2Monitor) Watch(ctx context.Context, targets []Target, incidents cha
 						PostLogs:     fmt.Sprintf("status=%s", p.PM2Env.Status),
 					}
 					if pm.Dir != "" {
-						if err := SaveIncident(pm.Dir, &inc); err != nil {
+						if err := SaveIncident(pm.Dir, &inc, pm.Keep); err != nil {
 							fmt.Fprintf(os.Stderr, "[pm2-monitor] warning: save incident: %v\n", err)
 						}
 					}

--- a/internal/watch/store.go
+++ b/internal/watch/store.go
@@ -148,7 +148,13 @@ func SaveState(dir string, states map[string]*ContainerState) error {
 	return os.WriteFile(statePath(dir), data, 0o644)
 }
 
-func SaveIncident(dir string, inc *Incident) error {
+// SaveIncident writes an incident and then enforces the retention cap.
+//
+// keep is the number of incidents to retain; zero or less keeps everything.
+// Pruning happens here rather than at the call sites because every monitor
+// writes through this function, and a cap that each caller had to remember to
+// apply would be a cap that one of them eventually forgets.
+func SaveIncident(dir string, inc *Incident, keep int) error {
 	idir := incidentsDir(dir)
 	if err := ensureDir(idir); err != nil {
 		return err
@@ -158,7 +164,48 @@ func SaveIncident(dir string, inc *Incident) error {
 		return err
 	}
 	path := filepath.Join(idir, inc.ID+".json")
-	return os.WriteFile(path, data, 0o644)
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		return err
+	}
+
+	// The incident is already on disk. A failed prune is a housekeeping problem,
+	// not a reason to tell the caller the incident was lost.
+	if _, err := PruneIncidents(dir, keep); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: prune incidents: %v\n", err)
+	}
+	return nil
+}
+
+// PruneIncidents deletes the oldest incidents until at most keep remain, and
+// reports how many it removed. keep of zero or less keeps everything.
+//
+// Incident files that cannot be read or parsed are left alone: ListIncidents
+// skips them, so they are never selected for deletion. Refusing to delete a
+// file we do not understand is the safer half of that trade.
+func PruneIncidents(dir string, keep int) (int, error) {
+	if keep <= 0 {
+		return 0, nil
+	}
+	incidents, err := ListIncidents(dir)
+	if err != nil {
+		return 0, err
+	}
+	if len(incidents) <= keep {
+		return 0, nil
+	}
+
+	idir := incidentsDir(dir)
+	removed := 0
+	for _, inc := range incidents[keep:] { // ListIncidents sorts newest first
+		if err := os.Remove(filepath.Join(idir, inc.ID+".json")); err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return removed, err
+		}
+		removed++
+	}
+	return removed, nil
 }
 
 func ListIncidents(dir string) ([]Incident, error) {

--- a/internal/watch/store_test.go
+++ b/internal/watch/store_test.go
@@ -1,6 +1,7 @@
 package watch
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -178,7 +179,7 @@ func TestIncidentRoundTrip(t *testing.T) {
 		PostLogs:     "post-restart log lines",
 	}
 
-	if err := SaveIncident(dir, inc); err != nil {
+	if err := SaveIncident(dir, inc, 0); err != nil {
 		t.Fatalf("SaveIncident: %v", err)
 	}
 
@@ -271,7 +272,7 @@ func TestListIncidents_Sorted(t *testing.T) {
 			Container:  pair.name,
 			DetectedAt: pair.t,
 		}
-		if err := SaveIncident(dir, inc); err != nil {
+		if err := SaveIncident(dir, inc, 0); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -311,7 +312,7 @@ func TestListIncidents_SkipsNonJSON(t *testing.T) {
 		Container:  "nginx",
 		DetectedAt: time.Now(),
 	}
-	if err := SaveIncident(dir, inc); err != nil {
+	if err := SaveIncident(dir, inc, 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -340,7 +341,7 @@ func TestListIncidents_CorruptJSON(t *testing.T) {
 		Container:  "nginx",
 		DetectedAt: time.Now(),
 	}
-	if err := SaveIncident(dir, inc); err != nil {
+	if err := SaveIncident(dir, inc, 0); err != nil {
 		t.Fatal(err)
 	}
 
@@ -484,7 +485,165 @@ func TestSaveIncident_CreatesDir(t *testing.T) {
 		ID:        GenerateIncidentID("x", time.Now()),
 		Container: "x",
 	}
-	if err := SaveIncident(dir, inc); err != nil {
+	if err := SaveIncident(dir, inc, 0); err != nil {
 		t.Fatalf("SaveIncident should create dir: %v", err)
+	}
+}
+
+func TestPruneIncidents_KeepsNewestAndDeletesOldest(t *testing.T) {
+	dir := t.TempDir()
+	base := time.Date(2026, 8, 21, 2, 0, 0, 0, time.UTC)
+
+	// Saved oldest-first so file order cannot be what makes the test pass.
+	var ids []string
+	for i := 0; i < 5; i++ {
+		inc := Incident{
+			ID:         fmt.Sprintf("svc-%02d", i),
+			Container:  "svc",
+			DetectedAt: base.Add(time.Duration(i) * time.Minute),
+		}
+		if err := SaveIncident(dir, &inc, 0); err != nil {
+			t.Fatal(err)
+		}
+		ids = append(ids, inc.ID)
+	}
+
+	removed, err := PruneIncidents(dir, 2)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if removed != 3 {
+		t.Errorf("expected 3 removed, got %d", removed)
+	}
+
+	left, err := ListIncidents(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) != 2 {
+		t.Fatalf("expected 2 incidents kept, got %d", len(left))
+	}
+	// ListIncidents sorts newest first.
+	if left[0].ID != ids[4] || left[1].ID != ids[3] {
+		t.Errorf("expected the two newest kept, got %s and %s", left[0].ID, left[1].ID)
+	}
+}
+
+func TestPruneIncidents_UnderCapIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 3; i++ {
+		inc := Incident{ID: fmt.Sprintf("svc-%02d", i), Container: "svc", DetectedAt: time.Now()}
+		if err := SaveIncident(dir, &inc, 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+	removed, err := PruneIncidents(dir, 10)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if removed != 0 {
+		t.Errorf("expected nothing removed, got %d", removed)
+	}
+	left, _ := ListIncidents(dir)
+	if len(left) != 3 {
+		t.Errorf("expected 3 incidents, got %d", len(left))
+	}
+}
+
+func TestPruneIncidents_NonPositiveKeepsEverything(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 4; i++ {
+		inc := Incident{ID: fmt.Sprintf("svc-%02d", i), Container: "svc", DetectedAt: time.Now()}
+		if err := SaveIncident(dir, &inc, 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, keep := range []int{0, -1} {
+		removed, err := PruneIncidents(dir, keep)
+		if err != nil {
+			t.Fatalf("keep=%d: unexpected error: %v", keep, err)
+		}
+		if removed != 0 {
+			t.Errorf("keep=%d: expected nothing removed, got %d", keep, removed)
+		}
+	}
+	left, _ := ListIncidents(dir)
+	if len(left) != 4 {
+		t.Errorf("expected all 4 incidents kept, got %d", len(left))
+	}
+}
+
+func TestPruneIncidents_MissingDirIsNoop(t *testing.T) {
+	removed, err := PruneIncidents(t.TempDir(), 5)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if removed != 0 {
+		t.Errorf("expected 0 removed, got %d", removed)
+	}
+}
+
+func TestSaveIncident_EnforcesCap(t *testing.T) {
+	// The cap has to apply on the write path — a monitor that never calls prune
+	// explicitly must still not grow the directory without bound.
+	dir := t.TempDir()
+	base := time.Date(2026, 8, 21, 2, 0, 0, 0, time.UTC)
+	for i := 0; i < 6; i++ {
+		inc := Incident{
+			ID:         fmt.Sprintf("svc-%02d", i),
+			Container:  "svc",
+			DetectedAt: base.Add(time.Duration(i) * time.Minute),
+		}
+		if err := SaveIncident(dir, &inc, 3); err != nil {
+			t.Fatal(err)
+		}
+	}
+	left, err := ListIncidents(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(left) != 3 {
+		t.Fatalf("expected the directory capped at 3, got %d", len(left))
+	}
+	if left[0].ID != "svc-05" {
+		t.Errorf("expected newest incident kept, got %s", left[0].ID)
+	}
+}
+
+func TestRetentionConfig_Normalize(t *testing.T) {
+	tests := []struct {
+		name string
+		in   int
+		want int
+	}{
+		{"unset falls back to the default", 0, defaultMaxIncidents},
+		{"negative means keep everything", -1, 0},
+		{"explicit value is kept", 50, 50},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			r := RetentionConfig{MaxIncidents: tc.in}
+			r.Normalize()
+			if r.MaxIncidents != tc.want {
+				t.Errorf("Normalize(%d) = %d, want %d", tc.in, r.MaxIncidents, tc.want)
+			}
+		})
+	}
+}
+
+func TestLoadWatchConfig_AppliesRetentionDefault(t *testing.T) {
+	// Configs written before retention existed have no such key. They must get
+	// the default cap, not "keep everything".
+	dir := t.TempDir()
+	legacy := `{"notify":{"enabled":false},"flapping":{}}`
+	if err := os.WriteFile(filepath.Join(dir, "config.json"), []byte(legacy), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg, err := LoadWatchConfig(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cfg.Retention.MaxIncidents != defaultMaxIncidents {
+		t.Errorf("expected default cap %d, got %d", defaultMaxIncidents, cfg.Retention.MaxIncidents)
 	}
 }

--- a/internal/watch/systemd_monitor.go
+++ b/internal/watch/systemd_monitor.go
@@ -18,6 +18,9 @@ type SystemdMonitor struct {
 
 	// Interval is the polling interval.
 	Interval time.Duration
+
+	// Keep caps how many incidents are retained; zero or less keeps everything.
+	Keep int
 }
 
 type systemdState struct {
@@ -113,7 +116,7 @@ func (sm *SystemdMonitor) Watch(ctx context.Context, targets []Target, incidents
 						PostLogs:    fmt.Sprintf("ActiveState=%s SubState=%s", curr.ActiveState, curr.SubState),
 					}
 					if sm.Dir != "" {
-						if err := SaveIncident(sm.Dir, &inc); err != nil {
+						if err := SaveIncident(sm.Dir, &inc, sm.Keep); err != nil {
 							fmt.Fprintf(os.Stderr, "[systemd-monitor] warning: save incident: %v\n", err)
 						}
 					}

--- a/internal/watch/watchconfig.go
+++ b/internal/watch/watchconfig.go
@@ -7,9 +7,41 @@ import (
 	"path/filepath"
 )
 
+// defaultMaxIncidents caps the incident directory by default. Each incident
+// file carries up to 100 lines of captured logs, so an uncapped directory grows
+// fastest exactly when something is wrong — a service restarting every 30s
+// writes thousands of them a day.
+const defaultMaxIncidents = 200
+
 type WatchConfig struct {
-	Notify   NotifySettings `json:"notify"`
-	Flapping FlappingConfig `json:"flapping"`
+	Notify    NotifySettings  `json:"notify"`
+	Flapping  FlappingConfig  `json:"flapping"`
+	Retention RetentionConfig `json:"retention"`
+}
+
+// RetentionConfig bounds how much incident history is kept on disk.
+type RetentionConfig struct {
+	// MaxIncidents is how many incidents to keep, newest first.
+	//
+	// Zero means "not configured" and takes the default, so that config files
+	// written before this setting existed do not silently read as unlimited.
+	// A negative value is the explicit way to ask for unlimited history.
+	MaxIncidents int `yaml:"max_incidents,omitempty" json:"max_incidents"`
+}
+
+func DefaultRetentionConfig() RetentionConfig {
+	return RetentionConfig{MaxIncidents: defaultMaxIncidents}
+}
+
+// Normalize resolves the sentinel values into the number PruneIncidents wants,
+// where zero or less means keep everything.
+func (r *RetentionConfig) Normalize() {
+	switch {
+	case r.MaxIncidents < 0:
+		r.MaxIncidents = 0
+	case r.MaxIncidents == 0:
+		r.MaxIncidents = defaultMaxIncidents
+	}
 }
 
 type NotifySettings struct {
@@ -29,7 +61,8 @@ func DefaultWatchConfig() WatchConfig {
 			OnFlapping: true,
 			Cooldown:   "5m",
 		},
-		Flapping: DefaultFlappingConfig(),
+		Flapping:  DefaultFlappingConfig(),
+		Retention: DefaultRetentionConfig(),
 	}
 }
 
@@ -52,6 +85,7 @@ func LoadWatchConfig(dir string) (*WatchConfig, error) {
 		return nil, err
 	}
 	cfg.Notify.Normalize()
+	cfg.Retention.Normalize()
 	return &cfg, nil
 }
 


### PR DESCRIPTION
> **Stacked on #46.** Based on `fix/watch-check-skipped-targets` because both touch
> `CheckTargets`. Review that one first; GitHub retargets this to `main` when it merges.
> The diff shown here is this change only.

## The problem

Nothing ever deletes an incident. `SaveIncident` writes one JSON file per incident and
there is no prune, rotate, or retention anywhere in `internal/watch`.

Each file embeds the captured logs — `journalctl -u <unit> -n 100` for systemd,
`docker logs --tail 100` for containers — so the directory grows fastest exactly when
something is wrong. A service in a restart loop at 30s intervals writes roughly 2,880
incidents a day, each tens of kilobytes, none of them ever collected.

Flapping detection does not bound this. `FlappingConfig.Check` classifies an incident once
it already exists; it never suppresses the write. So the case that produces the most files
is the one flapping was supposed to be about.

Noticed while looking at what `watch` would do on a small host — 16GB disk, 0.9GB RAM —
where a runaway incident directory is not a theoretical concern.

## The fix

`SaveIncident` enforces a cap after each write: keep the newest N, delete the rest.

Pruning lives on the write path rather than at the call sites. There are five writers —
the three monitors, `CheckTargets`, and the enrichment re-save in `cmd/watch.go` — and a
cap each caller had to remember to apply is a cap one of them eventually forgets. The
monitors carry a `Keep` field; `CheckTargets` and `SaveIncident` take it as a parameter.

## Configuration

```yaml
watch:
  retention:
    max_incidents: 200   # default; -1 keeps everything
```

Resolved like the neighbouring watch settings: `config.yaml` wins over
`watch/config.json`.

The sentinel handling is the part worth reviewing. `0` means **not configured** and takes
the default; `-1` is the explicit opt-out. If `0` meant unlimited, every `config.json`
written before this setting existed — they have no `retention` key, so it decodes to the
zero value — would silently read as "keep everything", which is the exact behaviour this
PR exists to end. `Normalize()` folds `-1` into the `0` that `PruneIncidents` treats as
unlimited, so the internal contract stays simple.

`config validate` needed `retention` and `max_incidents` added to its key allowlist —
`WatchRuntimeConfig` has a custom unmarshaler, so `KnownFields` does not reach into the
`watch:` subtree and a new block would otherwise be reported as an unknown key.

## Two deliberate non-behaviours

**Unparseable incident files are never deleted.** `ListIncidents` skips files it cannot
read or unmarshal, so pruning never selects them. They can accumulate. Refusing to delete
a file we do not understand seemed the safer half of that trade; the alternative is
deleting on a parse error, which is a worse failure mode than leaking a few bytes.

**A failed prune does not fail the save.** The incident is already on disk by then.
Returning an error would tell the caller the incident was lost when it was not, so the
prune error goes to stderr as a warning.

## Also here

`watch check` now calls `loadConfig()`, as `watch start` has since #31. Without it, `check`
would read retention only from `watch/config.json` while `start` read it from
`config.yaml`, and the two commands would enforce different caps on the same directory.

## Tests

`internal/watch`:
- `TestPruneIncidents_KeepsNewestAndDeletesOldest` — saved oldest-first so file order
  cannot be what makes it pass.
- `TestPruneIncidents_UnderCapIsNoop`, `TestPruneIncidents_MissingDirIsNoop`
- `TestPruneIncidents_NonPositiveKeepsEverything` — both `0` and `-1`.
- `TestSaveIncident_EnforcesCap` — the write path caps on its own, without an explicit
  prune call. This is the one that would catch a future monitor bypassing the cap.
- `TestRetentionConfig_Normalize`, `TestLoadWatchConfig_AppliesRetentionDefault` — the
  legacy-config case, written against a `config.json` with no `retention` key.

`internal/config`:
- `TestLoadWatchRetention`, `TestLoadWatchRetentionDefaultsWhenUnset`,
  `TestLoadWatchRetentionNegativeMeansUnlimited`
- `TestValidateAcceptsWatchRetention`, `TestValidateUnknownWatchRetentionKey`

`go build ./...` and `go vet ./...` clean. `internal/watch`, `internal/config`, and `cmd`
pass.

README documents the setting under the existing watch config block.
