### PR TITLE
feat: record which collector failed, so an empty result can be told from a missing one

### DIFF
--- a/internal/inventory/inventory.go
+++ b/internal/inventory/inventory.go
@@ -17,6 +17,30 @@ type Inventory struct {
 	Containers []docker.Container `json:"containers"`
 	Ports      []ports.PortInfo   `json:"ports"`
 	Warnings   []string           `json:"warnings,omitempty"`
+	// Failed names the collectors that did not answer, so a reader can ask
+	// which part of the snapshot is missing rather than matching on the
+	// prefix of a warning string. Warnings stays the human-readable list;
+	// this is the machine-readable half, kept separate so the two do not have
+	// to be one field doing both jobs.
+	Failed []string `json:"failed_collectors,omitempty"`
+}
+
+// Collector names recorded in Failed.
+const (
+	CollectorDocker = "docker"
+	CollectorPorts  = "ports"
+)
+
+// CollectorFailed reports whether the named collector failed during Collect.
+// An empty Ports slice means either "nothing is listening" or "the scan did
+// not run", and only this can tell them apart.
+func (inv *Inventory) CollectorFailed(name string) bool {
+	for _, f := range inv.Failed {
+		if f == name {
+			return true
+		}
+	}
+	return false
 }
 
 // CollectFuncs allows injecting data sources for testing.
