### PR TITLE
feat: expose watch history and the watch list over MCP

### DIFF
--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -204,28 +204,27 @@ func newWatchListCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			targets, err := watch.LoadTargets(dir)
+			watched, err := watch.ListWatched(dir)
 			if err != nil {
 				return err
 			}
-			if len(targets) == 0 {
-				fmt.Println("No containers being watched. Use 'homebutler watch add <container>' to add one.")
+			if jsonOutput {
+				return output(watched, true)
+			}
+			if len(watched) == 0 {
+				fmt.Println("No targets being watched. Use 'homebutler watch add <name>' to add one.")
 				return nil
 			}
 
-			states, _ := watch.LoadState(dir)
 			fmt.Printf("%-25s %-10s %-22s %-10s %s\n", "NAME", "KIND", "ADDED", "RESTARTS", "LAST CHECKED")
-			for _, t := range targets {
-				added := t.AddedAt.Format("2006-01-02 15:04")
+			for _, w := range watched {
 				restarts := "-"
 				lastChecked := "-"
-				if s, ok := states[t.Container]; ok {
-					restarts = fmt.Sprintf("%d", s.RestartCount)
-					if !s.LastChecked.IsZero() {
-						lastChecked = s.LastChecked.Format("15:04:05")
-					}
+				if w.LastChecked != "" {
+					restarts = fmt.Sprintf("%d", w.RestartCount)
+					lastChecked = w.LastChecked
 				}
-				fmt.Printf("%-25s %-10s %-22s %-10s %s\n", t.Container, t.EffectiveKind(), added, restarts, lastChecked)
+				fmt.Printf("%-25s %-10s %-22s %-10s %s\n", w.Container, w.Kind, w.AddedAt, restarts, lastChecked)
 			}
 			return nil
 		},
@@ -536,7 +535,12 @@ func resolveIncidentCap(dir string) int {
 }
 
 func newWatchHistoryCmd() *cobra.Command {
-	return &cobra.Command{
+	var (
+		limit     int
+		container string
+		logs      bool
+	)
+	cmd := &cobra.Command{
 		Use:     "history",
 		Aliases: []string{"incidents"},
 		Short:   "List restart history",
@@ -545,7 +549,11 @@ func newWatchHistoryCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			incidents, err := watch.ListIncidents(dir)
+			incidents, err := watch.History(dir, watch.HistoryOptions{
+				Limit:     limit,
+				Container: container,
+				Logs:      logs,
+			})
 			if err != nil {
 				return err
 			}
@@ -578,6 +586,13 @@ func newWatchHistoryCmd() *cobra.Command {
 			return nil
 		},
 	}
+
+	cmd.Flags().IntVar(&limit, "limit", 0, "Show only the most recent N incidents (0 = all)")
+	cmd.Flags().StringVar(&container, "container", "", "Show only incidents for this target")
+	// Only affects --json. The table never printed logs, and a hundred lines of
+	// container output twice per incident is not something to put in a table.
+	cmd.Flags().BoolVar(&logs, "logs", false, "Include captured logs in --json output")
+	return cmd
 }
 
 func newWatchShowCmd() *cobra.Command {

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -80,6 +80,8 @@ Restart your AI client — homebutler tools will appear automatically.
 | `report` | Butler-style health report with snapshot comparison and suggested actions |
 | `doctor` | Read-only diagnosis of resource pressure, stopped containers, public ports, backup hygiene, and notification readiness |
 | `watch_check` | One-shot restart check on watched targets; reports systemd and pm2 targets as skipped rather than healthy |
+| `watch_history` | Recorded restart incidents, newest first. Captured logs are excluded unless `include_logs` is set |
+| `watch_list` | Targets being watched, with their kind and what the last check recorded |
 | `inventory_scan` | Server inventory/topology: system, containers, app ports, system ports |
 | `inventory_export` | Export inventory as Mermaid (local) or JSON |
 | `docker_list` | List containers |

--- a/internal/mcp/capabilities.go
+++ b/internal/mcp/capabilities.go
@@ -279,6 +279,37 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
+		risk:    riskRead,
+		targets: []targetKind{targetLocal, targetServer},
+		tool: toolDef{
+			Name:        "watch_history",
+			Description: "List recorded restart incidents, newest first. Captured logs are excluded unless include_logs is set, because every incident carries a hundred lines of output twice over",
+			InputSchema: inputSchema{
+				Type: "object",
+				Properties: map[string]propDef{
+					"limit":        {Type: "string", Description: "Most recent N incidents (default: 10, 0 for all)"},
+					"container":    {Type: "string", Description: "Only incidents for this target (optional)"},
+					"include_logs": {Type: "boolean", Description: "Include the logs captured before and after each restart (default: false)"},
+					"server":       {Type: "string", Description: "Remote server name from config (optional, runs locally if omitted)"},
+				},
+			},
+		},
+	},
+	{
+		risk:    riskRead,
+		targets: []targetKind{targetLocal, targetServer},
+		tool: toolDef{
+			Name:        "watch_list",
+			Description: "List the targets being watched, with their kind and what the last check recorded",
+			InputSchema: inputSchema{
+				Type: "object",
+				Properties: map[string]propDef{
+					"server": {Type: "string", Description: "Remote server name from config (optional, runs locally if omitted)"},
+				},
+			},
+		},
+	},
+	{
 		risk:    riskWrite,
 		targets: []targetKind{targetLocal, targetServer},
 		tool: toolDef{

--- a/internal/mcp/demo.go
+++ b/internal/mcp/demo.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/Higangssh/homebutler/internal/install"
 )
@@ -103,6 +104,21 @@ func (s *Server) executeDemoTool(name string, args map[string]any) (any, error) 
 				{"name": "caddy.service", "kind": "systemd"},
 			},
 		}, nil
+
+	case "watch_history":
+		return demoWatchHistory(args), nil
+
+	case "watch_list":
+		// Mirrors demoWatchHistory's targets, and carries a systemd entry with
+		// no last_checked: watch check cannot inspect those, so a caller that
+		// only ever saw polled docker targets would not learn that some of the
+		// list is only covered while watch start is running.
+		return []map[string]any{
+			{"container": "nextcloud", "kind": "docker", "added_at": "2026-04-12 09:31:00", "restart_count": 3, "last_checked": "2026-04-30 12:00:00"},
+			{"container": "postgres", "kind": "docker", "added_at": "2026-04-12 09:31:12", "restart_count": 0, "last_checked": "2026-04-30 12:00:00"},
+			{"container": "caddy.service", "kind": "systemd", "added_at": "2026-04-18 22:04:00", "restart_count": 0},
+		}, nil
+
 	case "backup_create":
 		service := stringArg(args, "service")
 		if service == "" {
@@ -354,4 +370,65 @@ func demoAlerts(server string) map[string]any {
 			},
 		}
 	}
+}
+
+// demoWatchHistory honours limit, container and include_logs so a caller can
+// see what those arguments actually do. A demo that ignored them would teach
+// the wrong thing about the tool it is demonstrating — particularly
+// include_logs, whose whole purpose is that the expensive shape is opt-in.
+func demoWatchHistory(args map[string]any) []map[string]any {
+	incidents := []map[string]any{
+		{
+			"id": "demo-nextcloud-20260430T120000Z", "container": "nextcloud",
+			"detected_at": "2026-04-30T12:00:00Z", "restart_count": 3,
+			"prev_started_at": "2026-04-30T09:14:02Z", "curr_started_at": "2026-04-30T11:58:41Z",
+			"pre_logs":  "PHP Fatal error: Allowed memory size exhausted",
+			"post_logs": "MySQL server has gone away\nRetrying connection (1/5)",
+		},
+		{
+			"id": "demo-nextcloud-20260429T031500Z", "container": "nextcloud",
+			"detected_at": "2026-04-29T03:15:00Z", "restart_count": 2,
+			"prev_started_at": "2026-04-28T20:02:11Z", "curr_started_at": "2026-04-29T03:14:47Z",
+			"pre_logs":  "Redis connection refused",
+			"post_logs": "Starting apache2",
+		},
+		{
+			"id": "demo-postgres-20260427T181200Z", "container": "postgres",
+			"detected_at": "2026-04-27T18:12:00Z", "restart_count": 1,
+			"prev_started_at": "2026-04-20T11:00:00Z", "curr_started_at": "2026-04-27T18:11:30Z",
+			"pre_logs":  "received fast shutdown request",
+			"post_logs": "database system is ready to accept connections",
+		},
+	}
+
+	if c := stringArg(args, "container"); c != "" {
+		filtered := incidents[:0:0]
+		for _, inc := range incidents {
+			if strings.EqualFold(inc["container"].(string), c) {
+				filtered = append(filtered, inc)
+			}
+		}
+		incidents = filtered
+	}
+
+	if n := intArg(args, "limit", 10); n > 0 && len(incidents) > n {
+		incidents = incidents[:n]
+	}
+
+	if !boolArg(args, "include_logs") {
+		stripped := make([]map[string]any, 0, len(incidents))
+		for _, inc := range incidents {
+			c := make(map[string]any, len(inc))
+			for k, v := range inc {
+				if k == "pre_logs" || k == "post_logs" {
+					continue
+				}
+				c[k] = v
+			}
+			stripped = append(stripped, c)
+		}
+		incidents = stripped
+	}
+
+	return incidents
 }

