### PR TITLE
chore: prepare the 0.21.0 release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ demo-chat.sh
 demo-chat.cast
 # /demo
 docs/TUI_SPEC.md
+docs/DIRECTION_SPEC.md
 demo-mcp.gif
 *.bak
 *.tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,55 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.0](https://github.com/Higangssh/homebutler/compare/v0.20.0...v0.21.0) - 2026-08-23
+
+**Three commands were confidently answering the wrong question.** `watch check` called systemd and pm2 targets clean without inspecting them, `report` counted fewer public ports than `doctor` did on the same scan, and a failed first connection blamed the host key rather than the reason it failed.
+
+```bash
+homebutler inventory scan --filter exposed
+```
+
+### ✨ Features
+
+- add `inventory scan --filter exposed` to answer "what is reachable from outside" without reading the whole tree, reusing the container-owner and dedupe logic the default view already has (#51, thanks @lenny-ts)
+- surface collection warnings in the filtered view, so a failed port scan never renders as an authoritative empty list
+- expose `watch_check` over MCP, so an agent can ask what broke and not just what changed. Classified `riskWrite` rather than `riskRead`, since it records container state and saves any incident it finds (#55)
+- cap incident history with `watch.retention.max_incidents`, default 200. `SaveIncident` wrote one file per incident and nothing ever deleted them, so the watch directory grew fastest exactly when something was wrong — a service restarting every 30s wrote roughly 2,880 files a day, each carrying 100 lines of captured logs (#50)
+- align and colour the `report` and `doctor` output, with colour dropped automatically when piped, redirected, or run from cron (#42)
+
+### 🐛 Fixes
+
+- report what `watch check` actually inspected. It only examines docker targets — systemd and pm2 need a previous poll to compare against — but the skip was silent and the count included every registered target, so a watch list holding one systemd unit printed "Checked 1 container(s). No restarts detected." having looked at nothing (#46)
+- count `[::]` and empty-address binds as public in `report`, which used its own inline comparison while `doctor` and the new exposure filter used `ports.IsPublicBind`. The same scan produced two different answers
+- warn when `serve` binds to any wildcard address. The check matched only `0.0.0.0`, so `--host ::` exposed the dashboard with nothing printed
+- don't blame the host key when the TOFU connection fails (#44)
+- name the build matrix jobs after the platform they build. All four reported as "Build ()", so a cross-compile failure gave no way to tell which platform had broken (#53)
+
+### ⚠️ Behavior changes
+
+- **`watch check` now reports zero for a list it cannot inspect.** A watch list holding only systemd or pm2 targets previously read as a clean bill of health. It now prints what was checked, lists what was skipped, and points at `homebutler watch start`, which does monitor them
+- **`PublicPortCount` in `report --json` rises on hosts with IPv6 wildcard listeners**, and now matches `doctor`. Anything comparing the two across versions will see the corrected value
+- **`serve --host ::` now prints the exposure warning** it should always have printed
+- **Incident files are pruned to the newest 200.** Existing directories are trimmed on the next write. Set `watch.retention.max_incidents` to change it; a negative value keeps everything. Files that cannot be parsed are never deleted
+
+### 📝 Documentation
+
+- write down which contributions homebutler accepts in `CONTRIBUTING.md`: the two-tier bar, what a new target has to prove, and what is waiting until 1.0
+- replace the README `report` and `doctor` blocks with hand-written SVG terminal cards, since a fenced code block cannot show the colour that does most of the visual work (#43)
+- add `doctor` to the tool table in `docs/mcp-server.md`, missing since it shipped in v0.19.0
+- lead the README with what homebutler actually prints, and restore the logo and mascot placement
+
+### 📦 Distribution
+
+- publish releases to the MCP Registry after the npm step that proves ownership, now that `modelcontextprotocol/servers` has retired its third-party list (#52)
+- drop the Go Report Card badge, which rendered as "go report | retired" after the service shut down and told every visitor the project was abandoned
+- add the social preview card
+
+### ♻️ Internal
+
+- consolidate `isPublicBind` into `internal/ports` (#47)
+- move the docker-only rule for `watch check` onto `Target.CheckSupported` so callers stop duplicating it
+
 ## [0.20.0](https://github.com/Higangssh/homebutler/compare/v0.19.2...v0.20.0) - 2026-08-18
 
 **Config that fails silently now speaks up.** This release adds `homebutler config validate` and fixes three ways configuration could be ignored without producing any error at all — including a form documented in this project's own README that never worked.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,66 @@
 
 Thanks for your interest in contributing!
 
+## What homebutler is
+
+homebutler operates a homelab server through one structured surface that both
+people and AI agents use. It answers "what changed?" rather than "what is the
+state right now?"
+
+That sentence settles most scope questions. If you are unsure whether an idea
+fits, open an issue before writing code — we would rather talk it through early
+than turn down finished work.
+
+## What we accept
+
+### App catalogue additions
+
+Adding an app to `homebutler install` is the easiest place to start, and the bar
+is mechanical:
+
+- Official or first-party image
+- Pinned tag, not `:latest`
+- Default ports that do not collide with the existing catalogue
+- Volume and data paths following the existing convention
+- A smoke test that passes: install, start, health check
+- README app list updated
+
+We do not debate whether an app belongs in a homelab. If the checklist passes,
+it goes in.
+
+### Everything else
+
+Four questions, in order. A "no" is not a verdict on the idea — it tells you what
+the PR is still missing.
+
+1. **Which target?** homebutler covers `docker`, `systemd`, `pm2`, `ports`,
+   `network`, and `system`. A *new* target is a larger commitment: open an issue
+   first, and expect to answer questions 2 through 4 for the whole target.
+2. **Does it emit JSON?** Human-readable output is not enough. Anything a person
+   can ask for, an agent should be able to parse — including on the `--json` path.
+3. **Which question does it answer?** The README lists the ones homebutler exists
+   for: what is running, which container owns this port, why did this restart at
+   3 AM, is the backup restorable, what is reachable from outside. A new question
+   needs a case for why operators ask it.
+4. **If it detects a problem, can something act on it?** Either remediation
+   arrives with the detection, or an issue is open committing to it. A read-only
+   first phase is fine when a second phase is named. Reporting state — `docker
+   top`, `docker inspect` — is not detection and this question does not apply.
+
+## Priorities
+
+Depth before breadth. Covering the existing targets thoroughly comes before
+adding new ones.
+
+Working toward 1.0, which freezes the MCP tool surface and the JSON schema:
+
+- Complete MCP coverage (#54)
+- Close the detect/remediate gap in `watch` (#49)
+
+New targets generally wait until after 1.0, so open an issue before starting one.
+Work already discussed and agreed in an issue keeps the terms it was given —
+Proxmox (#32) is proceeding on the plan in that thread.
+
 ## Before submitting a PR
 
 Please run these checks locally before pushing:

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -130,7 +130,7 @@ func buildSnapshot(inv *inventory.Inventory) *Snapshot {
 func countPublicPorts(pp []ports.PortInfo) int {
 	count := 0
 	for _, p := range pp {
-		if p.Address == "*" || p.Address == "0.0.0.0" || p.Address == "::" {
+		if ports.IsPublicBind(p.Address) {
 			count++
 		}
 	}

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -262,3 +262,32 @@ func join(ss []string) string {
 	}
 	return result
 }
+
+// countPublicPorts must agree with ports.IsPublicBind. It used to compare
+// addresses inline, missing bracketed IPv6 and the empty address, so report
+// and doctor could disagree about the same port.
+func TestCountPublicPortsMatchesIsPublicBind(t *testing.T) {
+	pp := []ports.PortInfo{
+		{Port: "80", Address: "0.0.0.0"},
+		{Port: "443", Address: "::"},
+		{Port: "8080", Address: "*"},
+		{Port: "8443", Address: "[::]"},
+		{Port: "9000", Address: ""},
+		{Port: "5432", Address: "127.0.0.1"},
+		{Port: "6379", Address: "192.168.1.10"},
+	}
+
+	want := 0
+	for _, p := range pp {
+		if ports.IsPublicBind(p.Address) {
+			want++
+		}
+	}
+	if want != 5 {
+		t.Fatalf("fixture no longer exercises the cases it was written for: %d public binds", want)
+	}
+
+	if got := countPublicPorts(pp); got != want {
+		t.Errorf("countPublicPorts = %d, ports.IsPublicBind classifies %d as public", got, want)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -73,8 +73,12 @@ func (s *Server) Handler() http.Handler {
 
 // Run starts the HTTP server.
 func (s *Server) Run() error {
-	if s.host == "0.0.0.0" {
-		fmt.Fprintln(os.Stderr, "⚠️  WARNING: binding to 0.0.0.0 exposes the dashboard to all network interfaces.")
+	if ports.IsPublicBind(s.host) {
+		bound := s.host
+		if bound == "" {
+			bound = "all interfaces"
+		}
+		fmt.Fprintf(os.Stderr, "⚠️  WARNING: binding to %s exposes the dashboard to all network interfaces.\n", bound)
 		if s.token == "" {
 			fmt.Fprintln(os.Stderr, "   Consider using --token to require authentication.")
 		}


### PR DESCRIPTION
Release prep for 0.21.0, plus one fix that belongs in this release rather than the next one.

`report` counted public ports with its own inline comparison, missing bracketed IPv6 and empty-address binds, while `doctor` and the new `inventory scan --filter exposed` both use `ports.IsPublicBind`. The same scan produced two different answers. That would have been a normal follow-up except this release ships #47, which consolidated that predicate, and #51, which is built on it — shipping a third private copy in the release that advertises the consolidation is the wrong time to leave it.

Grepping for the remaining copies turned up a third site: `serve` warned about public binding only when the host was exactly `0.0.0.0`, so `--host ::` exposed the dashboard with nothing printed. Both now call `ports.IsPublicBind`.

The test asserts agreement with `ports.IsPublicBind` rather than a hardcoded count, so it fails if either side drifts. Verified it fails against the old implementation (`countPublicPorts = 3, ports.IsPublicBind classifies 5 as public`) before the fix went in.

`CONTRIBUTING.md` now states what homebutler accepts: the two-tier bar, what a new target has to prove before it lands, and what is waiting until 1.0. Until now it covered `gofmt` and PR size but said nothing about which features belong here, so scope was only discoverable by writing something and being turned down.

`internal/server` tests do not pass locally on Windows — `TestProcessesEndpoint` fails on a clean tree too — so the `serve` change is unverified outside of build and vet until CI runs it.