@@ -56,7 +80,8 @@ func Collect(cfg *config.Config, fns CollectFuncs) (*Inventory, error) {
 	// Docker: best-effort.
 	containers, err := fns.DockerListFn()
 	if err != nil {
-		inv.Warnings = append(inv.Warnings, "docker: "+err.Error())
+		inv.Warnings = append(inv.Warnings, CollectorDocker+": "+err.Error())
+		inv.Failed = append(inv.Failed, CollectorDocker)
 	} else {
 		inv.Containers = containers
 	}
@@ -64,7 +89,8 @@ func Collect(cfg *config.Config, fns CollectFuncs) (*Inventory, error) {
 	// Ports: best-effort.
 	result, err := fns.PortsListFn()
 	if err != nil {
-		inv.Warnings = append(inv.Warnings, "ports: "+err.Error())
+		inv.Warnings = append(inv.Warnings, CollectorPorts+": "+err.Error())
+		inv.Failed = append(inv.Failed, CollectorPorts)
 	} else {
 		inv.Ports = result.Ports
 	}

--- a/internal/inventory/inventory_test.go
+++ b/internal/inventory/inventory_test.go
@@ -292,6 +292,7 @@ func TestRenderTreeFiltered_ExposedShowsWarnings(t *testing.T) {
 		Host:       "10.0.0.1",
 		Ports:      []ports.PortInfo{},
 		Warnings:   []string{"ports: failed to list ports: exit status 1"},
+		Failed:     []string{CollectorPorts},
 	}
 
 	out, err := RenderTreeFiltered(inv, "exposed")
@@ -303,6 +304,30 @@ func TestRenderTreeFiltered_ExposedShowsWarnings(t *testing.T) {
 	}
 	if strings.Contains(out, "(none)") {
 		t.Errorf("(none) must not print when the scan failed; it reads as an authoritative count\n%s", out)
+	}
+}
+
+// A Docker failure says nothing about whether the port scan ran. Withholding
+// (none) here would hide a good answer on a host where Docker happens to be
+// down, which is a common state on a machine someone is checking ports on.
+func TestRenderTreeFiltered_ExposedStillAnswersWhenOnlyDockerFailed(t *testing.T) {
+	inv := &Inventory{
+		ServerName: "demo-lab",
+		Host:       "10.0.0.1",
+		Ports:      []ports.PortInfo{{Port: "5432", Protocol: "tcp", Address: "127.0.0.1", Process: "postgres"}},
+		Warnings:   []string{"docker: cannot connect to the Docker daemon"},
+		Failed:     []string{CollectorDocker},
+	}
+
+	out, err := RenderTreeFiltered(inv, "exposed")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(out, "(none)") {
+		t.Errorf("the port scan succeeded and found nothing exposed; that answer should be given\n%s", out)
+	}
+	if !strings.Contains(out, "Warnings (1)") {
+		t.Errorf("the docker failure should still be surfaced\n%s", out)
 	}
 }
 
@@ -384,3 +409,52 @@ func TestJSON_Roundtrip(t *testing.T) {
 type errTest string
 
 func (e errTest) Error() string { return string(e) }
+
+// Collect has to record the failure in both places: Warnings for a person and
+// Failed for a caller that needs to know which half of the snapshot is
+// missing. An empty Ports slice cannot tell those apart on its own.
+func TestCollectRecordsWhichCollectorFailed(t *testing.T) {
+	inv, err := Collect(&config.Config{}, fakeFuncs(nil, nil, errTest("docker down"), nil))
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+
+	if !inv.CollectorFailed(CollectorDocker) {
+		t.Error("a docker failure should be recorded in Failed")
+	}
+	if inv.CollectorFailed(CollectorPorts) {
+		t.Error("the port scan succeeded and must not be reported as failed")
+	}
+	if len(inv.Warnings) != 1 {
+		t.Errorf("the human-readable warning should still be there, got %v", inv.Warnings)
+	}
+
+	both, err := Collect(&config.Config{}, fakeFuncs(nil, nil, errTest("docker down"), errTest("no lsof")))
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if !both.CollectorFailed(CollectorDocker) || !both.CollectorFailed(CollectorPorts) {
+		t.Errorf("both failures should be recorded, got %v", both.Failed)
+	}
+}
+
+// Nothing failed, so Failed stays empty and omitempty keeps it out of the JSON
+// entirely. Adding the field has to be invisible to existing readers and to
+// snapshots written before it existed.
+func TestCollectLeavesFailedEmptyOnSuccess(t *testing.T) {
+	inv, err := Collect(&config.Config{}, fakeFuncs(nil, nil, nil, nil))
+	if err != nil {
+		t.Fatalf("Collect: %v", err)
+	}
+	if len(inv.Failed) != 0 {
+		t.Errorf("nothing failed, Failed should be empty, got %v", inv.Failed)
+	}
+
+	data, err := json.Marshal(inv)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "failed_collectors") {
+		t.Errorf("an empty Failed must not appear in JSON\n%s", data)
+	}
+}

--- a/internal/inventory/render.go
+++ b/internal/inventory/render.go
@@ -124,7 +124,11 @@ func renderExposedPorts(inv *Inventory) string {
 	fmt.Fprintf(&b, "   Server  %s\n", inv.ServerName)
 
 	b.WriteString("\n🌐 Exposed Ports\n")
-	if len(exposed) == 0 && len(inv.Warnings) == 0 {
+	// (none) is an authoritative answer, so it is only printed when the port
+	// scan actually ran. Suppressing on any warning was the safe first cut but
+	// it withheld a good answer whenever Docker happened to be down, which is
+	// common on a host someone is checking ports on.
+	if len(exposed) == 0 && !inv.CollectorFailed(CollectorPorts) {
 		b.WriteString("   (none)\n")
 	}
 	for i, p := range exposed {

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -19,15 +19,19 @@ import (
 
 // Snapshot persists inventory state for future comparison.
 type Snapshot struct {
-	Timestamp       string             `json:"timestamp"`
-	ServerName      string             `json:"server_name"`
-	System          *system.StatusInfo `json:"system"`
-	Containers      []docker.Container `json:"containers"`
-	Ports           []ports.PortInfo   `json:"ports"`
-	Warnings        []string           `json:"warnings,omitempty"`
-	RunningCount    int                `json:"running_count"`
-	StoppedCount    int                `json:"stopped_count"`
-	PublicPortCount int                `json:"public_port_count"`
+	Timestamp  string             `json:"timestamp"`
+	ServerName string             `json:"server_name"`
+	System     *system.StatusInfo `json:"system"`
+	Containers []docker.Container `json:"containers"`
+	Ports      []ports.PortInfo   `json:"ports"`
+	Warnings   []string           `json:"warnings,omitempty"`
+	// Failed records which collectors did not answer when this snapshot was
+	// taken. A diff that does not know this would report every container as
+	// having disappeared when Docker was simply down at collection time.
+	Failed          []string `json:"failed_collectors,omitempty"`
+	RunningCount    int      `json:"running_count"`
+	StoppedCount    int      `json:"stopped_count"`
+	PublicPortCount int      `json:"public_port_count"`
 }
 
 // Report is the structured output of a report run.
@@ -114,6 +118,7 @@ func buildSnapshot(inv *inventory.Inventory) *Snapshot {
 		Containers: inv.Containers,
 		Ports:      inv.Ports,
 		Warnings:   inv.Warnings,
+		Failed:     inv.Failed,
 	}
 	for _, c := range inv.Containers {
 		switch c.State {


### PR DESCRIPTION
`Collect` appended `"docker: "` or `"ports: "` to a warning string, and that prefix was the only record of which half of the snapshot was missing. #69 asked whether `Warnings` should become structured before 1.0 freezes it.

**It should not.** The answer is a third option that was not in the issue when I wrote it: leave `Warnings` alone and add the machine-readable half beside it.

`Warnings` is serialized in three places — `inventory scan --json`, `report --json`, and the snapshot files on disk — all as `[]string`. Restructuring it changes the shape of two commands and stops old snapshots round-tripping, in exchange for serving exactly one consumer. Adding a field costs none of that: it is additive, `omitempty` keeps it out of the JSON when nothing failed, snapshots written before it read back fine, and 1.0 can freeze `Warnings []string` honestly because it is no longer being asked to do two jobs.

## The consumer this was for

The exposed filter suppressed its `(none)` line whenever any warning was present. That was the right first cut — a bare `(none)` after a failed port scan reads as "nothing is exposed", the one answer that view must never give wrongly. But it keyed on the wrong thing. With Docker down and a perfectly good port scan finding nothing exposed, the answer was withheld even though it was trustworthy, and Docker being down is a common state on a host someone is checking ports on.

It now suppresses only when the port scan itself failed. `TestRenderTreeFiltered_ExposedStillAnswersWhenOnlyDockerFailed` covers the case that was broken; the existing test for the real failure still passes with the fixture updated to the new representation, which is how I found that a hand-built `Inventory` now has to say `Failed` as well as `Warnings`.

## The snapshot carries it

`Snapshot` gets the field too, and nothing reads it yet. That is deliberate. #58 will diff containers and ports by identity, and a diff that does not know a collector failed would report every container as having disappeared when Docker was simply down at collection time. Adding the field when that work starts would leave every snapshot written between now and then unable to say, and those are exactly the snapshots it would be comparing against.

Closes #69.