--- a/internal/mcp/demo_test.go
+++ b/internal/mcp/demo_test.go
@@ -92,3 +92,47 @@ func TestEveryAdvertisedToolHasADemoImplementation(t *testing.T) {
 		}
 	}
 }
+
+// The arguments have to reach the demo the same way they reach the real tool.
+// A demo that ignored include_logs would teach the opposite of what that
+// argument is for, since the whole point is that the expensive shape is opt-in.
+func TestDemoWatchHistoryHonoursItsArguments(t *testing.T) {
+	s := NewServer(&config.Config{}, "dev", true)
+
+	call := func(args map[string]any) []map[string]any {
+		t.Helper()
+		got, err := s.executeDemoTool("watch_history", args)
+		if err != nil {
+			t.Fatalf("watch_history%v: %v", args, err)
+		}
+		list, ok := got.([]map[string]any)
+		if !ok {
+			t.Fatalf("watch_history returned %T, want a list", got)
+		}
+		return list
+	}
+
+	if n := len(call(map[string]any{"limit": "2"})); n != 2 {
+		t.Errorf("limit 2 returned %d incidents", n)
+	}
+
+	withoutLogs := call(map[string]any{"limit": "1"})
+	if _, ok := withoutLogs[0]["pre_logs"]; ok {
+		t.Error("logs must be absent unless include_logs is set")
+	}
+
+	withLogs := call(map[string]any{"limit": "1", "include_logs": true})
+	if _, ok := withLogs[0]["pre_logs"]; !ok {
+		t.Error("include_logs must bring the captured logs back")
+	}
+
+	filtered := call(map[string]any{"container": "postgres"})
+	if len(filtered) == 0 {
+		t.Fatal("container filter returned nothing; the demo data no longer has a postgres incident")
+	}
+	for _, inc := range filtered {
+		if inc["container"] != "postgres" {
+			t.Errorf("container filter returned an incident for %v", inc["container"])
+		}
+	}
+}

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -95,35 +95,18 @@ func TestToolsList(t *testing.T) {
 		t.Fatalf("unmarshal toolsListResult: %v", err)
 	}
 
