### PR TITLE
feat: expose processes and config validation over MCP

### DIFF
--- a/cmd/mcp.go
+++ b/cmd/mcp.go
@@ -16,7 +16,11 @@ func newMCPCmd() *cobra.Command {
 			if err := loadConfig(); err != nil {
 				return err
 			}
-			return mcp.NewServer(cfg, Version, demo).Run()
+			srv := mcp.NewServer(cfg, Version, demo)
+			// So config_validate checks the file this server is running on
+			// rather than resolving one of its own.
+			srv.SetConfigPath(cfgPath)
+			return srv.Run()
 		},
 	}
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -102,8 +102,22 @@ Restart your AI client — homebutler tools will appear automatically.
 | `install_status` | Check installed app status |
 | `install_uninstall` | Stop an app while preserving data |
 | `install_purge` | Stop an app and delete all data |
+| `processes` | Top processes by CPU or memory, with zombies broken out separately |
+| `config_validate` | Check the config file this server is running on |
 
 Most read/check tools support an optional `server` parameter — manage every server from a single prompt. Destructive tools such as `backup_restore`, `install_purge`, and container stop/restart should only be called after the user clearly confirms intent.
+
+`config_validate` is the exception: it has no `server` parameter. It answers whether the config this MCP server is running on is valid, which is a question about this machine, and pointing it at a remote would answer about a different file.
+
+### What is deliberately not exposed
+
+Omissions worth stating, so they read as decisions rather than gaps.
+
+**`trust`** accepts SSH host keys on first use. An agent auto-accepting TOFU is exactly the boundary this project promises not to cross, so there is no tool for it and there will not be one.
+
+**`upgrade`** replaces the running binary. **`serve`**, **`init`**, **`watch start`** and **`watch tui`** are daemons or interactive; neither shape fits a stdio request and response.
+
+**`deploy`** is deferred past 1.0. Remote install is the highest-risk surface here and should not be frozen into the first stable tool set.
 
 ## How It Works
 

--- a/internal/mcp/capabilities.go
+++ b/internal/mcp/capabilities.go
@@ -282,6 +282,39 @@ var capabilityRegistry = []capability{
 		risk:    riskRead,
 		targets: []targetKind{targetLocal, targetServer},
 		tool: toolDef{
+			Name:        "processes",
+			Description: "List the top processes by CPU or memory, with a total count and any zombies broken out separately",
+			InputSchema: inputSchema{
+				Type: "object",
+				Properties: map[string]propDef{
+					"limit":   {Type: "string", Description: "Number of processes to return (default: 10, 0 for all)"},
+					"sort_by": {Type: "string", Description: "Sort by cpu (default) or mem"},
+					"server":  {Type: "string", Description: "Remote server name from config (optional, runs locally if omitted)"},
+				},
+			},
+		},
+	},
+	{
+		// Local only. It answers "is the config this MCP server is running on
+		// valid", which is a question about this machine. Pointing it at a
+		// remote would silently answer about a different file.
+		risk:    riskRead,
+		targets: []targetKind{targetLocal},
+		tool: toolDef{
+			Name:        "config_validate",
+			Description: "Check the config file this server is running on: which file was used, which rule selected it, what was read from each section, and anything wrong or silently ignored",
+			InputSchema: inputSchema{
+				Type: "object",
+				Properties: map[string]propDef{
+					"strict": {Type: "boolean", Description: "Treat warnings as failures in the passed field (default: false)"},
+				},
+			},
+		},
+	},
+	{
+		risk:    riskRead,
+		targets: []targetKind{targetLocal, targetServer},
+		tool: toolDef{
 			Name:        "watch_history",
 			Description: "List recorded restart incidents, newest first. Captured logs are excluded unless include_logs is set, because every incident carries a hundred lines of output twice over",
 			InputSchema: inputSchema{

--- a/internal/mcp/demo.go
+++ b/internal/mcp/demo.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/Higangssh/homebutler/internal/install"
@@ -102,6 +103,34 @@ func (s *Server) executeDemoTool(name string, args map[string]any) (any, error) 
 			},
 			"skipped": []map[string]any{
 				{"name": "caddy.service", "kind": "systemd"},
+			},
+		}, nil
+
+	case "processes":
+		return demoProcesses(args), nil
+
+	case "config_validate":
+		// Reports a warning rather than a clean bill of health. A demo that
+		// only ever passed would teach a caller that this tool has nothing to
+		// say, when catching the silently-ignored key is the reason it exists.
+		strict := boolArg(args, "strict")
+		return map[string]any{
+			"passed":   !strict,
+			"errors":   0,
+			"warnings": 1,
+			"result": map[string]any{
+				"path":   "/home/demo/.homebutler/config.yaml",
+				"source": "default location (~/.homebutler/config.yaml)",
+				"exists": true,
+				"valid":  true,
+				"findings": []map[string]any{
+					{
+						"severity": "warning",
+						"section":  "watch",
+						"message":  "unknown key \"cooldwn\" is ignored",
+						"hint":     "did you mean \"cooldown\"?",
+					},
+				},
 			},
 		}, nil
 
@@ -431,4 +460,37 @@ func demoWatchHistory(args map[string]any) []map[string]any {
 	}
 
 	return incidents
+}
+
+// demoProcesses honours limit and sort_by, and always carries a zombie. The
+// real tool breaks zombies out separately because they do not show up in a
+// CPU-sorted top ten while still being worth knowing about; a demo without one
+// would hide the field that exists for that.
+func demoProcesses(args map[string]any) map[string]any {
+	procs := []map[string]any{
+		{"pid": 1187, "name": "postgres", "cpu": 12.4, "mem": 8.1, "rss": 1329152},
+		{"pid": 902, "name": "plex", "cpu": 9.7, "mem": 14.6, "rss": 2394112},
+		{"pid": 1544, "name": "prometheus", "cpu": 4.2, "mem": 4.5, "rss": 738304},
+		{"pid": 311, "name": "dockerd", "cpu": 2.1, "mem": 2.2, "rss": 360448},
+		{"pid": 1290, "name": "nginx", "cpu": 0.4, "mem": 0.2, "rss": 24576},
+	}
+
+	if stringArg(args, "sort_by") == "mem" {
+		sort.SliceStable(procs, func(i, j int) bool {
+			return procs[i]["mem"].(float64) > procs[j]["mem"].(float64)
+		})
+	}
+
+	total := len(procs) + 173
+	if n := intArg(args, "limit", 10); n > 0 && len(procs) > n {
+		procs = procs[:n]
+	}
+
+	return map[string]any{
+		"processes": procs,
+		"total":     total,
+		"zombies": []map[string]any{
+			{"pid": 2077, "name": "ffmpeg", "cpu": 0.0, "mem": 0.0, "rss": 0, "state": "Z", "zombie": true},
+		},
+	}
 }

