### PR TITLE
fix: the MCP Registry rejected the server description as too long

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.1](https://github.com/Higangssh/homebutler/compare/v0.21.0...v0.21.1) - 2026-08-23
+
+**Patch release to complete the MCP Registry listing.** v0.21.0 published its binaries, Homebrew tap and npm package, then failed on the last step of the release: the registry rejected a `server.json` description three characters over its 100-character limit. That step shipped in v0.21.0 itself, so the rejection means homebutler has never appeared in the registry at all.
+
+```bash
+npx -y homebutler@latest
+```
+
+### 🐛 Fixes
+
+- shorten the `server.json` description to 94 characters so the MCP Registry accepts it. Nothing else about v0.21.0 changes; the binaries, tap and npm package are identical
+
+### 🧪 Tests
+
+- assert in CI that the `server.json` description fits the registry limit, and that the server version and its npm package version agree. Both constraints were previously only enforced by the registry, at the end of a release that had already published everything else
+
 ## [0.21.0](https://github.com/Higangssh/homebutler/compare/v0.20.0...v0.21.0) - 2026-08-23
 
 **Three commands were confidently answering the wrong question.** `watch check` called systemd and pm2 targets clean without inspecting them, `report` counted fewer public ports than `doctor` did on the same scan, and a failed first connection blamed the host key rather than the reason it failed.

--- a/internal/mcp/serverjson_test.go
+++ b/internal/mcp/serverjson_test.go
@@ -1,0 +1,64 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// serverManifest mirrors the fields of server.json that the MCP Registry
+// validates. The publish step rewrites the two version fields from the tag,
+// so those are checked for shape rather than for a particular value.
+type serverManifest struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Version     string `json:"version"`
+	Packages    []struct {
+		RegistryType string `json:"registryType"`
+		Identifier   string `json:"identifier"`
+		Version      string `json:"version"`
+	} `json:"packages"`
+}
+
+func loadServerManifest(t *testing.T) serverManifest {
+	t.Helper()
+	path := filepath.Join("..", "..", "server.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	var m serverManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+	return m
+}
+
+// The registry rejects a description over 100 characters with a 422, and that
+// happens in the last step of the release, after the binaries, the Homebrew
+// tap and the npm package have already been published. v0.21.0 shipped with a
+// 103-character description and never reached the registry. Fail here instead.
+func TestServerJSONDescriptionWithinRegistryLimit(t *testing.T) {
+	const maxDescription = 100
+
+	m := loadServerManifest(t)
+	if got := len(m.Description); got > maxDescription {
+		t.Errorf("server.json description is %d characters, registry rejects over %d:\n%s",
+			got, maxDescription, m.Description)
+	}
+}
+
+// The registry rejects a server version whose package version does not exist
+// on npm, so the two have to move together. The publish step sets both from
+// the tag; this catches a hand-edit that touches only one.
+func TestServerJSONVersionsAgree(t *testing.T) {
+	m := loadServerManifest(t)
+	if len(m.Packages) == 0 {
+		t.Fatal("server.json declares no packages")
+	}
+	if m.Version != m.Packages[0].Version {
+		t.Errorf("server.json version %q does not match packages[0].version %q",
+			m.Version, m.Packages[0].Version)
+	}
+}

--- a/internal/mcp/serverjson_test.go
+++ b/internal/mcp/serverjson_test.go
@@ -39,6 +39,12 @@ func loadServerManifest(t *testing.T) serverManifest {
 // happens in the last step of the release, after the binaries, the Homebrew
 // tap and the npm package have already been published. v0.21.0 shipped with a
 // 103-character description and never reached the registry. Fail here instead.
+//
+// The limit is not ours: it is ServerDetail.description.maxLength in the
+// schema server.json already names in its $schema field, generated from the
+// registry's own openapi.yaml. Hardcoded rather than fetched so the test does
+// not need the network; check the schema if a future release is rejected for
+// a field this does not cover.
 func TestServerJSONDescriptionWithinRegistryLimit(t *testing.T) {
 	const maxDescription = 100
 

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.higangssh/homebutler",
-  "description": "Inspect and manage a homelab over MCP - status, Docker, ports, backups - without granting shell access.",
+  "description": "Inspect and manage a homelab over MCP - status, Docker, ports, backups - without shell access.",
   "repository": {
     "url": "https://github.com/Higangssh/homebutler",
     "source": "github"
   },
-  "version": "0.21.0",
+  "version": "0.21.1",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "homebutler",
-      "version": "0.21.0",
+      "version": "0.21.1",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
v0.21.0 published its binaries, Homebrew tap and npm package, then failed on the last step: the MCP Registry returned a 422 because `server.json` carried a 103-character description against a 100-character limit. Since the publish step shipped in v0.21.0 itself, that rejection means homebutler has never appeared in the registry.

Dropping "granting" brings it to 94 and keeps the sentence intact.

The more useful part is the test. This constraint was only enforced by the registry, in the final step of a release, after everything else had already gone out — the worst place to learn about it, because the release cannot be retried without a new version. It now fails in the `Test` check on a PR. The same test asserts the server version matches its npm package version, which the registry also enforces and which is easy to break by hand-editing one of the two.

Both version fields are bumped to 0.21.1 for accuracy. The publish step overwrites them from the tag, so the checked-in values are documentation rather than input.

This goes out as v0.21.1. The binaries, tap and npm package will be identical to v0.21.0.
