### PR TITLE
refactor: single source of truth for inventory filters and --filter on show

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,7 @@ Findings
 
 ```bash
 homebutler inventory scan
+homebutler inventory show --filter exposed
 homebutler inventory export --format mermaid
 homebutler --json inventory scan
 ```

--- a/cmd/inventory.go
+++ b/cmd/inventory.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/Higangssh/homebutler/internal/inventory"
 	"github.com/spf13/cobra"
@@ -24,6 +23,11 @@ func newInventoryCmd() *cobra.Command {
 	return invCmd
 }
 
+// addInventoryFilterFlag registers --filter on an inventory command.
+func addInventoryFilterFlag(cmd *cobra.Command, filter *string) {
+	cmd.Flags().StringVar(filter, "filter", "", "Filter inventory output (supported: exposed)")
+}
+
 func newInventoryScanCmd() *cobra.Command {
 	var filter string
 	cmd := &cobra.Command{
@@ -33,23 +37,26 @@ func newInventoryScanCmd() *cobra.Command {
 			return runInventoryScan(filter)
 		},
 	}
-	cmd.Flags().StringVar(&filter, "filter", "", "Filter inventory output (supported: exposed)")
+	addInventoryFilterFlag(cmd, &filter)
 	return cmd
 }
 
 func newInventoryShowCmd() *cobra.Command {
-	return &cobra.Command{
+	var filter string
+	cmd := &cobra.Command{
 		Use:   "show",
 		Short: "Show current server inventory (same as scan)",
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runInventoryScan("")
+			return runInventoryScan(filter)
 		},
 	}
+	addInventoryFilterFlag(cmd, &filter)
+	return cmd
 }
 
 func runInventoryScan(filter string) error {
 	if filter != "" && !inventory.IsSupportedFilter(filter) {
-		return fmt.Errorf("unsupported filter %q (supported: %s)", filter, strings.Join(inventory.SupportedFilters(), ", "))
+		return inventory.UnsupportedFilterError(filter)
 	}
 	if filter != "" && jsonOutput {
 		return fmt.Errorf("--filter is not supported with --json; JSON output is always the full inventory")

--- a/cmd/inventory.go
+++ b/cmd/inventory.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Higangssh/homebutler/internal/inventory"
 	"github.com/spf13/cobra"
@@ -23,9 +24,11 @@ func newInventoryCmd() *cobra.Command {
 	return invCmd
 }
 
-// addInventoryFilterFlag registers --filter on an inventory command.
+// addInventoryFilterFlag registers --filter on an inventory command. The usage
+// string is derived from SupportedFilters so it cannot go stale.
 func addInventoryFilterFlag(cmd *cobra.Command, filter *string) {
-	cmd.Flags().StringVar(filter, "filter", "", "Filter inventory output (supported: exposed)")
+	usage := fmt.Sprintf("Filter inventory output (supported: %s)", strings.Join(inventory.SupportedFilters(), ", "))
+	cmd.Flags().StringVar(filter, "filter", "", usage)
 }
 
 func newInventoryScanCmd() *cobra.Command {

--- a/cmd/inventory_test.go
+++ b/cmd/inventory_test.go
@@ -3,6 +3,9 @@ package cmd
 import (
 	"strings"
 	"testing"
+
+	"github.com/Higangssh/homebutler/internal/inventory"
+	"github.com/spf13/cobra"
 )
 
 // The --json + --filter rejection happens before loadConfig, so the test can run
@@ -30,5 +33,21 @@ func TestNewInventoryShowCmdAcceptsFilter(t *testing.T) {
 	got, _ := cmd.Flags().GetString("filter")
 	if got != "exposed" {
 		t.Errorf("show --filter parsed %q, want \"exposed\"", got)
+	}
+}
+
+// The --filter usage string is derived from SupportedFilters, so it lists
+// exactly what the renderer accepts and never goes stale.
+func TestInventoryFilterFlagUsageListsSupportedFilters(t *testing.T) {
+	for _, cmd := range []*cobra.Command{newInventoryScanCmd(), newInventoryShowCmd()} {
+		flag := cmd.Flags().Lookup("filter")
+		if flag == nil {
+			t.Fatalf("%s must register --filter", cmd.Name())
+		}
+		for _, f := range inventory.SupportedFilters() {
+			if !strings.Contains(flag.Usage, f) {
+				t.Errorf("%s --filter usage %q does not list supported filter %q", cmd.Name(), flag.Usage, f)
+			}
+		}
 	}
 }

--- a/cmd/inventory_test.go
+++ b/cmd/inventory_test.go
@@ -20,3 +20,15 @@ func TestRunInventoryScanRejectsJSONWithFilter(t *testing.T) {
 		t.Errorf("unhelpful error for --filter + --json: %v", err)
 	}
 }
+
+// show advertises "same as scan", so it must accept the same flags.
+func TestNewInventoryShowCmdAcceptsFilter(t *testing.T) {
+	cmd := newInventoryShowCmd()
+	if err := cmd.ParseFlags([]string{"--filter", "exposed"}); err != nil {
+		t.Fatalf("show must accept --filter: %v", err)
+	}
+	got, _ := cmd.Flags().GetString("filter")
+	if got != "exposed" {
+		t.Errorf("show --filter parsed %q, want \"exposed\"", got)
+	}
+}

--- a/internal/inventory/inventory_test.go
+++ b/internal/inventory/inventory_test.go
@@ -337,15 +337,16 @@ func TestIsSupportedFilter(t *testing.T) {
 }
 
 // Pins the single-source-of-truth invariant: everything SupportedFilters()
-// lists must be accepted by the renderer, so the two can never disagree.
+// lists must be accepted by the renderer and by IsSupportedFilter, so the
+// three can never disagree.
 func TestRenderTreeFiltered_AgreesWithSupportedFilters(t *testing.T) {
 	for _, f := range SupportedFilters() {
 		if _, err := RenderTreeFiltered(&Inventory{ServerName: "lab"}, f); err != nil {
 			t.Errorf("SupportedFilters() lists %q but RenderTreeFiltered rejects it: %v", f, err)
 		}
-	}
-	if !IsSupportedFilter(SupportedFilters()[0]) {
-		t.Error("first supported filter is not accepted by IsSupportedFilter")
+		if !IsSupportedFilter(f) {
+			t.Errorf("SupportedFilters() lists %q but IsSupportedFilter rejects it", f)
+		}
 	}
 }
 

--- a/internal/inventory/inventory_test.go
+++ b/internal/inventory/inventory_test.go
@@ -336,6 +336,26 @@ func TestIsSupportedFilter(t *testing.T) {
 	}
 }
 
+// Pins the single-source-of-truth invariant: everything SupportedFilters()
+// lists must be accepted by the renderer, so the two can never disagree.
+func TestRenderTreeFiltered_AgreesWithSupportedFilters(t *testing.T) {
+	for _, f := range SupportedFilters() {
+		if _, err := RenderTreeFiltered(&Inventory{ServerName: "lab"}, f); err != nil {
+			t.Errorf("SupportedFilters() lists %q but RenderTreeFiltered rejects it: %v", f, err)
+		}
+	}
+	if !IsSupportedFilter(SupportedFilters()[0]) {
+		t.Error("first supported filter is not accepted by IsSupportedFilter")
+	}
+}
+
+func TestUnsupportedFilterError(t *testing.T) {
+	err := UnsupportedFilterError("bogus")
+	if !strings.Contains(err.Error(), `"bogus"`) || !strings.Contains(err.Error(), "exposed") {
+		t.Errorf("unhelpful unsupported-filter error: %v", err)
+	}
+}
+
 func TestJSON_Roundtrip(t *testing.T) {
 	inv := &Inventory{
 		ServerName: "s1",

--- a/internal/inventory/render.go
+++ b/internal/inventory/render.go
@@ -74,7 +74,11 @@ func RenderTree(inv *Inventory) string {
 // filterRenderers is the single source of truth for supported filters.
 // Registering an entry here wires up validation, listing, dispatch, and the
 // error message everywhere, with no second list to drift out of sync.
+// Describe each filter's semantics on its entry: this map is the one place a
+// reader of the exported API can see what each value means.
 var filterRenderers = map[string]func(*Inventory) string{
+	// "exposed" shows only ports listening on all interfaces (0.0.0.0, ::, *);
+	// anything bound to a specific address is hidden.
 	"exposed": renderExposedPorts,
 }
 

--- a/internal/inventory/render.go
+++ b/internal/inventory/render.go
@@ -71,30 +71,42 @@ func RenderTree(inv *Inventory) string {
 	return b.String()
 }
 
-// RenderTreeFiltered renders a filtered view of the inventory.
-// Supported filters: "exposed" (only ports bound to public interfaces).
-func RenderTreeFiltered(inv *Inventory, filter string) (string, error) {
-	switch filter {
-	case "exposed":
-		return renderExposedPorts(inv), nil
-	default:
-		return "", fmt.Errorf("unsupported filter %q (supported: %s)", filter, strings.Join(SupportedFilters(), ", "))
-	}
+// filterRenderers is the single source of truth for supported filters.
+// Registering an entry here wires up validation, listing, dispatch, and the
+// error message everywhere, with no second list to drift out of sync.
+var filterRenderers = map[string]func(*Inventory) string{
+	"exposed": renderExposedPorts,
 }
 
-// SupportedFilters returns the filter values accepted by RenderTreeFiltered.
+// RenderTreeFiltered renders a filtered view of the inventory.
+func RenderTreeFiltered(inv *Inventory, filter string) (string, error) {
+	render, ok := filterRenderers[filter]
+	if !ok {
+		return "", UnsupportedFilterError(filter)
+	}
+	return render(inv), nil
+}
+
+// SupportedFilters returns the sorted filter values accepted by RenderTreeFiltered.
 func SupportedFilters() []string {
-	return []string{"exposed"}
+	names := make([]string, 0, len(filterRenderers))
+	for name := range filterRenderers {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // IsSupportedFilter reports whether filter is accepted by RenderTreeFiltered.
 func IsSupportedFilter(filter string) bool {
-	for _, f := range SupportedFilters() {
-		if f == filter {
-			return true
-		}
-	}
-	return false
+	_, ok := filterRenderers[filter]
+	return ok
+}
+
+// UnsupportedFilterError builds the one error message for an unknown filter,
+// shared by every caller so the wording cannot drift apart.
+func UnsupportedFilterError(filter string) error {
+	return fmt.Errorf("unsupported filter %q (supported: %s)", filter, strings.Join(SupportedFilters(), ", "))
 }
 
 // renderExposedPorts renders a compact view of the ports bound to public interfaces.


### PR DESCRIPTION
## What does this PR do?

Both follow-ups from reviewing #51, done together as one change:

**`inventory show` now accepts `--filter`.** The flag was registered on `scan` only
while `show`'s Short promises "same as scan". Both commands already share
`runInventoryScan`, so registration goes through a shared helper
(`addInventoryFilterFlag`) and the promise holds.

**One source of truth for supported filters.** The switch inside
`RenderTreeFiltered` and the `SupportedFilters()` slice were two lists that could
disagree — add a filter to the slice and forget the case, and the pre-check passes,
then the renderer returns `unsupported filter "listening" (supported: exposed,
listening)`, naming the value it just rejected as supported.

The two lists are gone. A single `filterRenderers` map keyed by filter name now
drives dispatch, validation, listing, and the error message:

- adding a filter is one map entry — everything else follows
- `SupportedFilters()` derives from the keys, sorted
- `IsSupportedFilter` is a map lookup
- the error string is built in exactly one place, new exported
  `UnsupportedFilterError(filter)`, used by both `cmd/inventory.go` and the renderer

The double validation itself stays: failing before collection is still the right
behavior — it just can't contradict itself anymore.

### Tests

- `TestRenderTreeFiltered_AgreesWithSupportedFilters` pins the invariant: everything
  `SupportedFilters()` lists must be accepted by the renderer, so drift can't return
- `TestNewInventoryShowCmdAcceptsFilter` — `show` parses `--filter exposed`
- `TestUnsupportedFilterError` — single error wording

README adds `homebutler inventory show --filter exposed` to the command block.

Closes #60 

## Checklist

- [x] `gofmt -w .` — code is formatted
- [x] `go build ./...` — builds without errors
- [x] `go test ./...` — all tests pass
- [x] Tests added for new functionality
- [x] README updated (if user-facing change)

