### PR TITLE
ci: validate the registry manifest before anything is published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,45 @@ jobs:
       - name: Run tests
         run: go test ./...
 
+      # Everything the registry can reject runs before anything is published.
+      # The publish itself has to stay at the end - the registry reads mcpName
+      # back out of the npm package - so a rejection there costs a tag and
+      # cannot be retried. v0.21.0 and v0.21.1 were both spent that way.
+      - name: Validate the registry manifest
+        run: |
+          TAG=${GITHUB_REF#refs/tags/v}
+
+          # The registry grants io.github.<login>/* from the OIDC token and
+          # keeps the login's casing, and it matches the npm package's mcpName
+          # against the server name. Checked against the real owner rather
+          # than anything the repository declares about itself.
+          WANT="io.github.${GITHUB_REPOSITORY%%/*}/${GITHUB_REPOSITORY##*/}"
+          for file_field in "server.json:.name" "npm/package.json:.mcpName"; do
+            file=${file_field%%:*}
+            got=$(jq -r "${file_field##*:}" "$file")
+            if [ "$got" != "$WANT" ]; then
+              echo "::error file=$file::expected $WANT, found $got"
+              exit 1
+            fi
+          done
+
+          # Staged outside the checkout: GoReleaser refuses to run on a dirty
+          # tree, so nothing here may leave a modified or untracked file behind.
+          # Publishing later from this same directory also means the bytes that
+          # were validated are the bytes that go to the registry.
+          mkdir -p "$RUNNER_TEMP/registry"
+
+          # Both fields have to carry the tag: the registry rejects a server
+          # version whose package version does not exist on npm.
+          jq --arg v "$TAG" '.version = $v | .packages[0].version = $v' \
+            server.json > "$RUNNER_TEMP/registry/server.json"
+
+          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" \
+            | tar xz -C "$RUNNER_TEMP/registry" mcp-publisher
+
+          cd "$RUNNER_TEMP/registry"
+          ./mcp-publisher validate
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -136,17 +175,11 @@ jobs:
 
       # The registry stores metadata only. It verifies ownership by reading the
       # mcpName field back out of the published npm package, so this cannot run
-      # before the npm publish above succeeds.
+      # before the npm publish above succeeds. The manifest was stamped and
+      # validated before anything was published; this publishes that same copy.
       - name: Publish to MCP Registry
         if: steps.npm.outputs.published == 'true'
         run: |
-          TAG=${GITHUB_REF#refs/tags/v}
-
-          # Both fields have to carry the tag: the registry rejects a server
-          # version whose package version does not exist on npm.
-          jq --arg v "$TAG" '.version = $v | .packages[0].version = $v' \
-            server.json > server.tmp && mv server.tmp server.json
-
-          curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_$(uname -s | tr '[:upper:]' '[:lower:]')_$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
+          cd "$RUNNER_TEMP/registry"
           ./mcp-publisher login github-oidc
           ./mcp-publisher publish


### PR DESCRIPTION
v0.21.0 and v0.21.1 were both spent discovering registry rejections one at a time, because the only thing that ever read `server.json` was the registry itself, in the last step of the release — after the binaries, the Homebrew tap and the npm package had already gone out. Each rejection cost a tag that could not be retried.

The registry publish genuinely has to stay last: it confirms ownership by reading `mcpName` back out of the published npm package. What does not have to stay last is the validation. `mcp-publisher validate` checks `server.json` against the registry's schema without publishing and without authenticating, so it now runs before GoReleaser. The namespace check covers what `validate` cannot: the 403 was an authorization decision, not a schema error, so the owner is read from `GITHUB_REPOSITORY` and compared against both `server.json` and `npm/package.json`.

Validation runs in `$RUNNER_TEMP` rather than the checkout. GoReleaser refuses to run on a dirty tree, and stamping the version in place — which is what the publish step used to do, safely, because it ran afterwards — would now leave a modified file and an untracked binary in front of it. Publishing later from that same directory also means the bytes that were validated are the bytes that reach the registry, which was not previously guaranteed.

This cannot be exercised until the next tag, since the workflow only runs on `v*`. The failure mode is the point though: if this step is wrong, the release now stops before anything is published, which is the outcome the last two releases did not get.

The same four invariants are asserted in `internal/mcp/serverjson_test.go` on every PR. Keeping both is deliberate — the test catches an edit at review time, the workflow catches a release cut from a branch where the test was skipped or the schema moved underneath us.
