### PR TITLE
feat: expose watch_check over MCP

### DIFF
--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -78,6 +78,8 @@ Restart your AI client — homebutler tools will appear automatically.
 |---|---|
 | `system_status` | CPU, memory, disk, uptime |
 | `report` | Butler-style health report with snapshot comparison and suggested actions |
+| `doctor` | Read-only diagnosis of resource pressure, stopped containers, public ports, backup hygiene, and notification readiness |
+| `watch_check` | One-shot restart check on watched targets; reports systemd and pm2 targets as skipped rather than healthy |
 | `inventory_scan` | Server inventory/topology: system, containers, app ports, system ports |
 | `inventory_export` | Export inventory as Mermaid (local) or JSON |
 | `docker_list` | List containers |

--- a/internal/mcp/capabilities.go
+++ b/internal/mcp/capabilities.go
@@ -230,6 +230,23 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
+		// Write rather than read: CheckTargets records the new container state
+		// and saves any incident it detects, so a caller cannot treat this as a
+		// free query the way system_status is.
+		risk:          riskWrite,
+		remoteSupport: true,
+		tool: toolDef{
+			Name:        "watch_check",
+			Description: "Run a one-shot restart check on watched targets and report restarts detected since the last check. Only docker targets can be inspected this way; systemd and pm2 targets are reported as skipped rather than assumed healthy",
+			InputSchema: inputSchema{
+				Type: "object",
+				Properties: map[string]propDef{
+					"server": {Type: "string", Description: "Remote server name from config (optional, runs locally if omitted)"},
+				},
+			},
+		},
+	},
+	{
 		risk:          riskWrite,
 		remoteSupport: true,
 		tool: toolDef{

--- a/internal/mcp/demo.go
+++ b/internal/mcp/demo.go
@@ -75,6 +75,28 @@ func (s *Server) executeDemoTool(name string, args map[string]any) (any, error) 
 				{"severity": "warn", "category": "backup", "title": "Latest backup is older than expected", "action": "Run a fresh backup. If this app matters, follow up with a backup drill.", "command": "homebutler backup"},
 			},
 		}, nil