--- a/internal/mcp/demo_test.go
+++ b/internal/mcp/demo_test.go
@@ -136,3 +136,35 @@ func TestDemoWatchHistoryHonoursItsArguments(t *testing.T) {
 		}
 	}
 }
+
+// strict is the difference between "there are warnings" and "that counts as a
+// failure". The findings travel either way, so a caller that gates on passed
+// still gets to see what it is gating on.
+func TestDemoConfigValidateStrictChangesTheVerdictNotTheFindings(t *testing.T) {
+	s := NewServer(&config.Config{}, "dev", true)
+
+	lax, err := s.executeDemoTool("config_validate", map[string]any{})
+	if err != nil {
+		t.Fatalf("config_validate: %v", err)
+	}
+	strict, err := s.executeDemoTool("config_validate", map[string]any{"strict": true})
+	if err != nil {
+		t.Fatalf("config_validate strict: %v", err)
+	}
+
+	laxMap := lax.(map[string]any)
+	strictMap := strict.(map[string]any)
+
+	if laxMap["passed"] != true {
+		t.Error("warnings alone should not fail without strict")
+	}
+	if strictMap["passed"] != false {
+		t.Error("strict should turn a warning into a failure")
+	}
+	if laxMap["warnings"] != strictMap["warnings"] {
+		t.Error("strict must change the verdict, not what was found")
+	}
+	if strictMap["result"] == nil {
+		t.Error("the findings must travel with a failing verdict, or a caller cannot see why it failed")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -104,11 +104,20 @@ type toolsCallResult struct {
 // Server is the MCP server.
 type Server struct {
 	cfg     *config.Config
+	cfgPath string
 	version string
 	demo    bool
 	in      io.Reader
 	out     io.Writer
 }
+
+// SetConfigPath records the --config path this server was started with.
+//
+// config_validate answers "is the config this server is running on valid", and
+// without the path it would resolve one itself and check whatever the default
+// rules select. That is a different file, correctly labelled in the result but
+// not the one that was asked about.
+func (s *Server) SetConfigPath(path string) { s.cfgPath = path }
 
 // NewServer creates a new MCP server.
 func NewServer(cfg *config.Config, version string, demo ...bool) *Server {
@@ -312,6 +321,25 @@ func (s *Server) executeTool(name string, args map[string]any) (any, error) {
 			return nil, err
 		}
 		return watch.CheckTargets(dir, s.resolveIncidentCap(dir))
+	case "processes":
+		return system.ListProcesses(intArg(args, "limit", 10), stringArg(args, "sort_by"))
+	case "config_validate":
+		// Deliberately not s.cfg: that is the already-loaded config, and
+		// loading treats an unreadable or missing file as "use defaults",
+		// which is exactly the failure this answers. Validate reads the file.
+		result := config.Validate(s.cfgPath)
+		passed := result.Errors() == 0
+		if boolArg(args, "strict") && result.Warnings() > 0 {
+			passed = false
+		}
+		// The result travels with the verdict rather than the verdict being an
+		// error, so a caller that gates on passed still gets to see why.
+		return map[string]any{
+			"passed":   passed,
+			"errors":   result.Errors(),
+			"warnings": result.Warnings(),
+			"result":   result,
+		}, nil
 	case "watch_history":
 		dir, err := watch.WatchDir()
 		if err != nil {
@@ -478,6 +506,12 @@ func (s *Server) executeRemote(srv *config.ServerConfig, tool string, args map[s
 		remoteArgs = []string{"doctor", "--json", "--backup-max-age", fmt.Sprintf("%dh", intArg(args, "backup_max_age_hours", 168))}
 	case "watch_check":
 		remoteArgs = []string{"watch", "check", "--json"}
+	case "processes":
+		remoteArgs = []string{"processes", "--json",
+			"--limit", strconv.Itoa(intArg(args, "limit", 10))}
+		if by := stringArg(args, "sort_by"); by != "" {
+			remoteArgs = append(remoteArgs, "--sort", by)
+		}
 	case "watch_history":
 		// The flags go over rather than being applied to the response, so the
 		// remote answer is the same shape the local one is and the logs are

--- a/internal/mcp/targets_test.go
+++ b/internal/mcp/targets_test.go
@@ -114,3 +114,23 @@ func TestUnknownServerStillReportedBeforeTheGate(t *testing.T) {
 		t.Errorf("an unknown server should be reported as such, got: %v", err)
 	}
 }
+
+// config_validate answers "is the config this server is running on valid".
+// Pointing it at a remote would answer about a different file, so the registry
+// declares it local-only and the gate has to enforce that.
+func TestConfigValidateCannotBePointedAtAServer(t *testing.T) {
+	c, ok := capabilityFor("config_validate")
+	if !ok {
+		t.Fatal("config_validate is not registered")
+	}
+	if c.supports(targetServer) {
+		t.Error("config_validate must not declare targetServer; it would validate a different file than the one asked about")
+	}
+
+	s := NewServer(&config.Config{
+		Servers: []config.ServerConfig{{Name: "pve1", Host: "192.0.2.1"}},
+	}, "test")
+	if _, err := s.executeTool("config_validate", map[string]any{"server": "pve1"}); err == nil {
+		t.Error("expected config_validate pointed at a server to be rejected")
+	}
+}


### PR DESCRIPTION
The last two tools from #54. "What is eating the CPU" is near the top of what anyone asks a server and had no tool; `config_validate` had none either, so an agent could not check the file the server it was talking to was running on.

**`config_validate` is local-only**, as #54 decided. Pointing it at a remote would answer about a different file. The registry now enforces that rather than describing it — the gate from #71 rejects it before routing, and a test asserts both the declaration and the behaviour.

**The MCP server did not know its own config path.** `cmd/mcp.go` passed the loaded `*config.Config` but not where it came from, so `config_validate` would have resolved a path of its own and checked whatever the default rules select. Under `homebutler --config /custom.yaml mcp` that is a different file — correctly labelled in the result, since `ValidationResult` reports `path` and `source`, but not the one that was asked about. `SetConfigPath` closes it.

**`strict` changes the verdict, not the return.** It would have been easy to make strict mode return an error, mirroring the CLI's non-zero exit. That takes the findings with it, and a caller gating on the result still has to be able to see what it is gating on. So the tool returns `passed`, `errors`, `warnings` and the full result, and `strict` only moves `passed`.

**`processes`** takes `limit` and `sort_by` and passes them over the wire for the remote path, same as `watch_history` in #72 — applying them after the call would have meant the arguments worked locally and silently did nothing remotely.

## What is deliberately not exposed

#54 asked for this to be written down rather than left as an omission, so `docs/mcp-server.md` now says it: `trust` accepts SSH host keys on first use and an agent auto-accepting TOFU is the boundary the README promises not to cross; `upgrade` replaces the running binary; `serve`, `init`, `watch start` and `watch tui` are daemons or interactive and do not fit a stdio request and response; `deploy` is deferred past 1.0 because remote install is the highest-risk surface here and should not be frozen into the first stable tool set.

## Verified end to end

Over the real stdio protocol against `homebutler mcp --demo`:

```
processes limit=3 sort_by=mem   -> 3 processes, memory-sorted, total 178, 1 zombie
config_validate strict=true     -> passed=false, warnings=1, path reported
tools/list                      -> 28 tools
```

The demo for `config_validate` reports a warning rather than a clean bill of health, and the one for `processes` always carries a zombie. A demo that only ever passed would teach a caller that these tools have nothing to say, when catching the silently-ignored key and the process that will not die is why they exist.

Closes #54.
