### PR TITLE
fix: configs holding only a notification credential were never permission-checked

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,7 +122,7 @@ type ServerConfig struct {
 	User     string `yaml:"user,omitempty"`
 	Port     int    `yaml:"port,omitempty"`
 	KeyFile  string `yaml:"key,omitempty"`
-	Password string `yaml:"password,omitempty"`
+	Password string `yaml:"password,omitempty" json:"-" secret:"true"`
 	AuthMode string `yaml:"auth,omitempty"` // "key" (default) or "password"
 	BinPath  string `yaml:"bin,omitempty"`  // remote homebutler path (default: homebutler)
 }
@@ -255,16 +255,6 @@ func Load(path string) (*Config, error) {
 	}
 
 	return cfg, nil
-}
-
-// hasSecrets returns true if any server uses password auth.
-func hasSecrets(cfg *Config) bool {
-	for _, s := range cfg.Servers {
-		if s.Password != "" {
-			return true
-		}
-	}
-	return false
 }
 
 // FindServer returns the server config by name, or nil if not found.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -57,7 +57,11 @@ wake:
     mac: "AA:BB:CC:DD:EE:FF"
     ip: "192.168.1.255"
 `
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+	// 0600 because this fixture holds a bot token. Written 0644 it used to
+	// load without complaint, only because hasSecrets could not see notify
+	// credentials. Load now refuses that, which is what
+	// TestLoadRefusesAnOpenFileHoldingOnlyANotifyCredential covers.
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
 		t.Fatalf("failed to write test config: %v", err)
 	}
 

--- a/internal/config/secrets.go
+++ b/internal/config/secrets.go
@@ -1,0 +1,72 @@
+package config
+
+import "reflect"
+
+// secretTag marks a field that holds a plaintext credential.
+//
+// Fields carrying this tag are what hasSecrets looks for, and they are also
+// the fields that must never be serialized: tag them `json:"-"` as well, so a
+// leak is structurally impossible rather than merely absent from today's call
+// sites.
+const secretTag = "secret"
+
+// hasSecrets reports whether cfg holds a plaintext credential.
+//
+// It walks the config rather than checking a hand-kept list of fields. The
+// list was the bug: it knew only about servers[].password, so a config holding
+// nothing but a Telegram bot token was never permission-checked at all, and
+// every credential-bearing section added since would have had to be remembered
+// in a function far away from the field it was about. A field now declares
+// what it is, next to itself.
+func hasSecrets(cfg *Config) bool {
+	if cfg == nil {
+		return false
+	}
+	return containsSecret(reflect.ValueOf(cfg))
+}
+
+func containsSecret(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Pointer, reflect.Interface:
+		if v.IsNil() {
+			return false
+		}
+		return containsSecret(v.Elem())
+
+	case reflect.Slice, reflect.Array:
+		for i := 0; i < v.Len(); i++ {
+			if containsSecret(v.Index(i)) {
+				return true
+			}
+		}
+
+	case reflect.Map:
+		for _, k := range v.MapKeys() {
+			if containsSecret(v.MapIndex(k)) {
+				return true
+			}
+		}
+
+	case reflect.Struct:
+		t := v.Type()
+		for i := 0; i < v.NumField(); i++ {
+			f := t.Field(i)
+			if !f.IsExported() {
+				continue
+			}
+			// A tagged field counts only when it actually holds something.
+			// An empty password is not a secret to protect.
+			if f.Tag.Get(secretTag) == "true" {
+				if fv := v.Field(i); fv.Kind() == reflect.String && fv.String() != "" {
+					return true
+				}
+				continue
+			}
+			if containsSecret(v.Field(i)) {
+				return true
+			}
+		}
+	}
+
+	return false
+}

--- a/internal/config/secrets_test.go
+++ b/internal/config/secrets_test.go
@@ -2,7 +2,10 @@ package config
 
 import (
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -124,5 +127,35 @@ func TestMarshallingAConfigLeaksNoCredentials(t *testing.T) {
 		if strings.Contains(string(data), secret) {
 			t.Errorf("serialized config contains %q\n%s", secret, data)
 		}
+	}
+}
+
+// The end of the whole change, through Load rather than through hasSecrets: a
+// config whose only credential is a notification token must be refused when
+// its permissions are open. Before this it loaded without complaint, and the
+// guard that exists to prevent exactly that never ran.
+func TestLoadRefusesAnOpenFileHoldingOnlyANotifyCredential(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Load only enforces permissions on non-Windows")
+	}
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := "notify:\n  telegram:\n    bot_token: \"123:abc\"\n    chat_id: \"999\"\n"
+
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+		t.Fatalf("writing config: %v", err)
+	}
+	if _, err := Load(path); err == nil {
+		t.Fatal("a world-readable config holding a bot token should be refused")
+	} else if !strings.Contains(err.Error(), "chmod 600") {
+		t.Errorf("the refusal should say how to fix it, got: %v", err)
+	}
+
+	if err := os.Chmod(path, 0600); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	if _, err := Load(path); err != nil {
+		t.Errorf("the same config at 0600 should load: %v", err)
 	}
 }

--- a/internal/config/secrets_test.go
+++ b/internal/config/secrets_test.go
@@ -1,0 +1,128 @@
+package config
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/Higangssh/homebutler/internal/notify"
+)
+
+// The bug this closes: hasSecrets only inspected servers[].password, so a
+// config whose only credential was a notification token was never permission
+// checked at all. watch notifications are set up far more often than SSH
+// passwords, which made this the common case rather than the rare one.
+func TestHasSecretsFindsNotifyCredentials(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *Config
+	}{
+		{"telegram bot token", &Config{Notify: notify.ProviderConfig{
+			Telegram: &notify.TelegramConfig{BotToken: "123:abc", ChatID: "42"},
+		}}},
+		{"slack webhook", &Config{Notify: notify.ProviderConfig{
+			Slack: &notify.SlackConfig{WebhookURL: "https://hooks.slack.com/services/T/B/x"},
+		}}},
+		{"discord webhook", &Config{Notify: notify.ProviderConfig{
+			Discord: &notify.DiscordConfig{WebhookURL: "https://discord.com/api/webhooks/1/x"},
+		}}},
+		{"generic webhook", &Config{Notify: notify.ProviderConfig{
+			Webhook: &notify.WebhookConfig{URL: "https://example.com/hook?token=x"},
+		}}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if !hasSecrets(tt.cfg) {
+				t.Error("a config holding only this credential was treated as having no secrets, so its file permissions were never checked")
+			}
+		})
+	}
+}
+
+// A configured provider with no credential in it is not a secret to protect.
+func TestHasSecretsIgnoresEmptyCredentials(t *testing.T) {
+	cfg := &Config{
+		Servers: []ServerConfig{{Name: "a", Password: ""}},
+		Notify: notify.ProviderConfig{
+			Telegram: &notify.TelegramConfig{ChatID: "42"},
+		},
+	}
+	if hasSecrets(cfg) {
+		t.Error("an empty credential should not trigger the permission check")
+	}
+}
+
+func TestHasSecretsHandlesNilAndEmpty(t *testing.T) {
+	if hasSecrets(nil) {
+		t.Error("a nil config has no secrets")
+	}
+	if hasSecrets(&Config{}) {
+		t.Error("an empty config has no secrets")
+	}
+}
+
+// Every field tagged as a secret must also be unserializable. Nothing
+// serializes a *config.Config today, but that is a property of the current
+// call sites rather than of the types, and report, doctor and the MCP tools
+// serialize a growing amount of state. Tagging both ways makes a leak
+// structurally impossible instead of merely absent.
+func TestEverySecretFieldIsAlsoUnserializable(t *testing.T) {
+	var walk func(t *testing.T, rt reflect.Type, path string, seen map[reflect.Type]bool)
+	walk = func(t *testing.T, rt reflect.Type, path string, seen map[reflect.Type]bool) {
+		for rt.Kind() == reflect.Pointer || rt.Kind() == reflect.Slice || rt.Kind() == reflect.Array {
+			rt = rt.Elem()
+		}
+		if rt.Kind() != reflect.Struct || seen[rt] {
+			return
+		}
+		seen[rt] = true
+
+		for i := 0; i < rt.NumField(); i++ {
+			f := rt.Field(i)
+			if !f.IsExported() {
+				continue
+			}
+			where := path + "." + f.Name
+			if f.Tag.Get(secretTag) == "true" && f.Tag.Get("json") != "-" {
+				t.Errorf(`%s is tagged secret but its json tag is %q; it must be "-" so it cannot be serialized`, where, f.Tag.Get("json"))
+			}
+			walk(t, f.Type, where, seen)
+		}
+	}
+	walk(t, reflect.TypeOf(Config{}), "Config", map[reflect.Type]bool{})
+}
+
+// The end of the same argument: a config full of credentials, serialized, must
+// not contain any of them.
+func TestMarshallingAConfigLeaksNoCredentials(t *testing.T) {
+	const (
+		pw      = "sup3r-secret-password"
+		token   = "9876543:AAH-telegram-bot-token"
+		slack   = "https://hooks.slack.com/services/T00/B00/leaked"
+		discord = "https://discord.com/api/webhooks/1/leaked"
+		hook    = "https://example.com/hook?token=leaked"
+	)
+
+	cfg := &Config{
+		Servers: []ServerConfig{{Name: "pve1", Host: "10.0.0.1", Password: pw}},
+		Notify: notify.ProviderConfig{
+			Telegram: &notify.TelegramConfig{BotToken: token, ChatID: "42"},
+			Slack:    &notify.SlackConfig{WebhookURL: slack},
+			Discord:  &notify.DiscordConfig{WebhookURL: discord},
+			Webhook:  &notify.WebhookConfig{URL: hook},
+		},
+	}
+
+	data, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	for _, secret := range []string{pw, token, slack, discord, hook} {
+		if strings.Contains(string(data), secret) {
+			t.Errorf("serialized config contains %q\n%s", secret, data)
+		}
+	}
+}

--- a/internal/notify/config.go
+++ b/internal/notify/config.go
@@ -9,21 +9,27 @@ const (
 	ChannelWebhook  Channel = "webhook"
 )
 
+// The credential fields below carry json:"-" so they cannot be serialized at
+// all, and secret:"true" so config.hasSecrets finds them without having to be
+// told about each new section. Nothing serializes a *config.Config today, but
+// that is a property of the current call sites rather than of these types, and
+// report, doctor and the MCP tools all serialize a growing amount of state.
+
 type TelegramConfig struct {
-	BotToken string `yaml:"bot_token" json:"bot_token"`
+	BotToken string `yaml:"bot_token" json:"-" secret:"true"`
 	ChatID   string `yaml:"chat_id" json:"chat_id"`
 }
 
 type SlackConfig struct {
-	WebhookURL string `yaml:"webhook_url" json:"webhook_url"`
+	WebhookURL string `yaml:"webhook_url" json:"-" secret:"true"`
 }
 
 type DiscordConfig struct {
-	WebhookURL string `yaml:"webhook_url" json:"webhook_url"`
+	WebhookURL string `yaml:"webhook_url" json:"-" secret:"true"`
 }
 
 type WebhookConfig struct {
-	URL string `yaml:"url" json:"url"`
+	URL string `yaml:"url" json:"-" secret:"true"`
 }
 
 type ProviderConfig struct {

--- a/internal/report/report_test.go
+++ b/internal/report/report_test.go
@@ -4,11 +4,14 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/Higangssh/homebutler/internal/config"
 	"github.com/Higangssh/homebutler/internal/docker"
 	"github.com/Higangssh/homebutler/internal/inventory"
+	"github.com/Higangssh/homebutler/internal/notify"
 	"github.com/Higangssh/homebutler/internal/ports"
 	"github.com/Higangssh/homebutler/internal/system"
 )
@@ -289,5 +292,62 @@ func TestCountPublicPortsMatchesIsPublicBind(t *testing.T) {
 
 	if got := countPublicPorts(pp); got != want {
 		t.Errorf("countPublicPorts = %d, ports.IsPublicBind classifies %d as public", got, want)
+	}
+}
+
+// report takes the config and writes snapshots to disk that persist for as
+// long as retention keeps them. Neither the report nor the snapshot has any
+// reason to carry a credential, and the config fields are tagged json:"-" so
+// they cannot. This is the behavioural end of that: give Run a config full of
+// secrets and check that nothing it produces contains one.
+func TestReportAndSnapshotLeakNoCredentials(t *testing.T) {
+	const (
+		pw    = "sup3r-secret-password"
+		token = "9876543:AAH-telegram-bot-token"
+		slack = "https://hooks.slack.com/services/T00/B00/leaked"
+	)
+
+	cfg := &config.Config{
+		Servers: []config.ServerConfig{{Name: "pve1", Host: "10.0.0.1", Local: true, Password: pw}},
+		Notify: notify.ProviderConfig{
+			Telegram: &notify.TelegramConfig{BotToken: token, ChatID: "42"},
+			Slack:    &notify.SlackConfig{WebhookURL: slack},
+		},
+	}
+
+	dir := t.TempDir()
+	rep, err := Run(cfg, fakeFuncs(nil, nil), Options{SnapshotDir: dir, Keep: 3})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	reportJSON, err := json.Marshal(rep)
+	if err != nil {
+		t.Fatalf("marshal report: %v", err)
+	}
+
+	files, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading snapshot dir: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatal("no snapshot was written, so this test is not checking what it claims to")
+	}
+
+	haystacks := map[string]string{"report --json": string(reportJSON)}
+	for _, f := range files {
+		data, err := os.ReadFile(filepath.Join(dir, f.Name()))
+		if err != nil {
+			t.Fatalf("reading %s: %v", f.Name(), err)
+		}
+		haystacks[f.Name()] = string(data)
+	}
+
+	for where, body := range haystacks {
+		for _, secret := range []string{pw, token, slack} {
+			if strings.Contains(body, secret) {
+				t.Errorf("%s contains the credential %q", where, secret)
+			}
+		}
 	}
 }


### PR DESCRIPTION
`config.Load` refuses a world-readable config file when it holds plaintext secrets. It decided that with `hasSecrets`, which inspected `servers[].password` and nothing else — so a config whose only credential was a Telegram bot token or a Slack webhook never reached the check at all.

That is the common case, not a rare one. `watch` notifications are set up far more often than SSH passwords, so for most people who have a credential in their config, the guard has never run.

## Why a walk instead of adding four lines

The obvious fix is to teach `hasSecrets` about the notify fields. That is what created this: a function far away from the fields it is about, which every credential-bearing section since has had to be remembered in. Proxmox (#32) would have been the next one, and its API token would have bypassed the check exactly as these did.

`hasSecrets` now walks the config for fields tagged `secret:"true"`. A field declares what it is, next to itself, and a section added later is covered by tagging its credential rather than by editing a list somewhere else.

## The same fields are tagged `json:"-"`

Nothing serializes a `*config.Config` today — `handleConfig` builds its response by hand and masks the password as `••••••`. But that is a property of the current call sites rather than of the types, and `report`, `doctor` and the MCP tools serialize a growing amount of state. A field that cannot be serialized cannot leak by accident later.

`TestEverySecretFieldIsAlsoUnserializable` walks the config type and fails if a field is tagged one way and not the other, so the two cannot drift apart.

## Verified against the bug, not just against itself

Both halves were confirmed to fail with the tag removed before the tag went in:

```
--- FAIL: TestHasSecretsFindsNotifyCredentials/telegram_bot_token
    a config holding only this credential was treated as having no secrets,
    so its file permissions were never checked

--- FAIL: TestMarshallingAConfigLeaksNoCredentials
    serialized config contains "9876543:AAH-telegram-bot-token"
```

`report` is covered end to end rather than only at the type level: `Run` is given a config full of credentials and both the report JSON and the snapshot files written to disk are checked for them. Snapshots matter here because they persist for as long as retention keeps them.

Local note: `TestResolveBackupDir` fails on Windows for path-separator reasons, on a clean tree as well. Unrelated.

Closes #61.
