### PR TITLE
fix: refuse flag-shaped container arguments before routing to a remote host

### DIFF
--- a/internal/docker/docker.go
+++ b/internal/docker/docker.go
@@ -44,7 +44,7 @@ type ActionResult struct {
 }
 
 func Restart(name string) (*ActionResult, error) {
-	if !isValidName(name) {
+	if !ValidName(name) {
 		return nil, fmt.Errorf("invalid container name: %s", name)
 	}
 	out, err := util.DockerCmd("restart", name)
@@ -55,7 +55,7 @@ func Restart(name string) (*ActionResult, error) {
 }
 
 func Stop(name string) (*ActionResult, error) {
-	if !isValidName(name) {
+	if !ValidName(name) {
 		return nil, fmt.Errorf("invalid container name: %s", name)
 	}
 	out, err := util.DockerCmd("stop", name)
@@ -73,14 +73,11 @@ type LogsResult struct {
 }
 
 func Logs(name string, lines string) (*LogsResult, error) {
-	if !isValidName(name) {
+	if !ValidName(name) {
 		return nil, fmt.Errorf("invalid container name: %s", name)
 	}
-	// Validate lines is a positive integer
-	for _, c := range lines {
-		if c < '0' || c > '9' {
-			return nil, fmt.Errorf("invalid line count: %s (must be a positive integer)", lines)
-		}
+	if !ValidLines(lines) {
+		return nil, fmt.Errorf("invalid line count: %s (must be a positive integer)", lines)
 	}
 	out, err := util.DockerCmd("logs", "--tail", lines, name)
 	if err != nil {
@@ -108,7 +105,7 @@ type TopProcess struct {
 }
 
 func Top(name string) (*TopResult, error) {
-	if !isValidName(name) {
+	if !ValidName(name) {
 		return nil, fmt.Errorf("invalid container name: %s", name)
 	}
 	out, err := util.DockerCmd("top", name)
@@ -209,7 +206,7 @@ type Network struct {
 }
 
 func Inspect(name string) (*InspectResult, error) {
-	if !isValidName(name) {
+	if !ValidName(name) {
 		return nil, fmt.Errorf("invalid container name: %s", name)
 	}
 	out, err := util.DockerCmd("inspect", name)
@@ -431,13 +428,22 @@ func shortenDuration(s string) string {
 	return s
 }
 
-// isValidName prevents command injection by allowing only safe characters,
-// and blocks a leading dash so a name can never be parsed as a docker CLI
-// flag rather than an argument (CWE-88). Docker's own name grammar is
-// stricter — it also refuses a leading '_' or '.', which still pass here —
-// but the dash is the only leading character that creates flag ambiguity
-// for the commands this validates.
-func isValidName(name string) bool {
+// ValidName reports whether name is safe to hand to a docker command: only
+// characters a container name can carry, and no leading dash, which a command
+// parser would read as a flag rather than an argument (CWE-88).
+//
+// It is exported because the rule has to hold before the local-or-remote
+// decision in the MCP layer, not only where these functions run: remotely the
+// name becomes one shell-quoted element of a homebutler command line whose
+// own parser sees the dash first, so checking on the far side of the wire is
+// too late to answer with these words. The functions below still validate at
+// the point the name meets a real argv, because callers outside the MCP layer
+// (the CLI, alert remediation) arrive here directly.
+//
+// Docker's own name grammar is stricter — it also refuses a leading '_' or
+// '.', which still pass here — but the dash is the only leading character
+// that creates flag ambiguity for the commands this validates.
+func ValidName(name string) bool {
 	for _, c := range name {
 		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || //nolint:staticcheck // readability
 			(c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.') {
@@ -445,6 +451,22 @@ func isValidName(name string) bool {
 		}
 	}
 	return len(name) > 0 && name[0] != '-' && len(name) <= 128
+}
+
+// ValidLines reports whether lines is a tail count docker logs accepts: digits
+// only. A signed or flag-shaped value must be refused here and by the MCP
+// gate, because remotely it travels as an argument of the homebutler command
+// line and would otherwise come back parsed as a flag rather than a number.
+func ValidLines(lines string) bool {
+	if lines == "" {
+		return false
+	}
+	for _, c := range lines {
+		if c < '0' || c > '9' {
+			return false
+		}
+	}
+	return true
 }
 
 func splitLines(s string) []string {

--- a/internal/docker/docker_test.go
+++ b/internal/docker/docker_test.go
@@ -2,7 +2,7 @@ package docker
 
 import "testing"
 
-func TestIsValidName(t *testing.T) {
+func TestValidName(t *testing.T) {
 	tests := []struct {
 		name  string
 		input string
@@ -32,9 +32,9 @@ func TestIsValidName(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isValidName(tt.input)
+			got := ValidName(tt.input)
 			if got != tt.want {
-				t.Errorf("isValidName(%q) = %v, want %v", tt.input, got, tt.want)
+				t.Errorf("ValidName(%q) = %v, want %v", tt.input, got, tt.want)
 			}
 		})
 	}
@@ -167,13 +167,13 @@ func TestSplit(t *testing.T) {
 	}
 }
 
-func TestIsValidNameMaxLength(t *testing.T) {
+func TestValidNameMaxLength(t *testing.T) {
 	// Exactly 128 valid characters should be valid
 	name := make([]byte, 128)
 	for i := range name {
 		name[i] = 'a'
 	}
-	if !isValidName(string(name)) {
+	if !ValidName(string(name)) {
 		t.Error("expected 128-char valid name to be valid")
 	}
 
@@ -182,8 +182,34 @@ func TestIsValidNameMaxLength(t *testing.T) {
 	for i := range name {
 		name[i] = 'a'
 	}
-	if isValidName(string(name)) {
+	if ValidName(string(name)) {
 		t.Error("expected 129-char name to be invalid")
+	}
+}
+
+func TestValidLines(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		{"50", true},
+		{"0", true},
+		{"100000", true},
+		{"", false},
+		{"-5", false},
+		{"+5", false},
+		{"--json", false},
+		{"ten", false},
+		{"10x", false},
+		{"1 0", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			if got := ValidLines(tt.input); got != tt.want {
+				t.Errorf("ValidLines(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/mcp/container_args_test.go
+++ b/internal/mcp/container_args_test.go
@@ -1,0 +1,170 @@
+package mcp
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/Higangssh/homebutler/internal/config"
+)
+
+func rejectionOf(t *testing.T, s *Server, tool string, args map[string]any) string {
+	t.Helper()
+	_, err := s.executeTool(tool, args)
+	if err == nil {
+		t.Fatalf("%s with %v was accepted; expected a rejection", tool, args)
+	}
+	return err.Error()
+}
+
+// A flag-shaped name used to reach the remote homebutler as a bare argv
+// element whose cobra parser turned it into a flag: docker_restart came back
+// with help text and exit zero, reading as a restart that never happened.
+// The gate in executeTool refuses it before routing, so the answer is the
+// same words whichever machine would have answered — and no SSH connection
+// is ever attempted for an input that cannot be executed.
+func TestFlagShapedNameRefusedWithSameWordsOnBothPaths(t *testing.T) {
+	s := NewServer(&config.Config{
+		Servers: []config.ServerConfig{{Name: "pve1", Host: "192.0.2.1"}},
+	}, "test")
+
+	for _, tool := range []string{"docker_restart", "docker_stop", "docker_logs", "docker_top", "docker_inspect"} {
+		local := rejectionOf(t, s, tool, map[string]any{"name": "--help"})
+		remote := rejectionOf(t, s, tool, map[string]any{"server": "pve1", "name": "--help"})
+
+		want := "invalid container name: --help"
+		if local != want {
+			t.Errorf("%s local rejection = %q, want %q", tool, local, want)
+		}
+		if remote != local {
+			t.Errorf("%s pointed at a server answers %q, locally %q; the paths disagree", tool, remote, local)
+		}
+		// The rejection must come from the gate rather than a failed dial: on
+		// this config any real attempt would surface a connection error, and
+		// before the fix it surfaced success carrying help text instead.
+		if strings.Contains(remote, "ssh") || strings.Contains(remote, "connection") {
+			t.Errorf("%s reached the remote host before being rejected: %q", tool, remote)
+		}
+	}
+}
+
+// Remotely, a missing name used to travel as an empty argument and come back
+// as whatever the far side makes of it; locally it was refused outright.
+func TestMissingNameRejectedOnBothPaths(t *testing.T) {
+	s := NewServer(&config.Config{
+		Servers: []config.ServerConfig{{Name: "pve1", Host: "192.0.2.1"}},
+	}, "test")
+
+	for _, tool := range []string{"docker_restart", "docker_stop", "docker_logs", "docker_top", "docker_inspect"} {
+		local := rejectionOf(t, s, tool, map[string]any{})
+		remote := rejectionOf(t, s, tool, map[string]any{"server": "pve1"})
+
+		want := "missing required parameter: name"
+		if local != want || remote != want {
+			t.Errorf("%s missing name: local %q, remote %q, want %q", tool, local, remote, want)
+		}
+	}
+}
+
+// lines rides next to the name and had the same shape: "--json" became a
+// flag of the remote command rather than the bad number it is.
+func TestDockerLogsLinesRejectedBeforeRouting(t *testing.T) {
+	s := NewServer(&config.Config{
+		Servers: []config.ServerConfig{{Name: "pve1", Host: "192.0.2.1"}},
+	}, "test")
+
+	for _, lines := range []string{"--json", "-n", "ten", "10x"} {
+		local := rejectionOf(t, s, "docker_logs", map[string]any{"name": "web", "lines": lines})
+		remote := rejectionOf(t, s, "docker_logs", map[string]any{"server": "pve1", "name": "web", "lines": lines})
+
+		want := fmt.Sprintf("invalid line count: %s (must be a positive integer)", lines)
+		if local != want || remote != want {
+			t.Errorf("lines %q: local %q, remote %q, want %q", lines, local, remote, want)
+		}
+	}
+}
+
+// The gate itself, without routing: acceptance must hold for every forwarded
+// tool, and tools that forward nothing must pass through untouched.
+func TestValidateContainerArgs(t *testing.T) {
+	tests := []struct {
+		name    string
+		tool    string
+		args    map[string]any
+		wantErr string
+	}{
+		{"restart", "docker_restart", map[string]any{"name": "web"}, ""},
+		{"stop dotted name", "docker_stop", map[string]any{"name": "app.v2_1"}, ""},
+		{"logs default lines", "docker_logs", map[string]any{"name": "web"}, ""},
+		{"logs explicit lines", "docker_logs", map[string]any{"name": "web", "lines": "100"}, ""},
+		{"logs empty lines falls back to default", "docker_logs", map[string]any{"name": "web", "lines": ""}, ""},
+		{"top", "docker_top", map[string]any{"name": "web"}, ""},
+		{"inspect", "docker_inspect", map[string]any{"name": "web"}, ""},
+		{"missing name", "docker_restart", map[string]any{}, "missing required parameter: name"},
+		{"empty name counts as missing", "docker_stop", map[string]any{"name": ""}, "missing required parameter: name"},
+		{"long dash", "docker_restart", map[string]any{"name": "--rm"}, "invalid container name: --rm"},
+		{"short dash", "docker_top", map[string]any{"name": "-H"}, "invalid container name: -H"},
+		{"charset still applies", "docker_inspect", map[string]any{"name": "web;id"}, "invalid container name: web;id"},
+		{"non numeric lines", "docker_logs", map[string]any{"name": "web", "lines": "ten"}, "invalid line count: ten (must be a positive integer)"},
+		{"flag shaped lines", "docker_logs", map[string]any{"name": "web", "lines": "--json"}, "invalid line count: --json (must be a positive integer)"},
+		{"tool forwarding nothing passes through", "network_scan", map[string]any{"name": "--help"}, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateContainerArgs(tt.tool, tt.args)
+			got := ""
+			if err != nil {
+				got = err.Error()
+			}
+			if got != tt.wantErr {
+				t.Errorf("validateContainerArgs(%q, %v) = %q, want %q", tt.tool, tt.args, got, tt.wantErr)
+			}
+		})
+	}
+}
+
+// Every executeRemote arm that forwards stringArg(args, "name") has to appear
+// in containerArgTools, or a future tool reintroduces the gap where a
+// flag-shaped value travels to the remote parser unchecked. Reading the source
+// keeps this free of an SSH connection, the same reasoning as the registry
+// test that pins the argv switch against the capability list.
+func TestForwardedContainerNamesHaveAGate(t *testing.T) {
+	src, err := os.ReadFile("server.go")
+	if err != nil {
+		t.Fatalf("reading server.go: %v", err)
+	}
+
+	fn := regexp.MustCompile(`(?s)func \(s \*Server\) executeRemote\(.*?\n\tout, err := remote\.Run`)
+	body := fn.Find(src)
+	if body == nil {
+		t.Fatal("could not locate the executeRemote argv switch; update this test if it moved")
+	}
+
+	forwarded := map[string]bool{}
+	for _, arm := range strings.Split(string(body), "\n\tcase ")[1:] {
+		end := strings.Index(arm, `":`)
+		if end < 0 {
+			continue
+		}
+		if strings.Contains(arm, `stringArg(args, "name")`) {
+			forwarded[strings.Trim(arm[:end], `"`)] = true
+		}
+	}
+	if len(forwarded) == 0 {
+		t.Fatal("found no arm forwarding a name in executeRemote; the split above needs updating")
+	}
+
+	for tool := range forwarded {
+		if _, gated := containerArgTools[tool]; !gated {
+			t.Errorf("executeRemote forwards name for %q but the gate does not cover it; add it to containerArgTools", tool)
+		}
+	}
+	for tool := range containerArgTools {
+		if !forwarded[tool] {
+			t.Errorf("%q sits in containerArgTools but its executeRemote arm no longer forwards a name; drop it from the map", tool)
+		}
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -254,14 +254,14 @@ func validateContainerArgs(tool string, args map[string]any) error {
 }
 
 func (s *Server) executeTool(name string, args map[string]any) (any, error) {
-	if s.demo {
-		return s.executeDemoTool(name, args)
-	}
-
 	// Before any routing: whichever machine ends up answering, the argument
 	// rules are the same and were already checked.
 	if err := validateContainerArgs(name, args); err != nil {
 		return nil, err
+	}
+
+	if s.demo {
+		return s.executeDemoTool(name, args)
 	}
 
 	if cap, ok := capabilityFor(name); ok && cap.supports(targetProxmox) {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -206,9 +206,61 @@ func (s *Server) handleToolCall(req *jsonRPCRequest) {
 	})
 }
 
+// containerArgTools lists the tools whose container name travels into a
+// command line, here or on a remote host, and names the second value they
+// forward alongside it where one exists. executeTool validates each of them
+// before choosing a path, because the paths fail differently otherwise: the
+// local switch lands in the docker package, which rejects a bad name with
+// these exact words, while the remote path builds an argv for another
+// homebutler whose own command parser reads a leading dash as a flag — the
+// help text then comes back through remote.Run as if a restart had happened.
+var containerArgTools = map[string]string{
+	"docker_restart": "",
+	"docker_stop":    "",
+	"docker_logs":    "lines",
+	"docker_top":     "",
+	"docker_inspect": "",
+}
+
+// validateContainerArgs is the one gate for forwarded container arguments,
+// applied before the local-or-remote decision so neither path can grow its
+// own dialect of the rule. The error messages match what the docker package
+// returns on the local path, so a caller cannot tell which machine would have
+// answered from the rejection alone.
+func validateContainerArgs(tool string, args map[string]any) error {
+	numberArg, forwarded := containerArgTools[tool]
+	if !forwarded {
+		return nil
+	}
+	cname, ok := requireString(args, "name")
+	if !ok {
+		return fmt.Errorf("missing required parameter: name")
+	}
+	if !docker.ValidName(cname) {
+		return fmt.Errorf("invalid container name: %s", cname)
+	}
+	if numberArg == "" {
+		return nil
+	}
+	lines := "50"
+	if v := stringArg(args, numberArg); v != "" {
+		lines = v
+	}
+	if !docker.ValidLines(lines) {
+		return fmt.Errorf("invalid line count: %s (must be a positive integer)", lines)
+	}
+	return nil
+}
+
 func (s *Server) executeTool(name string, args map[string]any) (any, error) {
 	if s.demo {
 		return s.executeDemoTool(name, args)
+	}
+
+	// Before any routing: whichever machine ends up answering, the argument
+	// rules are the same and were already checked.
+	if err := validateContainerArgs(name, args); err != nil {
+		return nil, err
 	}
 
 	if cap, ok := capabilityFor(name); ok && cap.supports(targetProxmox) {


### PR DESCRIPTION
A name like `--help` sent to `docker_restart` with `server` set travelled over
as a single shell-quoted argv element and was parsed by the remote homebutler's
own cobra command, which read it as a flag: the help text came back with exit
zero and looked like a restart result. Locally the same call was refused, so
the same tool answered differently depending on whether `server` was set (#83).

Validation now runs once in `executeTool`, before the local-or-remote decision.
The rules themselves stay in `internal/docker` — `isValidName` becomes exported
`ValidName`, and the digits-only check that lived inline in `Logs` becomes
`ValidLines` — so there is one copy of each rule and the gate only applies it.
Rejection messages come from the gate, so remote answers match the local ones
word for word rather than by coincidence.

Two decisions worth calling out:

- The checks inside `Restart`, `Stop`, `Logs`, `Top` and `Inspect` stay. They
  are not part of the two-paths problem: `homebutler docker restart -- --help`
  and the alert remediation reach these functions directly, and that is where
  the name meets a real argv.
- `ValidLines("")` is false where the old inline loop passed an empty string
  through vacuously. Every caller defaults to `"50"` before validating, so
  nothing observable changes; the helper is honest on its own now. On the
  remote path this closes the same shape for `lines`: `--json` used to become
  a flag of the remote command, it is now refused locally with the message the
  local path already gave.

Missing names get the same treatment: they were previously forwarded as an
empty argument, and both paths now answer `missing required parameter: name`.

Tests exercise the remote path without opening a connection: the five tools
are pointed at a configured server and the assertion is that the rejection
carries the validation message rather than a dial error or a success.
`TestForwardedContainerNamesHaveAGate` reads `executeRemote`'s switch the way
`TestRegistryTargetsMatchRemoteArgvMapping` does, so a future tool forwarding
`name` cannot skip the gate silently.

Closes #83.
