### PR TITLE
fix: the registry namespace did not match the OIDC grant's casing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,23 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.21.2](https://github.com/Higangssh/homebutler/compare/v0.21.1...v0.21.2) - 2026-08-23
+
+**Second attempt at the MCP Registry listing.** v0.21.1 cleared the description limit and was then rejected with a 403: the registry grants publish rights to `io.github.<login>/*` from the GitHub OIDC token and keeps the login's casing, while `server.json` claimed `io.github.higangssh/homebutler` against a grant for `io.github.Higangssh/*`.
+
+```bash
+npx -y homebutler@latest
+```
+
+### 🐛 Fixes
+
+- declare the server namespace with the repository owner's actual casing, in both `server.json` and the `mcpName` the npm package carries. The registry reads `mcpName` to confirm ownership of the package, so correcting one without the other would have traded the 403 for a different rejection at the same step. Nothing else about v0.21.1 changes
+
+### 🧪 Tests
+
+- derive the expected namespace from `repository.url` and assert `server.json` matches it, casing included
+- assert the npm package's `mcpName` and the server name agree
+
 ## [0.21.1](https://github.com/Higangssh/homebutler/compare/v0.21.0...v0.21.1) - 2026-08-23
 
 **Patch release to complete the MCP Registry listing.** v0.21.0 published its binaries, Homebrew tap and npm package, then failed on the last step of the release: the registry rejected a `server.json` description three characters over its 100-character limit. That step shipped in v0.21.0 itself, so the rejection means homebutler has never appeared in the registry at all.

--- a/internal/mcp/serverjson_test.go
+++ b/internal/mcp/serverjson_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -14,11 +15,34 @@ type serverManifest struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
 	Version     string `json:"version"`
-	Packages    []struct {
+	Repository  struct {
+		URL string `json:"url"`
+	} `json:"repository"`
+	Packages []struct {
 		RegistryType string `json:"registryType"`
 		Identifier   string `json:"identifier"`
 		Version      string `json:"version"`
 	} `json:"packages"`
+}
+
+// npmManifest is the part of npm/package.json the registry reads. It proves
+// ownership of the npm package by matching mcpName against the server name.
+type npmManifest struct {
+	MCPName string `json:"mcpName"`
+}
+
+func loadNPMManifest(t *testing.T) npmManifest {
+	t.Helper()
+	path := filepath.Join("..", "..", "npm", "package.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading %s: %v", path, err)
+	}
+	var m npmManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		t.Fatalf("parsing %s: %v", path, err)
+	}
+	return m
 }
 
 func loadServerManifest(t *testing.T) serverManifest {
@@ -66,5 +90,45 @@ func TestServerJSONVersionsAgree(t *testing.T) {
 	if m.Version != m.Packages[0].Version {
 		t.Errorf("server.json version %q does not match packages[0].version %q",
 			m.Version, m.Packages[0].Version)
+	}
+}
+
+// The registry grants publish rights to io.github.<login>/* from the GitHub
+// OIDC token, and the login keeps its original casing. v0.21.1 declared
+// io.github.higangssh/homebutler against a grant for io.github.Higangssh/*
+// and was rejected with a 403, after the binaries and the npm package had
+// already been published. The owner in repository.url is the same login, so
+// the expected namespace can be derived rather than repeated.
+func TestServerJSONNamespaceMatchesRepositoryOwner(t *testing.T) {
+	m := loadServerManifest(t)
+
+	const prefix = "https://github.com/"
+	if !strings.HasPrefix(m.Repository.URL, prefix) {
+		t.Fatalf("repository.url %q is not a github.com URL", m.Repository.URL)
+	}
+	parts := strings.Split(strings.TrimSuffix(strings.TrimPrefix(m.Repository.URL, prefix), "/"), "/")
+	if len(parts) != 2 {
+		t.Fatalf("cannot read owner and repo from repository.url %q", m.Repository.URL)
+	}
+
+	want := "io.github." + parts[0] + "/" + parts[1]
+	if m.Name != want {
+		t.Errorf("server.json name is %q, but repository.url implies %q.\n"+
+			"The registry matches this against the OIDC grant io.github.<login>/*, case included.",
+			m.Name, want)
+	}
+}
+
+// The registry confirms ownership of the npm package by reading mcpName from
+// the published package and matching it against the server name. Correcting
+// one without the other trades a 403 for a different rejection at the same
+// point in the release.
+func TestNPMMCPNameMatchesServerName(t *testing.T) {
+	server := loadServerManifest(t)
+	npm := loadNPMManifest(t)
+
+	if npm.MCPName != server.Name {
+		t.Errorf("npm/package.json mcpName is %q, server.json name is %q; the registry requires both to agree",
+			npm.MCPName, server.Name)
 	}
 }

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "homebutler",
   "version": "0.0.0",
-  "mcpName": "io.github.higangssh/homebutler",
+  "mcpName": "io.github.Higangssh/homebutler",
   "description": "Homelab management CLI + MCP server — manage servers, Docker, ports, alerts via AI",
   "keywords": [
     "mcp",

--- a/server.json
+++ b/server.json
@@ -1,17 +1,17 @@
 {
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
-  "name": "io.github.higangssh/homebutler",
+  "name": "io.github.Higangssh/homebutler",
   "description": "Inspect and manage a homelab over MCP - status, Docker, ports, backups - without shell access.",
   "repository": {
     "url": "https://github.com/Higangssh/homebutler",
     "source": "github"
   },
-  "version": "0.21.1",
+  "version": "0.21.2",
   "packages": [
     {
       "registryType": "npm",
       "identifier": "homebutler",
-      "version": "0.21.1",
+      "version": "0.21.2",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
v0.21.1 cleared the description limit and was rejected with a 403 instead:

```
You have permission to publish: io.github.Higangssh/*
Attempting to publish: io.github.higangssh/homebutler
```

The registry derives the grant from the GitHub OIDC token and keeps the login's casing. `server.json` had the namespace lowercased.

`npm/package.json` carried the same lowercased value in `mcpName`, which the registry reads to confirm ownership of the npm package. Fixing only `server.json` would have traded the 403 for a different rejection at the same step, and cost another tag to discover.

The reason two releases were spent on this is that nothing in the repository read `server.json`. Grepping for it turns up one reference: the `jq` line in `release.yml` that overwrites the version fields. Not a check — the only validation was the registry itself, in the last step of the release, after the binaries, the tap and the npm package had already gone out. The `$schema` line looks like validation but no build step dereferences it.

Four assertions now run in the `Test` check: the description fits the registry's documented limit, the two version fields agree, the namespace matches the owner in `repository.url` casing included, and `mcpName` matches the server name. Each was confirmed to fail against the value that actually caused a rejection before being committed.

This goes out as v0.21.2. Everything else is identical to v0.21.1.
