### PR TITLE
refactor: let the capability registry decide what a tool can be pointed at

### DIFF
--- a/internal/mcp/capabilities.go
+++ b/internal/mcp/capabilities.go
@@ -8,10 +8,42 @@ const (
 	riskDestructive capabilityRisk = "destructive"
 )
 
+// targetKind is what a tool can be pointed at. A bool could only ask "is this a
+// named SSH server from servers:", which is the only kind of target homebutler
+// has had so far. An API-backed target has no agent on the far side and a
+// different way of being addressed, so the question has to be open-ended before
+// 1.0 freezes the answer.
+type targetKind string
+
+const (
+	targetLocal  targetKind = "local"  // this machine; no target argument
+	targetServer targetKind = "server" // a named SSH server from servers:
+)
+
 type capability struct {
-	tool          toolDef
-	risk          capabilityRisk
-	remoteSupport bool
+	tool    toolDef
+	risk    capabilityRisk
+	targets []targetKind
+}
+
+// supports reports whether the tool can be pointed at kind.
+func (c capability) supports(kind targetKind) bool {
+	for _, t := range c.targets {
+		if t == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// capabilityFor returns the registry entry for a tool name.
+func capabilityFor(name string) (capability, bool) {
+	for _, c := range capabilityRegistry {
+		if c.tool.Name == name {
+			return c, true
+		}
+	}
+	return capability{}, false
 }
 
 func toolDefinitions() []toolDef {
@@ -24,8 +56,8 @@ func toolDefinitions() []toolDef {
 
 var capabilityRegistry = []capability{
 	{
-		risk:          riskRead,
-		remoteSupport: true,
+		risk:    riskRead,
+		targets: []targetKind{targetLocal, targetServer},
 		tool: toolDef{
 			Name:        "system_status",
 			Description: "Get system status including CPU, memory, disk usage, and uptime",
@@ -38,8 +70,8 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
-		risk:          riskRead,
-		remoteSupport: true,
+		risk:    riskRead,
+		targets: []targetKind{targetLocal, targetServer},
 		tool: toolDef{
 			Name:        "docker_list",
 			Description: "List Docker containers with their status, image, and ports",
@@ -52,8 +84,8 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
-		risk:          riskWrite,
-		remoteSupport: true,
+		risk:    riskWrite,
+		targets: []targetKind{targetLocal, targetServer},
 		tool: toolDef{
 			Name:        "docker_restart",
 			Description: "Restart a Docker container by name",
@@ -68,8 +100,8 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
-		risk:          riskDestructive,
-		remoteSupport: true,
+		risk:    riskDestructive,
+		targets: []targetKind{targetLocal, targetServer},
 		tool: toolDef{
 			Name:        "docker_stop",
 			Description: "Stop a Docker container by name",
@@ -84,8 +116,8 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
-		risk:          riskRead,
-		remoteSupport: true,
+		risk:    riskRead,
+		targets: []targetKind{targetLocal, targetServer},
 		tool: toolDef{
 			Name:        "docker_logs",
 			Description: "Get logs from a Docker container",
@@ -101,8 +133,8 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
-		risk:          riskRead,
-		remoteSupport: true,
+		risk:    riskRead,
+		targets: []targetKind{targetLocal, targetServer},
 		tool: toolDef{
 			Name:        "docker_stats",
 			Description: "Get resource usage statistics (CPU, memory, network, block I/O) for all running Docker containers",
@@ -115,8 +147,8 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
-		risk:          riskWrite,
-		remoteSupport: false,
+		risk:    riskWrite,
+		targets: []targetKind{targetLocal},
 		tool: toolDef{
 			Name:        "wake",
 			Description: "Send a Wake-on-LAN magic packet to wake a machine",
@@ -131,8 +163,8 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
-		risk:          riskRead,
-		remoteSupport: true,
+		risk:    riskRead,
+		targets: []targetKind{targetLocal, targetServer},
 		tool: toolDef{
 			Name:        "open_ports",
 			Description: "List open network ports with associated process information",
@@ -145,8 +177,8 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
-		risk:          riskRead,
-		remoteSupport: false,
+		risk:    riskRead,
+		targets: []targetKind{targetLocal},
 		tool: toolDef{
 			Name:        "network_scan",
 			Description: "Scan the local network to discover devices (IP, MAC, hostname)",
@@ -156,8 +188,8 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
-		risk:          riskRead,
-		remoteSupport: true,
+		risk:    riskRead,
+		targets: []targetKind{targetLocal, targetServer},
 		tool: toolDef{
 			Name:        "alerts",
 			Description: "Check resource alerts for CPU, memory, and disk usage against configured thresholds",
@@ -170,8 +202,8 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
-		risk:          riskRead,
-		remoteSupport: true,
+		risk:    riskRead,
+		targets: []targetKind{targetLocal, targetServer},
 		tool: toolDef{
 			Name:        "inventory_scan",
 			Description: "Collect server inventory/topology including system status, Docker containers, app ports, and system ports",
@@ -184,8 +216,8 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
-		risk:          riskRead,
-		remoteSupport: true,
+		risk:    riskRead,
+		targets: []targetKind{targetLocal, targetServer},
 		tool: toolDef{
 			Name:        "inventory_export",
 			Description: "Export server inventory/topology as a Mermaid diagram locally, or JSON locally/remotely",
@@ -199,8 +231,8 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
-		risk:          riskWrite,
-		remoteSupport: true,
+		risk:    riskWrite,
+		targets: []targetKind{targetLocal, targetServer},
 		tool: toolDef{
 			Name:        "report",
 			Description: "Generate a butler-style health report with snapshot comparison, warnings, notable changes, and suggested actions",
@@ -215,8 +247,8 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
-		risk:          riskRead,
-		remoteSupport: true,
+		risk:    riskRead,
+		targets: []targetKind{targetLocal, targetServer},
 		tool: toolDef{
 			Name:        "doctor",
 			Description: "Run a read-only diagnosis for resource pressure, stopped containers, public ports, backup hygiene, notifications, and report baseline readiness",
@@ -233,8 +265,8 @@ var capabilityRegistry = []capability{
 		// Write rather than read: CheckTargets records the new container state
 		// and saves any incident it detects, so a caller cannot treat this as a
 		// free query the way system_status is.
-		risk:          riskWrite,
-		remoteSupport: true,
+		risk:    riskWrite,
+		targets: []targetKind{targetLocal, targetServer},
 		tool: toolDef{
 			Name:        "watch_check",
 			Description: "Run a one-shot restart check on watched targets and report restarts detected since the last check. Only docker targets can be inspected this way; systemd and pm2 targets are reported as skipped rather than assumed healthy",
@@ -247,8 +279,8 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
-		risk:          riskWrite,
-		remoteSupport: true,
+		risk:    riskWrite,
+		targets: []targetKind{targetLocal, targetServer},
 		tool: toolDef{
 			Name:        "backup_create",
 			Description: "Create a Docker compose backup archive for all services or one service",
@@ -263,8 +295,8 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
-		risk:          riskRead,
-		remoteSupport: true,
+		risk:    riskRead,
+		targets: []targetKind{targetLocal, targetServer},
 		tool: toolDef{
 			Name:        "backup_list",
 			Description: "List existing backup archives in the configured backup directory",
@@ -277,8 +309,8 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
-		risk:          riskWrite,
-		remoteSupport: true,
+		risk:    riskWrite,
+		targets: []targetKind{targetLocal, targetServer},
 		tool: toolDef{
 			Name:        "backup_drill",
 			Description: "Verify a backup by booting an app in an isolated Docker environment and checking that it responds",
@@ -294,8 +326,8 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
-		risk:          riskDestructive,
-		remoteSupport: true,
+		risk:    riskDestructive,
+		targets: []targetKind{targetLocal, targetServer},
 		tool: toolDef{
 			Name:        "backup_restore",
 			Description: "Restore Docker volumes from a backup archive. Destructive: confirm intent before calling.",
@@ -311,8 +343,8 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
-		risk:          riskRead,
-		remoteSupport: false,
+		risk:    riskRead,
+		targets: []targetKind{targetLocal},
 		tool: toolDef{
 			Name:        "install_list",
 			Description: "List available self-hosted apps that can be installed",
@@ -322,8 +354,8 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
-		risk:          riskWrite,
-		remoteSupport: false,
+		risk:    riskWrite,
+		targets: []targetKind{targetLocal},
 		tool: toolDef{
 			Name:        "install_app",
 			Description: "Install a self-hosted app via docker compose. Pre-checks docker, ports, and duplicates automatically.",
@@ -338,8 +370,8 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
-		risk:          riskRead,
-		remoteSupport: false,
+		risk:    riskRead,
+		targets: []targetKind{targetLocal},
 		tool: toolDef{
 			Name:        "install_status",
 			Description: "Check the status of an installed app",
@@ -353,8 +385,8 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
-		risk:          riskWrite,
-		remoteSupport: false,
+		risk:    riskWrite,
+		targets: []targetKind{targetLocal},
 		tool: toolDef{
 			Name:        "install_uninstall",
 			Description: "Stop an installed app and remove its containers. Data is preserved.",
@@ -368,8 +400,8 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
-		risk:          riskDestructive,
-		remoteSupport: false,
+		risk:    riskDestructive,
+		targets: []targetKind{targetLocal},
 		tool: toolDef{
 			Name:        "install_purge",
 			Description: "Stop an installed app and delete all data including containers, config, and volumes.",

--- a/internal/mcp/demo.go
+++ b/internal/mcp/demo.go
@@ -1,6 +1,10 @@
 package mcp
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/Higangssh/homebutler/internal/install"
+)
 
 func (s *Server) executeDemoTool(name string, args map[string]any) (any, error) {
 	server := stringArg(args, "server")
@@ -10,6 +14,8 @@ func (s *Server) executeDemoTool(name string, args map[string]any) (any, error) 
 		return demoStatus(server), nil
 	case "docker_list":
 		return demoDocker(server), nil
+	case "docker_stats":
+		return demoDockerStats(server), nil
 	case "docker_restart":
 		cname, ok := requireString(args, "name")
 		if !ok {
@@ -120,8 +126,77 @@ func (s *Server) executeDemoTool(name string, args map[string]any) (any, error) 
 			return nil, fmt.Errorf("missing required parameter: archive")
 		}
 		return map[string]any{"archive": archive, "services": []string{"demo"}, "volumes": 1}, nil
+	case "install_list":
+		// The catalogue is a static map compiled into the binary, so demo mode
+		// can answer this truthfully instead of inventing apps that would drift
+		// away from the real list.
+		return install.List(), nil
+
+	case "install_status":
+		app := stringArg(args, "app")
+		if _, ok := install.Registry[app]; !ok {
+			return nil, fmt.Errorf("unknown app %q, use install_list to see available apps", app)
+		}
+		return map[string]any{"app": app, "state": "running"}, nil
+
+	case "install_app":
+		app := stringArg(args, "app")
+		a, ok := install.Registry[app]
+		if !ok {
+			return nil, fmt.Errorf("unknown app %q, use install_list to see available apps", app)
+		}
+		port := a.DefaultPort
+		if p := stringArg(args, "port"); p != "" {
+			port = p
+		}
+		return map[string]any{
+			"status": "installed",
+			"app":    a.Name,
+			"port":   port,
+			"path":   "/home/demo/.homebutler/apps/" + a.Name,
+			"state":  "running",
+		}, nil
+
+	case "install_uninstall":
+		app := stringArg(args, "app")
+		if _, ok := install.Registry[app]; !ok {
+			return nil, fmt.Errorf("unknown app %q, use install_list to see available apps", app)
+		}
+		return map[string]any{"status": "uninstalled", "app": app, "data_preserved": true}, nil
+
+	case "install_purge":
+		app := stringArg(args, "app")
+		if _, ok := install.Registry[app]; !ok {
+			return nil, fmt.Errorf("unknown app %q, use install_list to see available apps", app)
+		}
+		return map[string]any{"status": "purged", "app": app}, nil
+
 	default:
 		return nil, fmt.Errorf("unknown tool: %s", name)
+	}
+}
+
+// demoDockerStats mirrors demoDocker's containers so the two tools do not
+// describe different machines.
+func demoDockerStats(server string) []map[string]any {
+	switch server {
+	case "nas-box":
+		return []map[string]any{
+			{"id": "aa11bb22cc33", "name": "samba", "cpu_percent": "0.42%", "mem_usage": "88MiB / 8GiB", "mem_percent": "1.07%", "net_io": "1.2GB / 340MB", "block_io": "820MB / 4.1GB", "pids": "12"},
+			{"id": "dd44ee55ff66", "name": "plex", "cpu_percent": "18.30%", "mem_usage": "1.4GiB / 8GiB", "mem_percent": "17.50%", "net_io": "44GB / 2.1GB", "block_io": "12GB / 900MB", "pids": "48"},
+		}
+	case "raspberry-pi":
+		return []map[string]any{
+			{"id": "pi11pi22pi33", "name": "pihole", "cpu_percent": "1.10%", "mem_usage": "76MiB / 1GiB", "mem_percent": "7.42%", "net_io": "3.4GB / 2.9GB", "block_io": "120MB / 640MB", "pids": "9"},
+		}
+	default:
+		return []map[string]any{
+			{"id": "a1b2c3d4e5f6", "name": "nginx", "cpu_percent": "0.15%", "mem_usage": "24MiB / 16GiB", "mem_percent": "0.15%", "net_io": "890MB / 1.1GB", "block_io": "12MB / 8MB", "pids": "5"},
+			{"id": "b2c3d4e5f6a1", "name": "postgres", "cpu_percent": "2.80%", "mem_usage": "412MiB / 16GiB", "mem_percent": "2.51%", "net_io": "220MB / 180MB", "block_io": "3.4GB / 9.8GB", "pids": "21"},
+			{"id": "c3d4e5f6a1b2", "name": "redis", "cpu_percent": "0.60%", "mem_usage": "38MiB / 16GiB", "mem_percent": "0.23%", "net_io": "140MB / 96MB", "block_io": "44MB / 12MB", "pids": "6"},
+			{"id": "d4e5f6a1b2c3", "name": "grafana", "cpu_percent": "1.90%", "mem_usage": "186MiB / 16GiB", "mem_percent": "1.13%", "net_io": "310MB / 420MB", "block_io": "88MB / 210MB", "pids": "14"},
+			{"id": "e5f6a1b2c3d4", "name": "prometheus", "cpu_percent": "4.20%", "mem_usage": "740MiB / 16GiB", "mem_percent": "4.51%", "net_io": "1.8GB / 640MB", "block_io": "5.2GB / 14GB", "pids": "17"},
+		}
 	}
 }
 

--- a/internal/mcp/demo_test.go
+++ b/internal/mcp/demo_test.go
@@ -52,3 +52,43 @@ func TestDemoLogsFallback(t *testing.T) {
 		t.Fatal("expected fallback logs message")
 	}
 }
+
+// Demo mode advertises the same tools/list as a real server, so a client that
+// reads that list and calls one of them must not be told the tool does not
+// exist. Six tools were advertised without a demo arm before this test:
+// docker_stats and the five install_* tools.
+//
+// Arguments are filled from the schema's properties rather than only its
+// required list, because a tool can need an argument the list cannot express:
+// backup_drill takes app or all=true, so neither is Required and calling it
+// with nothing fails.
+func TestEveryAdvertisedToolHasADemoImplementation(t *testing.T) {
+	s := NewServer(&config.Config{}, "dev", true)
+
+	sample := map[string]any{
+		"name":    "nginx",
+		"app":     "uptime-kuma",
+		"target":  "aa:bb:cc:dd:ee:ff",
+		"archive": "demo.tar.gz",
+	}
+
+	for _, c := range capabilityRegistry {
+		args := map[string]any{}
+		for prop := range c.tool.InputSchema.Properties {
+			if v, ok := sample[prop]; ok {
+				args[prop] = v
+			}
+		}
+		// Every required argument has to be covered, or the tool is not really
+		// being exercised.
+		for _, req := range c.tool.InputSchema.Required {
+			if _, ok := args[req]; !ok {
+				t.Fatalf("tool %q requires argument %q; add a sample value to this test", c.tool.Name, req)
+			}
+		}
+
+		if _, err := s.executeDemoTool(c.tool.Name, args); err != nil {
+			t.Errorf("demo mode advertises %q but calling it fails: %v", c.tool.Name, err)
+		}
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -211,6 +211,17 @@ func (s *Server) executeTool(name string, args map[string]any) (any, error) {
 			return nil, fmt.Errorf("server %q not found in config", server)
 		}
 		if !srv.Local {
+			// The registry decides what a tool can be pointed at. Before this,
+			// the decision lived in executeRemote's switch default, so the
+			// registry described a behaviour it did not control and the two
+			// could disagree without any test noticing.
+			cap, ok := capabilityFor(name)
+			if !ok {
+				return nil, fmt.Errorf("unknown tool: %s", name)
+			}
+			if !cap.supports(targetServer) {
+				return nil, fmt.Errorf("tool %q cannot be pointed at a server", name)
+			}
 			return s.executeRemote(srv, name, args)
 		}
 	}
@@ -485,7 +496,10 @@ func (s *Server) executeRemote(srv *config.ServerConfig, tool string, args map[s
 			remoteArgs = append(remoteArgs, "--service", service)
 		}
 	default:
-		return nil, fmt.Errorf("tool %q not supported for remote execution", tool)
+		// Unreachable: executeTool checks the registry before routing here.
+		// Kept so a tool added to the registry with targetServer but no argv
+		// mapping fails loudly instead of running an empty remote command.
+		return nil, fmt.Errorf("tool %q has no remote command mapping", tool)
 	}
 
 	out, err := remote.Run(srv, remoteArgs...)

--- a/internal/mcp/targets_test.go
+++ b/internal/mcp/targets_test.go
@@ -1,0 +1,116 @@
+package mcp
+
+import (
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/Higangssh/homebutler/internal/config"
+)
+
+// Every registry entry declares at least targetLocal. A tool that can be
+// pointed nowhere is registered but unreachable, which is a mistake rather than
+// a configuration.
+func TestEveryCapabilityDeclaresATarget(t *testing.T) {
+	for _, c := range capabilityRegistry {
+		if len(c.targets) == 0 {
+			t.Errorf("tool %q declares no targets", c.tool.Name)
+			continue
+		}
+		if !c.supports(targetLocal) {
+			t.Errorf("tool %q does not support targetLocal; every tool runs on this machine", c.tool.Name)
+		}
+		for _, k := range c.targets {
+			switch k {
+			case targetLocal, targetServer:
+			default:
+				t.Errorf("tool %q declares unknown target %q", c.tool.Name, k)
+			}
+		}
+	}
+}
+
+// The registry now gates remote routing, so what it claims and what
+// executeRemote can actually build have to be the same set. They agreed by
+// coincidence before this change; this is what makes that structural.
+//
+// Reading the source rather than calling executeRemote keeps the check free of
+// an SSH connection: the argv mapping is a compile-time switch, so its cases
+// are the complete list of tools that have a remote command.
+func TestRegistryTargetsMatchRemoteArgvMapping(t *testing.T) {
+	src, err := os.ReadFile("server.go")
+	if err != nil {
+		t.Fatalf("reading server.go: %v", err)
+	}
+
+	fn := regexp.MustCompile(`(?s)func \(s \*Server\) executeRemote\(.*?\n\tout, err := remote\.Run`)
+	body := fn.Find(src)
+	if body == nil {
+		t.Fatal("could not locate the executeRemote argv switch; update this test if it moved")
+	}
+
+	mapped := map[string]bool{}
+	for _, m := range regexp.MustCompile(`case "([a-z_]+)":`).FindAllSubmatch(body, -1) {
+		mapped[string(m[1])] = true
+	}
+	if len(mapped) == 0 {
+		t.Fatal("found no case arms in executeRemote; the regex above needs updating")
+	}
+
+	for _, c := range capabilityRegistry {
+		claims := c.supports(targetServer)
+		switch {
+		case claims && !mapped[c.tool.Name]:
+			t.Errorf("%q declares targetServer but executeRemote has no argv mapping for it, so pointing it at a server fails after the gate lets it through", c.tool.Name)
+		case !claims && mapped[c.tool.Name]:
+			t.Errorf("%q has an argv mapping in executeRemote but does not declare targetServer, so the gate now rejects it and the mapping is dead", c.tool.Name)
+		}
+	}
+
+	for name := range mapped {
+		if _, ok := capabilityFor(name); !ok {
+			t.Errorf("executeRemote maps %q, which is not in the capability registry", name)
+		}
+	}
+}
+
+func TestCapabilityForUnknownTool(t *testing.T) {
+	if _, ok := capabilityFor("no_such_tool"); ok {
+		t.Error("capabilityFor returned a capability for an unregistered tool")
+	}
+}
+
+// The gate has to reject before routing, not after. network_scan reads the
+// local network and has no remote path; pointing it at a server must fail on
+// the registry rather than travelling to executeRemote and falling through the
+// argv switch, which is where the decision used to live.
+func TestPointingALocalOnlyToolAtAServerIsRejected(t *testing.T) {
+	cfg := &config.Config{
+		Servers: []config.ServerConfig{
+			{Name: "pve1", Host: "192.0.2.1", Local: false},
+		},
+	}
+	s := NewServer(cfg, "test")
+
+	_, err := s.executeTool("network_scan", map[string]any{"server": "pve1"})
+	if err == nil {
+		t.Fatal("expected network_scan pointed at a remote server to be rejected")
+	}
+	if !strings.Contains(err.Error(), "cannot be pointed at a server") {
+		t.Errorf("rejection should name the reason, got: %v", err)
+	}
+
+	// The rejection must come from the registry, not from a failed SSH attempt.
+	if strings.Contains(err.Error(), "no remote command mapping") {
+		t.Error("rejected inside executeRemote; the gate did not run first")
+	}
+}
+
+func TestUnknownServerStillReportedBeforeTheGate(t *testing.T) {
+	s := NewServer(&config.Config{}, "test")
+	_, err := s.executeTool("docker_list", map[string]any{"server": "nope"})
+	if err == nil || !strings.Contains(err.Error(), "not found in config") {
+		t.Errorf("an unknown server should be reported as such, got: %v", err)
+	}
+}

--- a/internal/mcp/watch_check_test.go
+++ b/internal/mcp/watch_check_test.go
@@ -20,7 +20,7 @@ func TestWatchCheckCapabilityIsWriteAndRemoteCapable(t *testing.T) {
 		if c.risk != riskWrite {
 			t.Errorf("watch_check risk = %q, want %q", c.risk, riskWrite)
 		}
-		if !c.remoteSupport {
+		if !c.supports(targetServer) {
 			t.Error("watch_check should be routable to a remote server")
 		}
 		if _, ok := c.tool.InputSchema.Properties["server"]; !ok {


### PR DESCRIPTION
`capability.remoteSupport` read as the gate on whether an MCP tool could run against a remote server, and it was not one. `toolDefinitions` discards it, `executeTool` routed on the `server` argument alone, and the real decision lived in the `default` arm of `executeRemote`'s argv switch. The registry documented a behaviour it did not control.

Worth stating plainly: **they agree today.** Seventeen entries claim remote support and `executeRemote` has seventeen case arms, with no mismatch in either direction — I checked before changing anything. Nothing is broken for users. This makes the agreement structural rather than coincidental, before 1.0 freezes the surface. Freezing a field that only happens to be right is the thing to avoid.

`remoteSupport bool` becomes `targets []targetKind`. A bool can only ask "is this a named SSH server from `servers:`", which is the only kind of target homebutler has had. An API-backed target has no agent on the far side and is addressed differently, so the question has to be open-ended before the answer is frozen. All 24 entries migrate mechanically: `true` to `{targetLocal, targetServer}`, `false` to `{targetLocal}`.

`executeTool` consults the registry before routing. The argv switch keeps its case arms — that mapping has to live somewhere and nothing in the tool definition carries it — but its `default` is now unreachable, kept only so a tool registered with `targetServer` and no argv mapping fails loudly instead of running an empty remote command.

I said in #32 that this would let the switch be deleted. It does not; I corrected that there.

`TestRegistryTargetsMatchRemoteArgvMapping` is the part that matters. It reads the case arms out of `server.go` and fails in both directions. Verified by breaking each deliberately before committing:

```
"network_scan" declares targetServer but executeRemote has no argv mapping for it,
so pointing it at a server fails after the gate lets it through

"docker_list" has an argv mapping in executeRemote but does not declare targetServer,
so the gate now rejects it and the mapping is dead
```

Two behaviour tests cover the gate: a local-only tool pointed at a server is rejected by the registry rather than by a failed SSH attempt, and an unknown server is still reported as an unknown server rather than swallowed by the new check.

## Demo mode advertised six tools it could not run

Auditing the registry for the above turned up a second gap in the same shape. `tools/list` is identical in demo mode, so a client reading it and calling `docker_stats` or any of the five `install_*` tools was told `unknown tool` for something the server had just advertised.

`install_list` now answers from the real catalogue — a static map compiled into the binary, no host access — rather than inventing apps that would drift from the real list. The `install_*` write tools return the shape their real counterparts return without touching the host, and reject an unknown app the same way. `docker_stats` mirrors the containers `demoDocker` already reports, so the two tools do not describe different machines.

Its test walks the registry rather than a hand-kept list. It fills arguments from each tool's `Properties` rather than `Required`, because `backup_drill` takes `app` or `all=true` and expresses neither as required — that came out of the test failing on the first run.

Left alone deliberately: `mcp_test.go` still hardcodes the tool count and an `expectedTools` map. Real duplication, but not this change, and it did not break here since no tools were added or removed.

Prepares #32 Phase 1, which needs a third target kind. Closes #56.
