### PR TITLE
docs: point the priorities at work that is still open

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,12 +55,19 @@ adding new ones.
 
 Working toward 1.0, which freezes the MCP tool surface and the JSON schema:
 
-- Complete MCP coverage (#54)
-- Close the detect/remediate gap in `watch` (#49)
+- Bound the incident directory in bytes, not only in files (#81)
+- Give `watch` a way to survive logout and reboot (#80)
+- Compare identities rather than counts, so a swap is not read as no change
+  (#58, #59)
+
+The first two are commitments the code already makes and does not keep. The
+third is the question the tool exists to answer, which is why it comes before
+adding more things to ask it about.
 
 New targets generally wait until after 1.0, so open an issue before starting one.
 Work already discussed and agreed in an issue keeps the terms it was given —
-Proxmox (#32) is proceeding on the plan in that thread.
+Proxmox (#32) is on Phase 2 now that read-only visibility has landed, with the
+dashboard tracked separately in #79 and the Phase 3 question still open in #62.
 
 ## Before submitting a PR
 


### PR DESCRIPTION
The Priorities section is where a new contributor looks to find work, and both
items in it shipped in v0.22.0 — MCP coverage in #71, #72 and #73, the watch
detect/remediate gap in #76. It was pointing at two finished things.

The three replacements are ordered by what is broken before what is missing.
#81 and #80 are promises the code already makes and does not keep: the incident
directory is capped in files but not in bytes, and `watch start` cannot outlive
the terminal that launched it. #58 and #59 are the question the tool exists to
answer, which is the reason they come before widening the set of things it can
be asked about.

The Proxmox paragraph now says where that work actually stands, since #78 split
into three: Phase 2 open on #32, the dashboard on #79, and the Phase 3 question
still unsettled on #62.

Nothing here changes what the project accepts — only which open work it points
at first.