-	if len(list.Tools) != 24 {
-		t.Errorf("expected 24 tools, got %d", len(list.Tools))
+	// Derived from the registry rather than repeated here. The count and the
+	// name set were hardcoded, so adding a tool meant a failure in a test that
+	// had nothing to say about the change — it only knew the list had moved.
+	// What is worth asserting is that tools/list reports exactly what the
+	// registry holds, which is the thing that could actually be wrong.
+	if len(list.Tools) != len(capabilityRegistry) {
+		t.Errorf("tools/list returned %d tools, registry holds %d", len(list.Tools), len(capabilityRegistry))
 	}
 
-	expectedTools := map[string]bool{
-		"system_status":     false,
-		"docker_list":       false,
-		"docker_restart":    false,
-		"docker_stop":       false,
-		"docker_logs":       false,
-		"docker_stats":      false,
-		"wake":              false,
-		"open_ports":        false,
-		"network_scan":      false,
-		"alerts":            false,
-		"inventory_scan":    false,
-		"inventory_export":  false,
-		"report":            false,
-		"doctor":            false,
-		"watch_check":       false,
-		"backup_create":     false,
-		"backup_list":       false,
-		"backup_drill":      false,
-		"backup_restore":    false,
-		"install_list":      false,
-		"install_app":       false,
-		"install_status":    false,
-		"install_uninstall": false,
-		"install_purge":     false,
+	expectedTools := make(map[string]bool, len(capabilityRegistry))
+	for _, c := range capabilityRegistry {
+		expectedTools[c.tool.Name] = false
 	}
 
 	for _, tool := range list.Tools {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -312,6 +312,22 @@ func (s *Server) executeTool(name string, args map[string]any) (any, error) {
 			return nil, err
 		}
 		return watch.CheckTargets(dir, s.resolveIncidentCap(dir))
+	case "watch_history":
+		dir, err := watch.WatchDir()
+		if err != nil {
+			return nil, err
+		}
+		return watch.History(dir, watch.HistoryOptions{
+			Limit:     intArg(args, "limit", 10),
+			Container: stringArg(args, "container"),
+			Logs:      boolArg(args, "include_logs"),
+		})
+	case "watch_list":
+		dir, err := watch.WatchDir()
+		if err != nil {
+			return nil, err
+		}
+		return watch.ListWatched(dir)
 	case "backup_create":
 		backupDir := stringArg(args, "to")
 		if backupDir == "" {
@@ -462,6 +478,20 @@ func (s *Server) executeRemote(srv *config.ServerConfig, tool string, args map[s
 		remoteArgs = []string{"doctor", "--json", "--backup-max-age", fmt.Sprintf("%dh", intArg(args, "backup_max_age_hours", 168))}
 	case "watch_check":
 		remoteArgs = []string{"watch", "check", "--json"}
+	case "watch_history":
+		// The flags go over rather than being applied to the response, so the
+		// remote answer is the same shape the local one is and the logs are
+		// left on the remote host unless they were asked for.
+		remoteArgs = []string{"watch", "history", "--json",
+			"--limit", strconv.Itoa(intArg(args, "limit", 10))}
+		if c := stringArg(args, "container"); c != "" {
+			remoteArgs = append(remoteArgs, "--container", c)
+		}
+		if boolArg(args, "include_logs") {
+			remoteArgs = append(remoteArgs, "--logs")
+		}
+	case "watch_list":
+		remoteArgs = []string{"watch", "list", "--json"}
 	case "backup_list":
 		remoteArgs = []string{"backup", "list", "--json"}
 	case "backup_create":

--- a/internal/watch/query.go
+++ b/internal/watch/query.go
@@ -1,0 +1,97 @@
+package watch
+
+import "strings"
+
+// WatchedTarget is a target joined with whatever the last poll recorded about
+// it. `watch list` printed that join as a table and had no --json, so an agent
+// asking what is being watched had to be told to read a table. This is the
+// shape both paths now return.
+type WatchedTarget struct {
+	Container    string `json:"container"`
+	Kind         string `json:"kind"`
+	AddedAt      string `json:"added_at"`
+	RestartCount int    `json:"restart_count"`
+	LastChecked  string `json:"last_checked,omitempty"`
+}
+
+// ListWatched returns the watch list joined with the recorded state. A target
+// with no state yet is still returned: it is being watched, it simply has not
+// been polled.
+func ListWatched(dir string) ([]WatchedTarget, error) {
+	targets, err := LoadTargets(dir)
+	if err != nil {
+		return nil, err
+	}
+	// State is best effort. A missing or unreadable state file means nothing
+	// has been polled yet, which is not a reason to refuse to list the targets.
+	states, _ := LoadState(dir)
+
+	out := make([]WatchedTarget, 0, len(targets))
+	for _, t := range targets {
+		w := WatchedTarget{
+			Container: t.Container,
+			Kind:      t.EffectiveKind(),
+			AddedAt:   t.AddedAt.Format("2006-01-02 15:04:05"),
+		}
+		if s, ok := states[t.Container]; ok {
+			w.RestartCount = s.RestartCount
+			if !s.LastChecked.IsZero() {
+				w.LastChecked = s.LastChecked.Format("2006-01-02 15:04:05")
+			}
+		}
+		out = append(out, w)
+	}
+	return out, nil
+}
+
+// HistoryOptions narrows what ListIncidents returns.
+//
+// Logs are excluded unless asked for. Every incident carries PreLogs and
+// PostLogs, which are a hundred lines of container output each; thirty
+// incidents of that buries the caller in text it did not ask for. The caller
+// opts in to the expensive shape.
+type HistoryOptions struct {
+	Limit     int    // most recent N, 0 for all
+	Container string // exact container name, empty for all
+	Logs      bool   // include PreLogs and PostLogs
+}
+
+// History returns recorded incidents, newest first, narrowed by opts.
+func History(dir string, opts HistoryOptions) ([]Incident, error) {
+	incidents, err := ListIncidents(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	if opts.Container != "" {
+		filtered := incidents[:0:0]
+		for _, inc := range incidents {
+			if strings.EqualFold(inc.Container, opts.Container) {
+				filtered = append(filtered, inc)
+			}
+		}
+		incidents = filtered
+	}
+
+	// ListIncidents already sorts newest first, so a limit keeps the incidents
+	// most likely to matter. TestHistoryKeepsTheNewestIncidents pins that: if
+	// the sort there ever flips, a limit would silently return the oldest.
+	if opts.Limit > 0 && len(incidents) > opts.Limit {
+		incidents = incidents[:opts.Limit]
+	}
+
+	if !opts.Logs {
+		// Copy before blanking: ListIncidents returns freshly parsed values
+		// today, but a caller should not have to know that to be safe from
+		// having the logs removed underneath it.
+		stripped := make([]Incident, len(incidents))
+		copy(stripped, incidents)
+		for i := range stripped {
+			stripped[i].PreLogs = ""
+			stripped[i].PostLogs = ""
+		}
+		incidents = stripped
+	}
+
+	return incidents, nil
+}

--- a/internal/watch/query_test.go
+++ b/internal/watch/query_test.go
@@ -1,0 +1,131 @@
+package watch
+
+import (
+	"testing"
+	"time"
+)
+
+func seedIncidents(t *testing.T, dir string, specs ...Incident) {
+	t.Helper()
+	for i := range specs {
+		inc := specs[i]
+		if err := SaveIncident(dir, &inc, 0); err != nil {
+			t.Fatalf("saving incident %q: %v", inc.ID, err)
+		}
+	}
+}
+
+// A limit has to keep the newest incidents. ListIncidents sorts newest first
+// and History relies on that; if the sort ever flips, a limit would quietly
+// return the oldest incidents instead, which is the opposite of what an agent
+// asking "what broke" wants.
+func TestHistoryKeepsTheNewestIncidents(t *testing.T) {
+	dir := t.TempDir()
+	base := time.Date(2026, 8, 23, 12, 0, 0, 0, time.UTC)
+	seedIncidents(t, dir,
+		Incident{ID: "oldest", Container: "nginx", DetectedAt: base},
+		Incident{ID: "middle", Container: "nginx", DetectedAt: base.Add(time.Hour)},
+		Incident{ID: "newest", Container: "nginx", DetectedAt: base.Add(2 * time.Hour)},
+	)
+
+	got, err := History(dir, HistoryOptions{Limit: 2})
+	if err != nil {
+		t.Fatalf("History: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("limit 2 returned %d incidents", len(got))
+	}
+	if got[0].ID != "newest" || got[1].ID != "middle" {
+		t.Errorf("limit kept %q, %q; want newest, middle", got[0].ID, got[1].ID)
+	}
+}
+
+// Logs are the reason this filter exists: every incident carries a hundred
+// lines of container output twice over, and a caller that did not ask for them
+// should not receive them.
+func TestHistoryExcludesLogsUnlessAsked(t *testing.T) {
+	dir := t.TempDir()
+	seedIncidents(t, dir, Incident{
+		ID:         "i1",
+		Container:  "nginx",
+		DetectedAt: time.Now(),
+		PreLogs:    "before the restart",
+		PostLogs:   "after the restart",
+	})
+
+	got, err := History(dir, HistoryOptions{})
+	if err != nil {
+		t.Fatalf("History: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 incident, got %d", len(got))
+	}
+	if got[0].PreLogs != "" || got[0].PostLogs != "" {
+		t.Error("logs must be excluded unless include_logs is set")
+	}
+
+	withLogs, err := History(dir, HistoryOptions{Logs: true})
+	if err != nil {
+		t.Fatalf("History with logs: %v", err)
+	}
+	if withLogs[0].PreLogs != "before the restart" || withLogs[0].PostLogs != "after the restart" {
+		t.Error("logs must be present when asked for")
+	}
+}
+
+func TestHistoryFiltersByContainer(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now()
+	seedIncidents(t, dir,
+		Incident{ID: "a", Container: "nginx", DetectedAt: now},
+		Incident{ID: "b", Container: "postgres", DetectedAt: now.Add(time.Minute)},
+	)
+
+	got, err := History(dir, HistoryOptions{Container: "NGINX"})
+	if err != nil {
+		t.Fatalf("History: %v", err)
+	}
+	if len(got) != 1 || got[0].Container != "nginx" {
+		t.Errorf("container filter returned %+v; want the single nginx incident", got)
+	}
+}
+
+// A target that has never been polled is still being watched. Dropping it
+// would make the list disagree with what watch start is actually monitoring.
+func TestListWatchedIncludesTargetsWithNoStateYet(t *testing.T) {
+	dir := t.TempDir()
+	added := time.Date(2026, 8, 20, 9, 30, 0, 0, time.UTC)
+	if err := SaveTargets(dir, []Target{
+		{Container: "nginx", Kind: "docker", AddedAt: added},
+		{Container: "cron.service", Kind: "systemd", AddedAt: added},
+	}); err != nil {
+		t.Fatalf("SaveTargets: %v", err)
+	}
+	if err := SaveState(dir, map[string]*ContainerState{
+		"nginx": {Container: "nginx", RestartCount: 3, LastChecked: added.Add(time.Hour)},
+	}); err != nil {
+		t.Fatalf("SaveState: %v", err)
+	}
+
+	got, err := ListWatched(dir)
+	if err != nil {
+		t.Fatalf("ListWatched: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected both targets, got %d", len(got))
+	}
+
+	byName := map[string]WatchedTarget{}
+	for _, w := range got {
+		byName[w.Container] = w
+	}
+	if byName["nginx"].RestartCount != 3 || byName["nginx"].LastChecked == "" {
+		t.Errorf("nginx should carry its recorded state, got %+v", byName["nginx"])
+	}
+	if byName["cron.service"].Kind != "systemd" {
+		t.Errorf("kind should survive the join, got %q", byName["cron.service"].Kind)
+	}
+	if byName["cron.service"].LastChecked != "" {
+		t.Error("a target with no state should report no last-checked time rather than a zero one")
+	}
+}


### PR DESCRIPTION
The README leads with "Why did this service restart at 3 AM?" and `watch` is what answers it. `watch_check` reached that subsystem in #55; the two tools that answer what already happened did not. This adds them.

**`watch list` had no `--json` at all.** Not an oversight in the MCP layer — the command only ever printed a table, so there was nothing for a remote route to call and an agent asking what is being watched would have had to parse columns. It has JSON now, and both the CLI and the MCP tool go through `watch.ListWatched`, so the join between a target and its recorded state cannot drift between them.

**`watch history` grows `--limit`, `--container` and `--logs`.** The MCP tool needs all three. Applying them to the response after a remote call would have meant the arguments worked locally and silently did nothing remotely, so they go over the wire instead and both paths return the same shape.

Logs are excluded unless asked for. Every incident carries `PreLogs` and `PostLogs` — a hundred lines of container output each — and thirty incidents of that buries a caller in text it did not request. `include_logs` defaults to false so the expensive shape is opt-in, as #54 decided.

While writing `History` I reversed the incident order on the assumption `ListIncidents` returned oldest-first. It already sorts newest-first, so the reversal would have made `limit` return the *oldest* incidents — the opposite of what someone asking "what broke" wants. `TestHistoryKeepsTheNewestIncidents` pins it so the same mistake fails loudly if that sort ever changes.

A target that has never been polled is still listed. Dropping it would make the list disagree with what `watch start` is monitoring, and the demo carries a systemd entry with no `last_checked` for the same reason `watch_check` reports skipped targets rather than assuming them healthy.

## mcp_test.go stops repeating the registry

Adding two tools broke a hardcoded count and a hardcoded name map — the thing I left alone in #71 and said would bite when the tool count changed. It did, immediately.

Rather than bumping 24 to 26 and adding two lines, both now derive from `capabilityRegistry`. The assertion that matters is that `tools/list` reports exactly what the registry holds; the previous version only knew that a list had moved, and failed in a test that had nothing to say about the change.

## Verified end to end

Over the real stdio protocol against `homebutler mcp --demo`, not only in unit tests:

```
watch_history limit=2                    -> 2 incidents, no logs
watch_history limit=1 include_logs=true  -> 1 incident with pre_logs and post_logs
watch_list                               -> 3 targets, kinds and recorded state
```

Part of #54. `processes` and `config_validate` follow separately — they share nothing with these two and would only have made this harder to review.
