### PR TITLE
feat: restart systemd units and pm2 apps, not only containers

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,7 +354,37 @@ alerts:
       metric: cpu
       threshold: 90
       action: notify
+
+    - name: elsa-monitor-down
+      metric: container
+      kind: systemd          # docker (default) | systemd | pm2
+      watch: [lh-elsa-monitor.service]
+      action: restart
 ```
+
+### Restarting things that are not containers
+
+`action: restart` restarts Docker containers unless the rule says otherwise.
+`kind: systemd` or `kind: pm2` points it at a service or a PM2 app instead.
+
+The kind is written on the rule rather than looked up from the watch list, so
+restarting a host service is something you asked for in the config. It also
+means every rule written before `kind` existed keeps meaning exactly what it
+meant.
+
+Two things worth knowing before using it:
+
+**`systemctl restart` needs root or a polkit rule.** Running homebutler
+unprivileged, a systemd restart will be refused, reported as failed, and
+warned about when `alerts --watch` starts rather than when the rule first
+fires.
+
+**A target that is flapping is not restarted.** Restarting something already
+in a restart loop feeds the loop, and most systemd units carry
+`Restart=always`, so homebutler restarting them fights systemd's own backoff.
+The thresholds are the `watch.flapping` ones above, and the skip is reported
+rather than counted as either success or failure. This applies to Docker
+targets too.
 
 Legacy `~/.homebutler/watch/config.json` is still read as a fallback for watch-specific settings, and legacy `alerts.yaml` notify/webhook provider settings are still accepted for older setups.
 

--- a/cmd/alerts.go
+++ b/cmd/alerts.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/Higangssh/homebutler/internal/alerts"
 	"github.com/Higangssh/homebutler/internal/config"
 	"github.com/Higangssh/homebutler/internal/docker"
+	"github.com/Higangssh/homebutler/internal/watch"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -314,13 +316,75 @@ func runSelfHealingWatch(interval time.Duration, rulesCfg *alerts.AlertsConfig) 
 		cancel()
 	}()
 
+	warnUnprivilegedSystemdRules(rulesCfg)
+
 	fmt.Fprintf(os.Stderr, "🛡️ Self-Healing active — watching %d rules (interval: %s, Ctrl+C to stop)\n\n",
 		len(rulesCfg.Rules), interval)
 
-	events := alerts.WatchRules(ctx, interval, rulesCfg)
+	// Restarting a target that is already in a restart loop feeds the loop, so
+	// the playbook asks the recorded incident history before acting. A watch
+	// directory that cannot be resolved means no history to consult, not a
+	// reason to refuse to run.
+	var flap alerts.FlapChecker
+	if dir, err := watch.WatchDir(); err == nil {
+		flap = watch.IncidentHistory{Dir: dir, Flapping: resolveFlappingConfig(dir)}
+	}
+
+	events := alerts.WatchRules(ctx, interval, rulesCfg, flap)
 	for e := range events {
 		fmt.Println(e)
 	}
 	fmt.Fprintln(os.Stderr, "\n👋 Stopped watching.")
 	return nil
+}
+
+// resolveFlappingConfig resolves the flapping thresholds the way `watch start`
+// does: config.yaml wins over watch/config.json, defaults fill the rest. The
+// two must not disagree about what counts as flapping, or a target would be
+// suppressed by one command and restarted by the other.
+func resolveFlappingConfig(dir string) watch.FlappingConfig {
+	watchCfg, err := watch.LoadWatchConfig(dir)
+	if err != nil || watchCfg == nil {
+		d := watch.DefaultWatchConfig()
+		watchCfg = &d
+	}
+	if cfg != nil {
+		watchCfg.Flapping = cfg.Watch.Flapping
+	}
+	return watchCfg.Flapping
+}
+
+// warnUnprivilegedSystemdRules says up front that a systemd restart rule will
+// not work, rather than letting the user find out when it matters.
+//
+// systemctl restart needs root or a polkit rule. A remediation that silently
+// no-ops is worse than one that was never configured, and the moment it fires
+// is the worst time to discover the problem.
+func warnUnprivilegedSystemdRules(rulesCfg *alerts.AlertsConfig) {
+	if rulesCfg == nil || runtime.GOOS == "windows" || os.Geteuid() == 0 {
+		return
+	}
+
+	var names []string
+	for _, rule := range rulesCfg.Rules {
+		if rule.Action == "restart" && rule.EffectiveKind() == watch.KindSystemd {
+			names = append(names, rule.Name)
+		}
+	}
+	if len(names) == 0 {
+		return
+	}
+
+	fmt.Fprintf(os.Stderr,
+		"⚠️  %s restart systemd units but homebutler is not running as root: %s\n"+
+			"   systemctl will refuse, and the restart will be reported as failed.\n"+
+			"   Run as root, or grant a polkit rule for the units involved.\n\n",
+		plural(len(names), "rule"), strings.Join(names, ", "))
+}
+
+func plural(n int, noun string) string {
+	if n == 1 {
+		return "1 " + noun + " will"
+	}
+	return fmt.Sprintf("%d %ss will", n, noun)
 }

--- a/internal/alerts/playbook.go
+++ b/internal/alerts/playbook.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/Higangssh/homebutler/internal/docker"
+	"github.com/Higangssh/homebutler/internal/watch"
 )
 
 // ActionResult holds the outcome of a playbook action.
@@ -81,11 +82,24 @@ func IsDangerousCommand(cmd string) bool {
 	return false
 }
 
+// FlapChecker reports whether a target is in a restart loop right now.
+//
+// Restarting something that is already restarting feeds the loop, and most
+// systemd units carry Restart=always, so homebutler restarting them is at best
+// redundant and at worst fighting systemd's own backoff. Implemented by
+// internal/watch from the recorded incident history; a nil checker disables
+// the suppression.
+type FlapChecker interface {
+	IsFlapping(target string) bool
+}
+
 // ExecuteAction runs the appropriate playbook action for a triggered rule.
-func ExecuteAction(rule Rule) PlaybookResult {
+//
+// flap may be nil, which disables flapping suppression.
+func ExecuteAction(rule Rule, flap FlapChecker) PlaybookResult {
 	switch rule.Action {
 	case "restart":
-		return executeRestart(rule)
+		return executeRestart(rule, flap)
 	case "exec":
 		return executeExec(rule)
 	case "notify":
@@ -95,15 +109,35 @@ func ExecuteAction(rule Rule) PlaybookResult {
 	}
 }
 
-func executeRestart(rule Rule) PlaybookResult {
+func executeRestart(rule Rule, flap FlapChecker) PlaybookResult {
 	if len(rule.Watch) == 0 {
-		return PlaybookResult{Action: "restart", Success: false, Output: "no containers to restart"}
+		return PlaybookResult{Action: "restart", Success: false, Output: "no targets to restart"}
 	}
 
-	var failed []string
-	var restarted []string
+	kind := rule.EffectiveKind()
+	if !validKind(kind) {
+		return PlaybookResult{
+			Action:  "restart",
+			Success: false,
+			Output:  fmt.Sprintf("unknown kind %q (supported: %s)", kind, strings.Join(watch.Kinds(), ", ")),
+		}
+	}
+
+	var failed, restarted, skipped []string
 	for _, name := range rule.Watch {
-		_, err := docker.Restart(name)
+		if flap != nil && flap.IsFlapping(name) {
+			// Not a failure. The target is already restarting on its own and
+			// adding to that is the pathology, not the fix.
+			skipped = append(skipped, name)
+			continue
+		}
+
+		var err error
+		if kind == watch.KindDocker {
+			_, err = docker.Restart(name)
+		} else {
+			_, err = watch.Restart(kind, name, nil)
+		}
 		if err != nil {
 			failed = append(failed, fmt.Sprintf("%s: %v", name, err))
 		} else {
@@ -115,7 +149,16 @@ func executeRestart(rule Rule) PlaybookResult {
 		return PlaybookResult{
 			Action:  "restart",
 			Success: false,
-			Output:  fmt.Sprintf("restarted: [%s], failed: [%s]", strings.Join(restarted, ", "), strings.Join(failed, "; ")),
+			Output:  restartSummary(restarted, skipped, failed),
+		}
+	}
+	if len(restarted) == 0 && len(skipped) > 0 {
+		// Everything was suppressed. Reporting success would claim a
+		// remediation that did not happen.
+		return PlaybookResult{
+			Action:  "restart",
+			Success: false,
+			Output:  restartSummary(restarted, skipped, failed),
 		}
 	}
 
@@ -173,4 +216,42 @@ func executeExec(rule Rule) PlaybookResult {
 		Success: true,
 		Output:  output,
 	}
+}
+
+// EffectiveKind returns the rule's target kind, defaulting to docker so that
+// configs written before kind existed keep meaning what they meant.
+func (r Rule) EffectiveKind() string {
+	if r.Kind == "" {
+		return watch.KindDocker
+	}
+	return r.Kind
+}
+
+func validKind(kind string) bool {
+	for _, k := range watch.Kinds() {
+		if k == kind {
+			return true
+		}
+	}
+	return false
+}
+
+// restartSummary reports every outcome rather than only the good one. A
+// suppressed target is neither a success nor a failure and saying so is the
+// difference between "nothing needed doing" and "we chose not to".
+func restartSummary(restarted, skipped, failed []string) string {
+	var parts []string
+	if len(restarted) > 0 {
+		parts = append(parts, fmt.Sprintf("restarted: [%s]", strings.Join(restarted, ", ")))
+	}
+	if len(skipped) > 0 {
+		parts = append(parts, fmt.Sprintf("skipped while flapping: [%s]", strings.Join(skipped, ", ")))
+	}
+	if len(failed) > 0 {
+		parts = append(parts, fmt.Sprintf("failed: [%s]", strings.Join(failed, "; ")))
+	}
+	if len(parts) == 0 {
+		return "nothing to restart"
+	}
+	return strings.Join(parts, ", ")
 }

--- a/internal/alerts/playbook_test.go
+++ b/internal/alerts/playbook_test.go
@@ -41,7 +41,7 @@ func TestIsDangerousCommandAllowed(t *testing.T) {
 
 func TestExecuteActionNotify(t *testing.T) {
 	rule := Rule{Action: "notify"}
-	result := ExecuteAction(rule)
+	result := ExecuteAction(rule, nil)
 	if !result.Success {
 		t.Error("notify action should succeed")
 	}
@@ -52,7 +52,7 @@ func TestExecuteActionNotify(t *testing.T) {
 
 func TestExecuteActionExecSafe(t *testing.T) {
 	rule := Rule{Action: "exec", Exec: "echo hello"}
-	result := ExecuteAction(rule)
+	result := ExecuteAction(rule, nil)
 	if !result.Success {
 		t.Errorf("exec 'echo hello' should succeed: %s", result.Output)
 	}
@@ -63,7 +63,7 @@ func TestExecuteActionExecSafe(t *testing.T) {
 
 func TestExecuteActionExecDangerous(t *testing.T) {
 	rule := Rule{Action: "exec", Exec: "rm -rf /"}
-	result := ExecuteAction(rule)
+	result := ExecuteAction(rule, nil)
 	if result.Success {
 		t.Error("dangerous command should be blocked")
 	}
@@ -74,7 +74,7 @@ func TestExecuteActionExecDangerous(t *testing.T) {
 
 func TestExecuteActionExecEmpty(t *testing.T) {
 	rule := Rule{Action: "exec", Exec: ""}
-	result := ExecuteAction(rule)
+	result := ExecuteAction(rule, nil)
 	if result.Success {
 		t.Error("empty exec should fail")
 	}
@@ -82,7 +82,7 @@ func TestExecuteActionExecEmpty(t *testing.T) {
 
 func TestExecuteActionUnknown(t *testing.T) {
 	rule := Rule{Action: "unknown"}
-	result := ExecuteAction(rule)
+	result := ExecuteAction(rule, nil)
 	if result.Success {
 		t.Error("unknown action should fail")
 	}
@@ -127,7 +127,7 @@ func TestCooldownTrackerExpired(t *testing.T) {
 
 func TestExecuteRestartNoContainers(t *testing.T) {
 	rule := Rule{Action: "restart", Watch: nil}
-	result := ExecuteAction(rule)
+	result := ExecuteAction(rule, nil)
 	if result.Success {
 		t.Error("restart with no containers should fail")
 	}
@@ -135,7 +135,7 @@ func TestExecuteRestartNoContainers(t *testing.T) {
 
 func TestExecTimeout(t *testing.T) {
 	rule := Rule{Action: "exec", Exec: "sleep 10", Timeout: "1s"}
-	result := ExecuteAction(rule)
+	result := ExecuteAction(rule, nil)
 	if result.Success {
 		t.Error("long-running command should fail with timeout")
 	}
@@ -146,7 +146,7 @@ func TestExecTimeout(t *testing.T) {
 
 func TestExecDefaultTimeout(t *testing.T) {
 	rule := Rule{Action: "exec", Exec: "echo fast"}
-	result := ExecuteAction(rule)
+	result := ExecuteAction(rule, nil)
 	if !result.Success {
 		t.Errorf("fast command should succeed: %s", result.Output)
 	}
@@ -154,7 +154,7 @@ func TestExecDefaultTimeout(t *testing.T) {
 
 func TestExecCustomTimeout(t *testing.T) {
 	rule := Rule{Action: "exec", Exec: "echo ok", Timeout: "5s"}
-	result := ExecuteAction(rule)
+	result := ExecuteAction(rule, nil)
 	if !result.Success {
 		t.Errorf("command should succeed within timeout: %s", result.Output)
 	}
@@ -194,8 +194,65 @@ func TestIsDangerousCommandComment(t *testing.T) {
 func TestExecWithStrings(t *testing.T) {
 	// Verify the strings import is used
 	rule := Rule{Action: "exec", Exec: "echo hello"}
-	result := ExecuteAction(rule)
+	result := ExecuteAction(rule, nil)
 	if result.Output != "hello" {
 		t.Errorf("expected 'hello', got %q", result.Output)
+	}
+}
+
+// fakeFlap reports the listed targets as flapping.
+type fakeFlap map[string]bool
+
+func (f fakeFlap) IsFlapping(target string) bool { return f[target] }
+
+// Restarting something already in a restart loop feeds the loop. Most systemd
+// units carry Restart=always, so homebutler restarting them is redundant at
+// best and fighting systemd's backoff at worst.
+func TestRestartSkipsAFlappingTarget(t *testing.T) {
+	rule := Rule{
+		Name:   "elsa-down",
+		Action: "restart",
+		Kind:   "systemd",
+		Watch:  []string{"lh-elsa-monitor.service"},
+	}
+
+	res := ExecuteAction(rule, fakeFlap{"lh-elsa-monitor.service": true})
+
+	if res.Success {
+		t.Error("nothing was restarted, so this must not report success")
+	}
+	if !strings.Contains(res.Output, "skipped while flapping") {
+		t.Errorf("the output should say why nothing happened, got %q", res.Output)
+	}
+	if strings.Contains(res.Output, "failed") {
+		t.Errorf("a suppressed restart is not a failure, got %q", res.Output)
+	}
+}
+
+// A rule with no kind is a rule written before kind existed, and it has to
+// keep meaning exactly what it meant.
+func TestRuleKindDefaultsToDocker(t *testing.T) {
+	if got := (Rule{}).EffectiveKind(); got != "docker" {
+		t.Errorf("EffectiveKind() = %q, want docker", got)
+	}
+	if got := (Rule{Kind: "systemd"}).EffectiveKind(); got != "systemd" {
+		t.Errorf("EffectiveKind() = %q, want systemd", got)
+	}
+}
+
+// An unknown kind is refused before anything is run, and the message lists
+// what would have worked.
+func TestRestartRejectsAnUnknownKind(t *testing.T) {
+	rule := Rule{Name: "k8s", Action: "restart", Kind: "kubernetes", Watch: []string{"pod"}}
+
+	res := ExecuteAction(rule, nil)
+
+	if res.Success {
+		t.Error("an unknown kind must not report success")
+	}
+	for _, want := range []string{"kubernetes", "docker", "systemd", "pm2"} {
+		if !strings.Contains(res.Output, want) {
+			t.Errorf("output should mention %q, got %q", want, res.Output)
+		}
 	}
 }

--- a/internal/alerts/rules.go
+++ b/internal/alerts/rules.go
@@ -3,25 +3,33 @@ package alerts
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/Higangssh/homebutler/internal/notify"
+	"github.com/Higangssh/homebutler/internal/watch"
 	"gopkg.in/yaml.v3"
 )
 
 // Rule defines a single alert rule from the YAML configuration.
 type Rule struct {
-	Name       string   `yaml:"name" json:"name"`
-	Metric     string   `yaml:"metric" json:"metric"`       // "cpu", "memory", "disk", "container"
-	Threshold  float64  `yaml:"threshold" json:"threshold"` // percentage for cpu/memory/disk
-	Duration   string   `yaml:"duration,omitempty" json:"duration,omitempty"`
-	Watch      []string `yaml:"watch,omitempty" json:"watch,omitempty"` // container names
-	Action     string   `yaml:"action" json:"action"`                   // "notify", "restart", "exec"
-	Exec       string   `yaml:"exec,omitempty" json:"exec,omitempty"`
-	Timeout    string   `yaml:"timeout,omitempty" json:"timeout,omitempty"` // exec timeout (default 30s)
-	Notify     string   `yaml:"notify,omitempty" json:"notify,omitempty"`   // "webhook"
-	Cooldown   string   `yaml:"cooldown,omitempty" json:"cooldown,omitempty"`
-	MaxRetries int      `yaml:"max_retries,omitempty" json:"max_retries,omitempty"`
+	Name      string   `yaml:"name" json:"name"`
+	Metric    string   `yaml:"metric" json:"metric"`       // "cpu", "memory", "disk", "container"
+	Threshold float64  `yaml:"threshold" json:"threshold"` // percentage for cpu/memory/disk
+	Duration  string   `yaml:"duration,omitempty" json:"duration,omitempty"`
+	Watch     []string `yaml:"watch,omitempty" json:"watch,omitempty"` // target names
+	// Kind is what the names in Watch are: "docker" (default), "systemd" or
+	// "pm2". Written on the rule rather than looked up in the watch list so
+	// that restarting a host service is something asked for in the config
+	// rather than implied by a name appearing in another file, and so existing
+	// docker-only configs keep meaning exactly what they meant.
+	Kind       string `yaml:"kind,omitempty" json:"kind,omitempty"`
+	Action     string `yaml:"action" json:"action"` // "notify", "restart", "exec"
+	Exec       string `yaml:"exec,omitempty" json:"exec,omitempty"`
+	Timeout    string `yaml:"timeout,omitempty" json:"timeout,omitempty"` // exec timeout (default 30s)
+	Notify     string `yaml:"notify,omitempty" json:"notify,omitempty"`   // "webhook"
+	Cooldown   string `yaml:"cooldown,omitempty" json:"cooldown,omitempty"`
+	MaxRetries int    `yaml:"max_retries,omitempty" json:"max_retries,omitempty"`
 }
 
 // AlertsConfig is the top-level YAML structure for self-healing rules.
@@ -117,6 +125,12 @@ func validateRules(rules []Rule) error {
 			return fmt.Errorf("duplicate rule name: %s", r.Name)
 		}
 		names[r.Name] = true
+
+		// Caught at load rather than when the rule fires. A typo here would
+		// otherwise sit quietly until the moment remediation was needed.
+		if r.Kind != "" && !validKind(r.Kind) {
+			return fmt.Errorf("rule %q: unknown kind %q (must be %s)", r.Name, r.Kind, strings.Join(watch.Kinds(), ", "))
+		}
 
 		switch r.Metric {
 		case "cpu", "memory", "disk":

--- a/internal/alerts/watcher.go
+++ b/internal/alerts/watcher.go
@@ -199,7 +199,8 @@ func FormatEvent(e Event) string {
 
 // WatchRules runs the self-healing watch loop using YAML-defined rules.
 // Returns a channel of formatted log lines. Cancel the context to stop.
-func WatchRules(ctx context.Context, interval time.Duration, rulesCfg *AlertsConfig) <-chan string {
+// flap may be nil, which disables flapping suppression on restart actions.
+func WatchRules(ctx context.Context, interval time.Duration, rulesCfg *AlertsConfig, flap FlapChecker) <-chan string {
 	ch := make(chan string, 32)
 
 	go func() {
@@ -207,7 +208,7 @@ func WatchRules(ctx context.Context, interval time.Duration, rulesCfg *AlertsCon
 		cooldowns := newCooldownTracker()
 
 		// Check immediately
-		evaluateRules(rulesCfg, cooldowns, ch)
+		evaluateRules(rulesCfg, cooldowns, ch, flap)
 
 		ticker := time.NewTicker(interval)
 		defer ticker.Stop()
@@ -217,7 +218,7 @@ func WatchRules(ctx context.Context, interval time.Duration, rulesCfg *AlertsCon
 			case <-ctx.Done():
 				return
 			case <-ticker.C:
-				evaluateRules(rulesCfg, cooldowns, ch)
+				evaluateRules(rulesCfg, cooldowns, ch, flap)
 			}
 		}
 	}()
@@ -225,7 +226,7 @@ func WatchRules(ctx context.Context, interval time.Duration, rulesCfg *AlertsCon
 	return ch
 }
 
-func evaluateRules(rulesCfg *AlertsConfig, cooldowns *cooldownTracker, ch chan<- string) {
+func evaluateRules(rulesCfg *AlertsConfig, cooldowns *cooldownTracker, ch chan<- string, flap FlapChecker) {
 	now := time.Now()
 	ts := now.Format("15:04:05")
 
@@ -307,7 +308,7 @@ func evaluateRules(rulesCfg *AlertsConfig, cooldowns *cooldownTracker, ch chan<-
 		ch <- fmt.Sprintf("  ⏱️  %s  %s  %s triggered (%s)", ts, icon, rule.Name, details)
 
 		// Execute action
-		result := ExecuteAction(rule)
+		result := ExecuteAction(rule, flap)
 		resultStatus := "success"
 		if !result.Success {
 			resultStatus = "failed"

--- a/internal/watch/restart.go
+++ b/internal/watch/restart.go
@@ -1,0 +1,101 @@
+package watch
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Higangssh/homebutler/internal/util"
+)
+
+// Restart restarts a target of the given kind.
+//
+// The monitors have been able to detect systemd and pm2 incidents since those
+// landed, but nothing could act on one: the only remediation path called
+// docker.Restart, so `action: restart` on a systemd unit failed with a docker
+// error about a container that does not exist.
+//
+// run is the command runner, matching the monitors. A nil run uses the real
+// one, so callers that are not testing do not have to supply it.
+func Restart(kind, name string, run CommandRunner) (string, error) {
+	if strings.TrimSpace(name) == "" {
+		return "", fmt.Errorf("no target name to restart")
+	}
+	if run == nil {
+		run = util.RunCmd
+	}
+
+	switch kind {
+	case KindSystemd:
+		return restartSystemd(name, run)
+	case KindPM2:
+		return restartPM2(name, run)
+	default:
+		return "", fmt.Errorf("cannot restart %q: unknown target kind %q", name, kind)
+	}
+}
+
+func restartSystemd(unit string, run CommandRunner) (string, error) {
+	out, err := run("systemctl", "restart", unit)
+	if err != nil {
+		// systemctl needs root or a polkit rule. Saying so is the difference
+		// between a user fixing their setup and one reading a bare exit
+		// status, and this is the failure they are most likely to hit.
+		if isPrivilegeRefusal(out, err) {
+			return out, fmt.Errorf("restarting %s needs root: run homebutler as root or grant a polkit rule (%v)", unit, err)
+		}
+		return out, fmt.Errorf("restarting %s: %v: %s", unit, err, out)
+	}
+	return fmt.Sprintf("systemctl restart %s", unit), nil
+}
+
+func restartPM2(app string, run CommandRunner) (string, error) {
+	out, err := run("pm2", "restart", app)
+	if err != nil {
+		return out, fmt.Errorf("restarting %s: %v: %s", app, err, out)
+	}
+	return fmt.Sprintf("pm2 restart %s", app), nil
+}
+
+// isPrivilegeRefusal recognises the ways systemctl reports that it was not
+// allowed to do the thing, rather than that the thing failed.
+func isPrivilegeRefusal(out string, err error) bool {
+	if util.IsPermissionError(err) {
+		return true
+	}
+	lower := strings.ToLower(out)
+	return strings.Contains(lower, "access denied") ||
+		strings.Contains(lower, "permission denied") ||
+		strings.Contains(lower, "interactive authentication required") ||
+		strings.Contains(lower, "authentication is required")
+}
+
+// IncidentHistory answers whether a target is flapping, from the incidents
+// already recorded on disk. It satisfies the FlapChecker that the alerts
+// playbook consults before restarting anything.
+type IncidentHistory struct {
+	Dir      string
+	Flapping FlappingConfig
+	// Now is for tests. Nil uses time.Now.
+	Now func() time.Time
+}
+
+// IsFlapping reports whether target has restarted often enough recently to
+// count as a loop. Errors read as "not flapping": a missing or unreadable
+// incident directory is not evidence of a loop, and refusing to remediate on
+// the strength of a read error would be the wrong way to be careful.
+func (h IncidentHistory) IsFlapping(target string) bool {
+	if h.Dir == "" {
+		return false
+	}
+	incidents, err := ListIncidents(h.Dir)
+	if err != nil || len(incidents) == 0 {
+		return false
+	}
+	now := time.Now
+	if h.Now != nil {
+		now = h.Now
+	}
+	cfg := h.Flapping
+	return cfg.Check(target, incidents, now()).IsFlapping
+}

--- a/internal/watch/restart_test.go
+++ b/internal/watch/restart_test.go
@@ -1,0 +1,132 @@
+package watch
+
+import (
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func recordingRunner(out string, err error) (CommandRunner, *[]string) {
+	var calls []string
+	return func(name string, args ...string) (string, error) {
+		calls = append(calls, name+" "+strings.Join(args, " "))
+		return out, err
+	}, &calls
+}
+
+// The detection half for systemd and pm2 has existed since those monitors
+// landed; nothing could act on an incident because the only remediation path
+// called docker.Restart.
+func TestRestartDispatchesByKind(t *testing.T) {
+	tests := []struct {
+		kind string
+		name string
+		want string
+	}{
+		{KindSystemd, "lh-elsa-monitor.service", "systemctl restart lh-elsa-monitor.service"},
+		{KindPM2, "api", "pm2 restart api"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.kind, func(t *testing.T) {
+			run, calls := recordingRunner("", nil)
+			out, err := Restart(tt.kind, tt.name, run)
+			if err != nil {
+				t.Fatalf("Restart: %v", err)
+			}
+			if len(*calls) != 1 || (*calls)[0] != tt.want {
+				t.Errorf("ran %v, want %q", *calls, tt.want)
+			}
+			if !strings.Contains(out, tt.name) {
+				t.Errorf("output should name the target, got %q", out)
+			}
+		})
+	}
+}
+
+// systemctl needs root or a polkit rule, and that is the failure a homelab
+// user is most likely to hit. A bare exit status leaves them guessing.
+func TestRestartSystemdExplainsAPrivilegeRefusal(t *testing.T) {
+	for _, output := range []string{
+		"Failed to restart foo.service: Access denied",
+		"Interactive authentication required.",
+		"Failed to restart foo.service: Permission denied",
+	} {
+		run, _ := recordingRunner(output, errors.New("exit status 1"))
+		_, err := Restart(KindSystemd, "foo.service", run)
+		if err == nil {
+			t.Fatalf("a refused restart must be an error (%q)", output)
+		}
+		if !strings.Contains(err.Error(), "needs root") {
+			t.Errorf("refusal for %q should mention root, got: %v", output, err)
+		}
+	}
+}
+
+// A unit that genuinely failed to start is a different problem from one we
+// were not allowed to touch, and the message should not confuse the two.
+func TestRestartSystemdReportsAGenuineFailureAsItself(t *testing.T) {
+	run, _ := recordingRunner("Job for foo.service failed because the control process exited", errors.New("exit status 1"))
+	_, err := Restart(KindSystemd, "foo.service", run)
+	if err == nil {
+		t.Fatal("expected an error")
+	}
+	if strings.Contains(err.Error(), "needs root") {
+		t.Errorf("a genuine failure should not be reported as a privilege problem: %v", err)
+	}
+}
+
+func TestRestartRejectsUnknownKindAndEmptyName(t *testing.T) {
+	run, calls := recordingRunner("", nil)
+
+	if _, err := Restart("kubernetes", "pod", run); err == nil {
+		t.Error("an unknown kind should be refused")
+	}
+	if _, err := Restart(KindSystemd, "  ", run); err == nil {
+		t.Error("an empty target name should be refused")
+	}
+	if len(*calls) != 0 {
+		t.Errorf("nothing should have been run, got %v", *calls)
+	}
+}
+
+// Errors read as "not flapping". A missing incident directory is not evidence
+// of a restart loop, and refusing to remediate because a read failed would be
+// the wrong way to be careful.
+func TestIncidentHistoryTreatsNoHistoryAsNotFlapping(t *testing.T) {
+	h := IncidentHistory{Dir: t.TempDir(), Flapping: DefaultWatchConfig().Flapping}
+	if h.IsFlapping("nginx") {
+		t.Error("an empty incident directory is not a restart loop")
+	}
+
+	var empty IncidentHistory
+	if empty.IsFlapping("nginx") {
+		t.Error("an unset directory is not a restart loop")
+	}
+}
+
+func TestIncidentHistoryDetectsARestartLoop(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Date(2026, 8, 24, 12, 0, 0, 0, time.UTC)
+
+	cfg := DefaultWatchConfig().Flapping
+	for i := 0; i < cfg.ShortThreshold+1; i++ {
+		inc := Incident{
+			ID:         "loop-" + string(rune('a'+i)),
+			Container:  "nginx",
+			DetectedAt: now.Add(-time.Duration(i) * time.Minute),
+		}
+		if err := SaveIncident(dir, &inc, 0); err != nil {
+			t.Fatalf("SaveIncident: %v", err)
+		}
+	}
+
+	h := IncidentHistory{Dir: dir, Flapping: cfg, Now: func() time.Time { return now }}
+	if !h.IsFlapping("nginx") {
+		t.Errorf("%d restarts inside %s should count as flapping", cfg.ShortThreshold+1, cfg.ShortWindow)
+	}
+	if h.IsFlapping("postgres") {
+		t.Error("another target's incidents must not make this one look like a loop")
+	}
+}

--- a/internal/watch/store.go
+++ b/internal/watch/store.go
@@ -12,6 +12,18 @@ import (
 	"time"
 )
 
+// The kinds of thing homebutler can watch. Spelled out here rather than as
+// bare strings in each place that compares one, so adding a kind is a change
+// in one file rather than a search.
+const (
+	KindDocker  = "docker"
+	KindSystemd = "systemd"
+	KindPM2     = "pm2"
+)
+
+// Kinds returns every valid target kind.
+func Kinds() []string { return []string{KindDocker, KindSystemd, KindPM2} }
+
 type Target struct {
 	Container string    `json:"container"`
 	Kind      string    `json:"kind,omitempty"` // "docker" | "systemd" | "pm2"
@@ -22,7 +34,7 @@ type Target struct {
 // EffectiveKind returns the target kind, defaulting to "docker".
 func (t Target) EffectiveKind() string {
 	if t.Kind == "" {
-		return "docker"
+		return KindDocker
 	}
 	return t.Kind
 }
@@ -33,7 +45,7 @@ func (t Target) EffectiveKind() string {
 // single inspect call is enough. Systemd and pm2 state is only meaningful when
 // compared against a previous poll, which is what `watch start` does.
 func (t Target) CheckSupported() bool {
-	return t.EffectiveKind() == "docker"
+	return t.EffectiveKind() == KindDocker
 }
 
 // EffectiveUnit returns the unit name, defaulting to Container.
@@ -101,11 +113,14 @@ func LoadTargets(dir string) ([]Target, error) {
 		return nil, fmt.Errorf("corrupt targets.json: %w", err)
 	}
 	// Validate kind values
-	validKinds := map[string]bool{"": true, "docker": true, "systemd": true, "pm2": true}
+	validKinds := map[string]bool{"": true}
+	for _, k := range Kinds() {
+		validKinds[k] = true
+	}
 	for i, t := range targets {
 		if !validKinds[t.Kind] {
 			fmt.Fprintf(os.Stderr, "warning: target %q has unknown kind %q, defaulting to docker\n", t.Container, t.Kind)
-			targets[i].Kind = "docker"
+			targets[i].Kind = KindDocker
 		}
 	}
 	return targets, nil


### PR DESCRIPTION
The monitors have detected systemd and pm2 incidents since those landed, and nothing could act on one. `executeRestart` called `docker.Restart` for every name in a rule's watch list, so `action: restart` on a systemd unit failed with a docker error about a container that does not exist. The workaround was `action: exec` with a raw `systemctl` line, which loses per-target reporting and sits behind a blocklist whose own comment says it is not a security boundary.

#49 called this a design issue rather than a patch and asked for four decisions. Here is what each became.

**Where the kind comes from.** A rule carries `kind: docker` (default), `systemd` or `pm2`. On the rule rather than resolved from the watch list, because restarting a host service should be something asked for in the config rather than implied by a name appearing in another file — adding a target to the watch list would otherwise silently change what an alert rule does. Existing rules have no `kind` and keep meaning exactly what they meant.

**Blast radius.** Answered by the above: writing `kind: systemd` *is* the opt-in. No second flag needed.

**Flapping.** Suppressed, for every kind rather than only the new ones. Restarting something already in a restart loop feeds the loop, and most systemd units carry `Restart=always`, so homebutler restarting them fights systemd's own backoff. The reasoning does not depend on the kind, and having it differ by kind would be arbitrary. A skip is reported as neither success nor failure — "we chose not to" is a different thing from "nothing needed doing".

**Privilege.** `systemctl` needs root or a polkit rule, and that is the failure a homelab user is most likely to hit. It is recognised and explained rather than surfaced as a bare exit status, and `alerts --watch` warns at startup rather than leaving it to be discovered when the rule first fires. A genuine unit failure is deliberately *not* reported as a privilege problem; they are different problems.

An unknown `kind` is refused when the config loads rather than when a rule fires. A typo would otherwise sit quietly until the moment remediation was needed.

## What I did not do

I said `config validate` should carry the privilege warning too. It turned out `config.AlertConfig` has no rules — they are parsed separately by `cmd` into `alerts.UserConfig` — so putting it there would mean teaching the config package about alerts rules, which is a coupling decision of its own and larger than this issue. The startup warning gives the same "told before it matters" benefit at the layer that already has the rules loaded.

## Also

The kind strings were spelled out in four places in `store.go` and are now constants, the same pattern this repository has been closing all week.

`watch list`'s empty message said "No containers being watched" while the list has held more than containers since systemd support landed; #46 changed that wording elsewhere and missed this one.

Local note: `TestResolveBackupDir` fails on Windows for path-separator reasons, on a clean tree as well. Unrelated.

Closes #49.
