### PR TITLE
fix: name the build matrix jobs after the platform they build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
           go tool cover -func=coverage.out | tail -1
 
   build:
-    name: Build (${{ matrix.os }})
+    name: Build (${{ matrix.goos }}/${{ matrix.goarch }})
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
The matrix defines `goos` and `goarch`, but the job name interpolated
`matrix.os`, which does not exist. All four cross-compile jobs reported as
`Build ()`, so a failure gave no way to tell which platform had broken without
opening the log.

Job names become `Build (linux/amd64)`, `Build (linux/arm64)`,
`Build (darwin/amd64)`, `Build (darwin/arm64)`.

Note for after this merges: branch protection currently requires only `Lint` and
`Test`, so a broken cross-compile can still merge. Adding the four new names as
required checks should wait until #51 is in, since it would otherwise block that
branch until it is updated.