+	case "watch_check":
+		// Carries a skipped target on purpose: a demo that only ever returned
+		// incidents would teach a caller that an empty incident list means the
+		// whole watch list is healthy, which is the misreading the real
+		// command's Skipped field exists to prevent.
+		return map[string]any{
+			"checked": 2,
+			"incidents": []map[string]any{
+				{
+					"id":              "demo-nextcloud-20260430T120000Z",
+					"container":       "nextcloud",
+					"detected_at":     "2026-04-30T12:00:00Z",
+					"restart_count":   3,
+					"prev_started_at": "2026-04-30T09:14:02Z",
+					"curr_started_at": "2026-04-30T11:58:41Z",
+					"post_logs":       "MySQL server has gone away\nRetrying connection (1/5)",
+				},
+			},
+			"skipped": []map[string]any{
+				{"name": "caddy.service", "kind": "systemd"},
+			},
+		}, nil
 	case "backup_create":
 		service := stringArg(args, "service")
 		if service == "" {

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -95,8 +95,8 @@ func TestToolsList(t *testing.T) {
 		t.Fatalf("unmarshal toolsListResult: %v", err)
 	}
 
-	if len(list.Tools) != 23 {
-		t.Errorf("expected 23 tools, got %d", len(list.Tools))
+	if len(list.Tools) != 24 {
+		t.Errorf("expected 24 tools, got %d", len(list.Tools))
 	}
 
 	expectedTools := map[string]bool{
@@ -114,6 +114,7 @@ func TestToolsList(t *testing.T) {
 		"inventory_export":  false,
 		"report":            false,
 		"doctor":            false,
+		"watch_check":       false,
 		"backup_create":     false,
 		"backup_list":       false,
 		"backup_drill":      false,

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -22,6 +22,7 @@ import (
 	"github.com/Higangssh/homebutler/internal/report"
 	"github.com/Higangssh/homebutler/internal/system"
 	"github.com/Higangssh/homebutler/internal/wake"
+	"github.com/Higangssh/homebutler/internal/watch"
 )
 
 // JSON-RPC 2.0 types
@@ -294,6 +295,12 @@ func (s *Server) executeTool(name string, args map[string]any) (any, error) {
 		return doctor.Run(s.cfg, doctor.DefaultCollectFuncs(), doctor.Options{
 			BackupMaxAge: time.Duration(intArg(args, "backup_max_age_hours", 168)) * time.Hour,
 		})
+	case "watch_check":
+		dir, err := watch.WatchDir()
+		if err != nil {
+			return nil, err
+		}
+		return watch.CheckTargets(dir, s.resolveIncidentCap(dir))
 	case "backup_create":
 		backupDir := stringArg(args, "to")
 		if backupDir == "" {
@@ -379,6 +386,26 @@ func (s *Server) executeTool(name string, args map[string]any) (any, error) {
 	}
 }
 
+// resolveIncidentCap resolves the incident retention cap the same way the
+// watch commands do: config.yaml wins over watch/config.json, and an unset
+// value takes the default rather than reading as unlimited.
+//
+// Without this, watch_check would prune on a different rule than `watch check`
+// and `watch start`, and the incident history an agent reads would not match
+// the one the terminal shows.
+func (s *Server) resolveIncidentCap(dir string) int {
+	watchCfg, err := watch.LoadWatchConfig(dir)
+	if err != nil || watchCfg == nil {
+		defaults := watch.DefaultWatchConfig()
+		watchCfg = &defaults
+	}
+	if s.cfg != nil {
+		watchCfg.Retention = s.cfg.Watch.Retention
+	}
+	watchCfg.Retention.Normalize()
+	return watchCfg.Retention.MaxIncidents
+}
+
 func (s *Server) executeRemote(srv *config.ServerConfig, tool string, args map[string]any) (any, error) {
 	// Build remote command args
 	var remoteArgs []string
@@ -422,6 +449,8 @@ func (s *Server) executeRemote(srv *config.ServerConfig, tool string, args map[s
 		}
 	case "doctor":
 		remoteArgs = []string{"doctor", "--json", "--backup-max-age", fmt.Sprintf("%dh", intArg(args, "backup_max_age_hours", 168))}
+	case "watch_check":
+		remoteArgs = []string{"watch", "check", "--json"}
 	case "backup_list":
 		remoteArgs = []string{"backup", "list", "--json"}
 	case "backup_create":

--- a/internal/mcp/watch_check_test.go
+++ b/internal/mcp/watch_check_test.go
@@ -1,0 +1,108 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/Higangssh/homebutler/internal/config"
+	"github.com/Higangssh/homebutler/internal/watch"
+)
+
+// watch_check writes state and saves incidents, so it must not be advertised
+// with the same risk as a query like system_status. A client that gates write
+// tools behind confirmation relies on this classification.
+func TestWatchCheckCapabilityIsWriteAndRemoteCapable(t *testing.T) {
+	var found bool
+	for _, c := range capabilityRegistry {
+		if c.tool.Name != "watch_check" {
+			continue
+		}
+		found = true
+		if c.risk != riskWrite {
+			t.Errorf("watch_check risk = %q, want %q", c.risk, riskWrite)
+		}
+		if !c.remoteSupport {
+			t.Error("watch_check should be routable to a remote server")
+		}
+		if _, ok := c.tool.InputSchema.Properties["server"]; !ok {
+			t.Error("watch_check should accept a server argument")
+		}
+		if len(c.tool.InputSchema.Required) != 0 {
+			t.Errorf("watch_check should have no required arguments, got %v", c.tool.InputSchema.Required)
+		}
+	}
+	if !found {
+		t.Fatal("watch_check is not registered")
+	}
+}
+
+func TestResolveIncidentCap(t *testing.T) {
+	const defaultCap = 200
+
+	tests := []struct {
+		name string
+		cfg  *config.Config
+		want int
+	}{
+		{
+			name: "unset takes the default rather than reading as unlimited",
+			cfg:  &config.Config{},
+			want: defaultCap,
+		},
+		{
+			name: "config.yaml value wins",
+			cfg: &config.Config{
+				Watch: config.WatchRuntimeConfig{Retention: watch.RetentionConfig{MaxIncidents: 7}},
+			},
+			want: 7,
+		},
+		{
+			name: "negative is the explicit way to ask for unlimited",
+			cfg: &config.Config{
+				Watch: config.WatchRuntimeConfig{Retention: watch.RetentionConfig{MaxIncidents: -1}},
+			},
+			want: 0,
+		},
+		{
+			name: "nil config still resolves to the default",
+			cfg:  nil,
+			want: defaultCap,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewServer(tt.cfg, "test")
+			if got := s.resolveIncidentCap(t.TempDir()); got != tt.want {
+				t.Errorf("resolveIncidentCap() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+// The demo response has to show a skipped target. An agent that only ever saw
+// an empty incident list would learn that it means the watch list is healthy,
+// which is the reading Skipped exists to prevent.
+func TestDemoWatchCheckReportsSkippedTargets(t *testing.T) {
+	s := NewServer(&config.Config{}, "dev", true)
+
+	res, err := s.executeDemoTool("watch_check", nil)
+	if err != nil {
+		t.Fatalf("watch_check demo failed: %v", err)
+	}
+
+	out, ok := res.(map[string]any)
+	if !ok {
+		t.Fatalf("watch_check demo returned %T, want map", res)
+	}
+
+	skipped, ok := out["skipped"].([]map[string]any)
+	if !ok || len(skipped) == 0 {
+		t.Fatalf("demo response must carry a skipped target, got %v", out["skipped"])
+	}
+	if skipped[0]["kind"] == "docker" {
+		t.Error("a docker target is never skipped by check; the demo should skip a systemd or pm2 target")
+	}
+	if _, ok := out["checked"]; !ok {
+		t.Error("demo response is missing the checked count")
+	}
+}


### PR DESCRIPTION
The README leads with *"Why did this service restart at 3 AM?"* and `watch` is
what answers it, but no MCP tool reached the watch subsystem. `report` already
answers what changed over MCP; this answers what broke.

```
watch_check → { "checked": 2, "incidents": [...], "skipped": [...] }
```

First of the five tools in #54, and the reference the other four should follow.

### Decisions worth reviewing

**`riskWrite`, not `riskRead`.** `CheckTargets` records the new container state
and saves any incident it detects. It reads like a query but it is not one, and
a client that gates write tools behind confirmation should gate this one — the
same way it already gates `report` for saving a snapshot.

**The retention cap is resolved the way the watch commands resolve it.**
`config.yaml` wins over `watch/config.json`, and an unset value takes the
default rather than reading as unlimited. Reading it any other way would prune
the incident directory on a different rule than the terminal does, and the
history an agent sees would stop matching the history a person sees.

**The demo response carries a skipped systemd target.** A demo that only ever
returned incidents would teach a caller that an empty incident list means the
whole watch list is healthy — the misreading `Skipped` exists to prevent.

### Also

`doctor` was missing from the tool table in `docs/mcp-server.md`; it has been
absent since the tool shipped in v0.19.0.

### Testing

Four new tests: the capability's risk and remote support, retention resolution
across all four cases (unset, config value, negative, nil config), and the demo
response carrying a skipped target. Tool count and name set updated.

Verified with `go build ./...`, `go vet`, and `go test` on `internal/mcp`,
`internal/watch`, and `cmd`.