### PR TITLE
feat: start, shut down, and reboot Proxmox guests with task status lookup

### DIFF
--- a/cmd/proxmox.go
+++ b/cmd/proxmox.go
@@ -17,7 +17,7 @@ func newProxmoxCmd() *cobra.Command {
 		Short:        "Inspect Proxmox VE endpoints",
 		SilenceUsage: true,
 	}
-	cmd.AddCommand(newProxmoxStatusCmd(), newProxmoxGuestsCmd(), newProxmoxNodeCmd(), newProxmoxTasksCmd())
+	cmd.AddCommand(newProxmoxStatusCmd(), newProxmoxGuestsCmd(), newProxmoxNodeCmd(), newProxmoxTasksCmd(), newProxmoxGuestCmd(), newProxmoxTaskCmd())
 	return cmd
 }
 
@@ -186,6 +186,119 @@ func newProxmoxTasksCmd() *cobra.Command {
 	cmd.Flags().StringVar(&node, "node", "", "Node name")
 	cmd.Flags().IntVar(&limit, "limit", 50, "Maximum tasks per node")
 	return cmd
+}
+
+func newProxmoxGuestCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "guest", Short: "Control a Proxmox VE guest", Args: cobra.NoArgs}
+	cmd.AddCommand(
+		newProxmoxGuestActionCmd(proxmox.GuestActionStart),
+		newProxmoxGuestActionCmd(proxmox.GuestActionShutdown),
+		newProxmoxGuestActionCmd(proxmox.GuestActionReboot),
+	)
+	return cmd
+}
+
+func newProxmoxGuestActionCmd(action proxmox.GuestAction) *cobra.Command {
+	var endpointName, node, guestType string
+	var vmid int
+	var confirm bool
+	cmd := &cobra.Command{
+		Use:   string(action),
+		Short: fmt.Sprintf("Submit a Proxmox guest %s action", action),
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if endpointName == "" {
+				return fmt.Errorf("--endpoint is required for Proxmox guest actions")
+			}
+			if err := proxmox.ValidateGuestAction(node, guestType, vmid, action); err != nil {
+				return err
+			}
+			if !confirm {
+				return fmt.Errorf("confirmation required for Proxmox guest action: endpoint=%q node=%q type=%q vmid=%d action=%q; rerun with --endpoint %q --node %q --type %q --vmid %d --confirm",
+					endpointName, node, guestType, vmid, action, endpointName, node, guestType, vmid)
+			}
+			endpoint, client, err := openProxmoxClient(endpointName)
+			if err != nil {
+				return err
+			}
+			upid, err := client.ActOnGuest(context.Background(), node, guestType, vmid, action)
+			if err != nil {
+				return fmt.Errorf("submit Proxmox guest %s for endpoint %q node %q %s VMID %d: %w", action, endpoint.Name, node, guestType, vmid, err)
+			}
+			result := proxmoxGuestActionResult{
+				Endpoint: endpoint.Name, Node: node, Type: guestType, VMID: vmid,
+				Action: action, Status: "accepted", UPID: upid,
+			}
+			return writeProxmox(cmd, result, jsonOutput, "Guest action accepted", func(b *strings.Builder) {
+				fmt.Fprintf(b, "Endpoint: %s\nNode: %s\nType: %s\nVMID: %d\nAction: %s\nUPID: %s\n",
+					result.Endpoint, result.Node, result.Type, result.VMID, result.Action, result.UPID)
+			})
+		},
+	}
+	cmd.Flags().StringVar(&endpointName, "endpoint", "", "Proxmox endpoint name (required)")
+	cmd.Flags().StringVar(&node, "node", "", "Proxmox node name (required)")
+	cmd.Flags().StringVar(&guestType, "type", "", "Guest type: qemu or lxc (required)")
+	cmd.Flags().IntVar(&vmid, "vmid", 0, "Guest VMID (required)")
+	cmd.Flags().BoolVar(&confirm, "confirm", false, "Confirm the explicit guest action target")
+	return cmd
+}
+
+func newProxmoxTaskCmd() *cobra.Command {
+	var endpointName, node string
+	cmd := &cobra.Command{
+		Use:   "task <upid>",
+		Short: "Inspect one Proxmox VE task",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if endpointName == "" {
+				return fmt.Errorf("--endpoint is required for Proxmox task status")
+			}
+			if err := proxmox.ValidateTaskStatusRequest(node, args[0]); err != nil {
+				return err
+			}
+			endpoint, client, err := openProxmoxClient(endpointName)
+			if err != nil {
+				return err
+			}
+			status, err := client.TaskStatus(context.Background(), node, args[0])
+			if err != nil {
+				return fmt.Errorf("get Proxmox task %q from endpoint %q node %q: %w", args[0], endpoint.Name, node, err)
+			}
+			result := proxmoxTaskStatusResult{
+				Endpoint: endpoint.Name, Node: node, UPID: args[0], Status: status.Status,
+				ExitStatus: status.ExitStatus, Result: status.Result,
+			}
+			return writeProxmox(cmd, result, jsonOutput, "Task status", func(b *strings.Builder) {
+				fmt.Fprintf(b, "Endpoint: %s\nNode: %s\nUPID: %s\nStatus: %s\nResult: %s\n",
+					result.Endpoint, result.Node, result.UPID, result.Status, result.Result)
+				if result.ExitStatus != "" {
+					fmt.Fprintf(b, "Exit status: %s\n", result.ExitStatus)
+				}
+			})
+		},
+	}
+	cmd.Flags().StringVar(&endpointName, "endpoint", "", "Proxmox endpoint name (required)")
+	cmd.Flags().StringVar(&node, "node", "", "Proxmox node name (required)")
+	return cmd
+}
+
+type proxmoxGuestActionResult struct {
+	Endpoint string              `json:"endpoint"`
+	Node     string              `json:"node"`
+	Type     string              `json:"type"`
+	VMID     int                 `json:"vmid"`
+	Action   proxmox.GuestAction `json:"action"`
+	Status   string              `json:"status"`
+	UPID     string              `json:"upid"`
+}
+
+type proxmoxTaskStatusResult struct {
+	Endpoint   string `json:"endpoint"`
+	Node       string `json:"node"`
+	UPID       string `json:"upid"`
+	Status     string `json:"status"`
+	ExitStatus string `json:"exitstatus,omitempty"`
+	Result     string `json:"result"`
 }
 
 type proxmoxTasksView struct {

--- a/cmd/proxmox_test.go
+++ b/cmd/proxmox_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 
 	"github.com/Higangssh/homebutler/internal/config"
+	"github.com/Higangssh/homebutler/internal/proxmox"
 )
 
 func TestSelectProxmoxEndpoint(t *testing.T) {
@@ -362,6 +363,173 @@ func TestProxmoxGuestsRejectsInvalidStatus(t *testing.T) {
 	cmd.SetArgs([]string{"--status", "paused"})
 	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), "--status must be running or stopped") {
 		t.Fatalf("guests status error = %v", err)
+	}
+}
+
+func TestProxmoxGuestActions(t *testing.T) {
+	tests := []struct {
+		action    proxmox.GuestAction
+		guestType string
+	}{
+		{action: proxmox.GuestActionStart, guestType: "qemu"},
+		{action: proxmox.GuestActionShutdown, guestType: "lxc"},
+		{action: proxmox.GuestActionReboot, guestType: "qemu"},
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.action), func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodPost {
+					t.Errorf("method = %q, want POST", r.Method)
+				}
+				if got, want := r.Header.Get("Authorization"), "PVEAPIToken=monitoring@pve!readonly=test-token"; got != want {
+					t.Errorf("Authorization = %q, want %q", got, want)
+				}
+				wantPath := "/api2/json/nodes/pve1/" + tt.guestType + "/100/status/" + string(tt.action)
+				if r.URL.Path != wantPath {
+					t.Errorf("path = %q, want %q", r.URL.Path, wantPath)
+				}
+				_, _ = w.Write([]byte(`{"data":"UPID:pve1:opaque"}`))
+			}))
+			defer server.Close()
+
+			oldPath, oldJSON, oldCfg := cfgPath, jsonOutput, cfg
+			defer func() { cfgPath, jsonOutput, cfg = oldPath, oldJSON, oldCfg }()
+			cfgPath, jsonOutput, cfg = writeProxmoxTestConfig(t, server.URL), true, nil
+			cmd := newProxmoxGuestActionCmd(tt.action)
+			cmd.SetArgs([]string{"--endpoint", "pve", "--node", "pve1", "--type", tt.guestType, "--vmid", "100", "--confirm"})
+			var output bytes.Buffer
+			cmd.SetOut(&output)
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("proxmox guest %s: %v", tt.action, err)
+			}
+
+			var result proxmoxGuestActionResult
+			if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+				t.Fatal(err)
+			}
+			if result.Endpoint != "pve" || result.Node != "pve1" || result.Type != tt.guestType || result.VMID != 100 || result.Action != tt.action || result.Status != "accepted" || result.UPID != "UPID:pve1:opaque" {
+				t.Errorf("action result = %#v", result)
+			}
+			if strings.Contains(output.String(), "completed") || strings.Contains(output.String(), "test-token") {
+				t.Errorf("action output overclaims completion or exposes token: %q", output.String())
+			}
+		})
+	}
+}
+
+func TestProxmoxGuestActionHumanOutput(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":"UPID:pve1:opaque"}`))
+	}))
+	defer server.Close()
+
+	oldPath, oldJSON, oldCfg := cfgPath, jsonOutput, cfg
+	defer func() { cfgPath, jsonOutput, cfg = oldPath, oldJSON, oldCfg }()
+	cfgPath, jsonOutput, cfg = writeProxmoxTestConfig(t, server.URL), false, nil
+	cmd := newProxmoxGuestActionCmd(proxmox.GuestActionStart)
+	cmd.SetArgs([]string{"--endpoint", "pve", "--node", "pve1", "--type", "qemu", "--vmid", "100", "--confirm"})
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	if got := output.String(); !strings.Contains(got, "Guest action accepted") || !strings.Contains(got, "Action: start") || !strings.Contains(got, "UPID: UPID:pve1:opaque") || strings.Contains(got, "completed") {
+		t.Errorf("action output = %q", got)
+	}
+}
+
+func TestProxmoxGuestActionConfirmationPrecedesConfig(t *testing.T) {
+	oldPath, oldCfg := cfgPath, cfg
+	defer func() { cfgPath, cfg = oldPath, oldCfg }()
+	cfgPath, cfg = filepath.Join(t.TempDir(), "missing.yaml"), nil
+	cmd := newProxmoxGuestActionCmd(proxmox.GuestActionShutdown)
+	cmd.SetArgs([]string{"--endpoint", "pve", "--node", "pve1", "--type", "lxc", "--vmid", "101"})
+	err := cmd.Execute()
+	for _, want := range []string{`endpoint="pve"`, `node="pve1"`, `type="lxc"`, "vmid=101", `action="shutdown"`, "--confirm"} {
+		if err == nil || !strings.Contains(err.Error(), want) {
+			t.Fatalf("confirmation error = %v, want %q", err, want)
+		}
+	}
+}
+
+func TestProxmoxActionAndTaskRequireExplicitTargetsBeforeConfig(t *testing.T) {
+	oldPath, oldCfg := cfgPath, cfg
+	defer func() { cfgPath, cfg = oldPath, oldCfg }()
+	cfgPath, cfg = filepath.Join(t.TempDir(), "missing.yaml"), nil
+
+	action := newProxmoxGuestActionCmd(proxmox.GuestActionStart)
+	action.SetArgs([]string{"--node", "pve1", "--type", "qemu", "--vmid", "100", "--confirm"})
+	if err := action.Execute(); err == nil || !strings.Contains(err.Error(), "--endpoint is required") {
+		t.Errorf("action error = %v", err)
+	}
+
+	task := newProxmoxTaskCmd()
+	task.SetArgs([]string{"UPID:opaque", "--endpoint", "pve"})
+	if err := task.Execute(); err == nil || !strings.Contains(err.Error(), "node is required") {
+		t.Errorf("task error = %v", err)
+	}
+}
+
+func TestProxmoxTaskStatusOutput(t *testing.T) {
+	tests := []struct {
+		fixture string
+		result  string
+	}{
+		{fixture: "task-status-running.json", result: "in flight"},
+		{fixture: "task-status-stopped-ok.json", result: "completed successfully"},
+		{fixture: "task-status-stopped-error.json", result: "completed with failure"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.fixture, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if got, want := r.URL.EscapedPath(), "/api2/json/nodes/pve1/tasks/UPID:opaque/status"; got != want {
+					t.Errorf("path = %q, want %q", got, want)
+				}
+				_, _ = w.Write(readProxmoxFixture(t, tt.fixture))
+			}))
+			defer server.Close()
+
+			oldPath, oldJSON, oldCfg := cfgPath, jsonOutput, cfg
+			defer func() { cfgPath, jsonOutput, cfg = oldPath, oldJSON, oldCfg }()
+			cfgPath, jsonOutput, cfg = writeProxmoxTestConfig(t, server.URL), false, nil
+			cmd := newProxmoxTaskCmd()
+			cmd.SetArgs([]string{"UPID:opaque", "--endpoint", "pve", "--node", "pve1"})
+			var output bytes.Buffer
+			cmd.SetOut(&output)
+			if err := cmd.Execute(); err != nil {
+				t.Fatal(err)
+			}
+			if got := output.String(); !strings.Contains(got, "Status:") || !strings.Contains(got, "Result: "+tt.result) {
+				t.Errorf("task output = %q", got)
+			}
+		})
+	}
+}
+
+func TestProxmoxTaskStatusJSON(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write(readProxmoxFixture(t, "task-status-stopped-error.json"))
+	}))
+	defer server.Close()
+
+	oldPath, oldJSON, oldCfg := cfgPath, jsonOutput, cfg
+	defer func() { cfgPath, jsonOutput, cfg = oldPath, oldJSON, oldCfg }()
+	cfgPath, jsonOutput, cfg = writeProxmoxTestConfig(t, server.URL), true, nil
+	cmd := newProxmoxTaskCmd()
+	cmd.SetArgs([]string{"UPID:opaque", "--endpoint", "pve", "--node", "pve1"})
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	var result proxmoxTaskStatusResult
+	if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Status != "stopped" || result.ExitStatus != "guest is locked" || result.Result != "completed with failure" || result.UPID != "UPID:opaque" {
+		t.Errorf("task result = %#v", result)
 	}
 }
 

--- a/cmd/proxmox_test.go
+++ b/cmd/proxmox_test.go
@@ -476,9 +476,9 @@ func TestProxmoxTaskStatusOutput(t *testing.T) {
 		fixture string
 		result  string
 	}{
-		{fixture: "task-status-running.json", result: "in flight"},
-		{fixture: "task-status-stopped-ok.json", result: "completed successfully"},
-		{fixture: "task-status-stopped-error.json", result: "completed with failure"},
+		{fixture: "task-status-running.json", result: "running"},
+		{fixture: "task-status-stopped-ok.json", result: "ok"},
+		{fixture: "task-status-stopped-error.json", result: "failed"},
 	}
 
 	for _, tt := range tests {
@@ -528,7 +528,7 @@ func TestProxmoxTaskStatusJSON(t *testing.T) {
 	if err := json.Unmarshal(output.Bytes(), &result); err != nil {
 		t.Fatal(err)
 	}
-	if result.Status != "stopped" || result.ExitStatus != "guest is locked" || result.Result != "completed with failure" || result.UPID != "UPID:opaque" {
+	if result.Status != "stopped" || result.ExitStatus != "guest is locked" || result.Result != "failed" || result.UPID != "UPID:opaque" {
 		t.Errorf("task result = %#v", result)
 	}
 }

--- a/docs/proxmox.md
+++ b/docs/proxmox.md
@@ -139,9 +139,9 @@ it does not prompt interactively.
 An action response means Proxmox accepted the asynchronous request. It does not
 mean the guest transition completed. HomeButler returns the UPID exactly as
 Proxmox supplied it and does not parse or poll it. Inspect it separately with
-`proxmox task`. A running task is still in flight. A stopped task with
-`exitstatus: OK` completed successfully; any other stopped exit status is
-reported as a completed failure.
+`proxmox task`. It reports `result` as one of three short tokens: `running`
+for a task still in progress, `ok` for a stopped task with `exitstatus: OK`,
+and `failed` for any other stopped exit status.
 
 HomeButler never retries an action POST automatically. If a timeout or lost
 connection happens after Proxmox received the request, retrying could submit the

--- a/docs/proxmox.md
+++ b/docs/proxmox.md
@@ -1,20 +1,21 @@
 # Proxmox VE
 
-HomeButler can inspect one or more Proxmox VE API endpoints without installing
-an agent on a Proxmox node. Phase 1 is read-only: it reports cluster resources,
-guests, nodes, and recent tasks.
+HomeButler can inspect and perform a small set of confirmed guest power actions
+against one or more Proxmox VE API endpoints without installing an agent on a
+Proxmox node. Read operations report cluster resources, guests, nodes, recent
+tasks, and the status of one asynchronous task.
 
 ## Setup
 
-### Create a read-only API token
+### Create a least-privilege API token
 
-The built-in `PVEAuditor` role is the recommended minimum role. It is read-only
-and includes the audit privileges needed for the cluster, node, guest, storage,
+For read operations, the built-in `PVEAuditor` role is the recommended baseline.
+It includes the audit privileges needed for the cluster, node, guest, storage,
 and task views.
 
 ```bash
-# Create a token-only user in the PVE realm.
-pveum user add monitoring@pve --comment "read-only API user for homebutler"
+# Create a dedicated API user in the PVE realm.
+pveum user add monitoring@pve --comment "least-privilege API user for homebutler"
 
 # Privilege separation is enabled by default. The token value is displayed once.
 pveum user token add monitoring@pve readonly --privsep 1
@@ -32,6 +33,22 @@ intersection of the user ACLs and the token ACLs. Granting `PVEAuditor` only to
 the user is not enough: the token can authenticate yet return empty resource
 lists. The `/` ACL is recommended because `/cluster/status` needs `Sys.Audit`
 on `/`.
+
+Guest actions need `VM.PowerMgmt` on each selected `/vms/<vmid>` path. Keep
+that permission separate from `PVEAuditor`; do not grant an administrator role
+to HomeButler. Create a narrow role and grant it to both the user and the
+privilege-separated token only for guests HomeButler may control:
+
+```bash
+pveum role add HomeButlerPower -privs VM.PowerMgmt
+pveum acl modify /vms/100 --users 'monitoring@pve' --roles HomeButlerPower
+pveum acl modify /vms/100 --tokens 'monitoring@pve!readonly' --roles HomeButlerPower
+```
+
+Repeat the two ACL commands only for other approved VMIDs. The task owner may
+inspect its own task. Inspecting a task started by another user requires
+`Sys.Audit` on the task's node; the read-only setup above already provides the
+audit privileges used by HomeButler's read views.
 
 Save the token value when it is printed. Proxmox does not reveal it again; if
 it is lost, remove and create the token again. A newly granted token can briefly
@@ -91,6 +108,11 @@ homebutler proxmox guests --status running
 homebutler proxmox guests --endpoint pve --node pve1 --status stopped
 homebutler proxmox node pve1 --endpoint pve
 homebutler proxmox tasks --endpoint pve --node pve1 --limit 50
+homebutler proxmox guest start --endpoint pve --node pve1 --type qemu --vmid 100 --confirm
+homebutler proxmox guest shutdown --endpoint pve --node pve1 --type lxc --vmid 101 --confirm
+homebutler proxmox guest reboot --endpoint pve --node pve1 --type qemu --vmid 100 --confirm
+homebutler proxmox task 'UPID:pve1:...' --endpoint pve --node pve1
+homebutler proxmox task 'UPID:pve1:...' --endpoint pve --node pve1 --json
 ```
 
 Without `--node`, `proxmox tasks` queries recent tasks for each resource node.
@@ -108,20 +130,59 @@ Use `--json` for the full typed API view. CPU values remain Proxmox fractions
 (`0..1`), byte counters remain integers, and QEMU and LXC guests are returned
 in one `guests` list.
 
+Guest actions always require explicit `--endpoint`, `--node`, `--type`,
+`--vmid`, and `--confirm` values, even when only one endpoint is configured.
+HomeButler does not discover or infer the node or guest type before an action.
+Without `--confirm`, the command reports the full target and exact rerun flags;
+it does not prompt interactively.
+
+An action response means Proxmox accepted the asynchronous request. It does not
+mean the guest transition completed. HomeButler returns the UPID exactly as
+Proxmox supplied it and does not parse or poll it. Inspect it separately with
+`proxmox task`. A running task is still in flight. A stopped task with
+`exitstatus: OK` completed successfully; any other stopped exit status is
+reported as a completed failure.
+
+HomeButler never retries an action POST automatically. If a timeout or lost
+connection happens after Proxmox received the request, retrying could submit the
+same action twice. Treat that result as ambiguous and inspect Proxmox before
+deciding whether to run the command again.
+
+Phase 2 deliberately exposes graceful `shutdown`, not Proxmox hard `stop`.
+QEMU hard stop is equivalent to pulling the power plug and can damage guest
+data; LXC hard stop abruptly terminates container processes. A future hard-stop
+operation, if needed, must use its own unmistakable name and safety contract.
+
 ## MCP tools
 
-The MCP server exposes read-only Proxmox tools. Each accepts `endpoint` when
-needed to select among configured endpoints:
+The MCP server exposes these read-only Proxmox tools. Each accepts `endpoint`
+when needed to select among configured endpoints:
 
-- `proxmox_status` — version, cluster status, and resources.
-- `proxmox_guests` — unified guest list; optional `node`, `status`, and `type`
+- `proxmox_status` - version, cluster status, and resources.
+- `proxmox_guests` - unified guest list; optional `node`, `status`, and `type`
   (`qemu` or `lxc`) filters.
-- `proxmox_node` — node detail; requires `node`.
-- `proxmox_tasks` — recent tasks for a node; requires `node`.
+- `proxmox_node` - node detail; requires `node`.
+- `proxmox_tasks` - recent tasks for a node; requires `node`.
 
-## Not in Phase 1
+Phase 2 adds four explicit tools:
 
-Phase 1 does not start, stop, reboot, create, or otherwise change guests. The
-web dashboard is a separate follow-up. Community Scripts provisioning is a
-Phase 3 security decision and is not implemented here; HomeButler does not
+- `proxmox_guest_start` - `riskWrite`; requires `endpoint`, `node`, `type`,
+  `vmid`, and literal `confirm: true`.
+- `proxmox_guest_reboot` - `riskWrite`; requires `endpoint`, `node`, `type`,
+  `vmid`, and literal `confirm: true`.
+- `proxmox_guest_shutdown` - `riskDestructive`; requires `endpoint`, `node`,
+  `type`, `vmid`, and literal `confirm: true`.
+- `proxmox_task_status` - `riskRead`; requires `endpoint`, `node`, and the
+  opaque `upid`.
+
+Risk metadata helps MCP clients make policy decisions, but it does not replace
+runtime confirmation. Every action tool rejects a missing, false, or non-boolean
+confirmation before HomeButler resolves the token or contacts Proxmox.
+
+## Excluded scope
+
+HomeButler does not expose Proxmox hard stop, guest creation or deletion,
+migration, reset, suspend or resume, snapshots, task polling, automatic POST
+retries, arbitrary API actions, or root-only action overrides. The web dashboard
+and Community Scripts provisioning remain separate work; HomeButler does not
 fetch or execute external provisioning scripts.

--- a/internal/mcp/capabilities.go
+++ b/internal/mcp/capabilities.go
@@ -118,6 +118,46 @@ var capabilityRegistry = []capability{
 		},
 	},
 	{
+		risk:    riskWrite,
+		targets: []targetKind{targetProxmox},
+		tool: toolDef{
+			Name:        "proxmox_guest_start",
+			Description: "Start one explicitly targeted Proxmox guest after confirmation and return the accepted task UPID",
+			InputSchema: proxmoxGuestActionSchema(),
+		},
+	},
+	{
+		risk:    riskWrite,
+		targets: []targetKind{targetProxmox},
+		tool: toolDef{
+			Name:        "proxmox_guest_reboot",
+			Description: "Reboot one explicitly targeted Proxmox guest after confirmation and return the accepted task UPID",
+			InputSchema: proxmoxGuestActionSchema(),
+		},
+	},
+	{
+		risk:    riskDestructive,
+		targets: []targetKind{targetProxmox},
+		tool: toolDef{
+			Name:        "proxmox_guest_shutdown",
+			Description: "Gracefully shut down one explicitly targeted Proxmox guest after confirmation and return the accepted task UPID",
+			InputSchema: proxmoxGuestActionSchema(),
+		},
+	},
+	{
+		risk:    riskRead,
+		targets: []targetKind{targetProxmox},
+		tool: toolDef{
+			Name:        "proxmox_task_status",
+			Description: "Inspect one asynchronous Proxmox task by node and opaque UPID",
+			InputSchema: inputSchema{Type: "object", Properties: map[string]propDef{
+				"endpoint": {Type: "string", Description: "Explicit Proxmox endpoint name from config"},
+				"node":     {Type: "string", Description: "Proxmox node name"},
+				"upid":     {Type: "string", Description: "Opaque Proxmox task UPID"},
+			}, Required: []string{"endpoint", "node", "upid"}},
+		},
+	},
+	{
 		risk:    riskRead,
 		targets: []targetKind{targetLocal, targetServer},
 		tool: toolDef{

--- a/internal/mcp/demo.go
+++ b/internal/mcp/demo.go
@@ -35,6 +35,30 @@ func (s *Server) executeDemoTool(name string, args map[string]any) (any, error) 
 			return nil, fmt.Errorf("missing required parameter: node")
 		}
 		return []proxmox.Task{{UPID: "UPID:" + node + ":demo", Node: node, Type: "vzdump", Status: "OK"}}, nil
+	case "proxmox_guest_start", "proxmox_guest_reboot", "proxmox_guest_shutdown":
+		request, _, err := proxmoxGuestActionArgs(name, args)
+		if err != nil {
+			return nil, err
+		}
+		return proxmoxGuestActionResult{
+			Endpoint: request.Endpoint, Node: request.Node, Type: request.Type, VMID: request.VMID,
+			Action: request.Action, Status: "accepted", UPID: "UPID:" + request.Node + ":demo",
+		}, nil
+	case "proxmox_task_status":
+		endpoint, err := strictProxmoxStringArg(args, "endpoint")
+		if err != nil {
+			return nil, err
+		}
+		node, err := strictProxmoxStringArg(args, "node")
+		if err != nil {
+			return nil, err
+		}
+		upid, err := strictProxmoxStringArg(args, "upid")
+		if err != nil {
+			return nil, err
+		}
+		_ = endpoint
+		return proxmox.TaskStatus{UPID: upid, Node: node, Type: "qmstart", ID: "100", User: "demo@pve", Status: "stopped", ExitStatus: "OK", Result: proxmox.TaskResult("stopped", "OK")}, nil
 	case "system_status":
 		return demoStatus(server), nil
 	case "docker_list":

--- a/internal/mcp/demo_test.go
+++ b/internal/mcp/demo_test.go
@@ -66,11 +66,16 @@ func TestEveryAdvertisedToolHasADemoImplementation(t *testing.T) {
 	s := NewServer(&config.Config{}, "dev", true)
 
 	sample := map[string]any{
-		"name":    "nginx",
-		"node":    "pve1",
-		"app":     "uptime-kuma",
-		"target":  "aa:bb:cc:dd:ee:ff",
-		"archive": "demo.tar.gz",
+		"name":     "nginx",
+		"endpoint": "pve",
+		"node":     "pve1",
+		"type":     "qemu",
+		"vmid":     100,
+		"confirm":  true,
+		"upid":     "UPID:pve1:demo",
+		"app":      "uptime-kuma",
+		"target":   "aa:bb:cc:dd:ee:ff",
+		"archive":  "demo.tar.gz",
 	}
 
 	for _, c := range capabilityRegistry {

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -285,19 +285,23 @@ func TestEmptyLines(t *testing.T) {
 func TestToolDefinitionsHaveRequiredFields(t *testing.T) {
 	tools := toolDefinitions()
 	requireMap := map[string][]string{
-		"docker_restart":    {"name"},
-		"docker_stop":       {"name"},
-		"docker_logs":       {"name"},
-		"docker_top":        {"name"},
-		"docker_inspect":    {"name"},
-		"wake":              {"target"},
-		"install_app":       {"app"},
-		"install_status":    {"app"},
-		"install_uninstall": {"app"},
-		"install_purge":     {"app"},
-		"backup_restore":    {"archive"},
-		"proxmox_node":      {"node"},
-		"proxmox_tasks":     {"node"},
+		"docker_restart":         {"name"},
+		"docker_stop":            {"name"},
+		"docker_logs":            {"name"},
+		"docker_top":             {"name"},
+		"docker_inspect":         {"name"},
+		"wake":                   {"target"},
+		"install_app":            {"app"},
+		"install_status":         {"app"},
+		"install_uninstall":      {"app"},
+		"install_purge":          {"app"},
+		"backup_restore":         {"archive"},
+		"proxmox_node":           {"node"},
+		"proxmox_tasks":          {"node"},
+		"proxmox_guest_start":    {"endpoint", "node", "type", "vmid", "confirm"},
+		"proxmox_guest_reboot":   {"endpoint", "node", "type", "vmid", "confirm"},
+		"proxmox_guest_shutdown": {"endpoint", "node", "type", "vmid", "confirm"},
+		"proxmox_task_status":    {"endpoint", "node", "upid"},
 	}
 
 	for _, tool := range tools {

--- a/internal/mcp/proxmox.go
+++ b/internal/mcp/proxmox.go
@@ -20,7 +20,7 @@ func proxmoxGuestActionSchema() inputSchema {
 		"endpoint": {Type: "string", Description: "Explicit Proxmox endpoint name from config"},
 		"node":     {Type: "string", Description: "Proxmox node name"},
 		"type":     {Type: "string", Description: "Guest type: qemu or lxc"},
-		"vmid":     {Type: "integer", Description: "Proxmox guest VMID from 100 through 999999999"},
+		"vmid":     {Type: "integer", Description: "Proxmox guest VMID from 1 through 999999999"},
 		"confirm":  {Type: "boolean", Description: "Must be true to confirm the explicit guest action target"},
 	}, Required: []string{"endpoint", "node", "type", "vmid", "confirm"}}
 }

--- a/internal/mcp/proxmox.go
+++ b/internal/mcp/proxmox.go
@@ -3,6 +3,8 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"math"
+	"strings"
 
 	"github.com/Higangssh/homebutler/internal/proxmox"
 )
@@ -13,11 +15,64 @@ func proxmoxEndpointProperties() map[string]propDef {
 	}
 }
 
+func proxmoxGuestActionSchema() inputSchema {
+	return inputSchema{Type: "object", Properties: map[string]propDef{
+		"endpoint": {Type: "string", Description: "Explicit Proxmox endpoint name from config"},
+		"node":     {Type: "string", Description: "Proxmox node name"},
+		"type":     {Type: "string", Description: "Guest type: qemu or lxc"},
+		"vmid":     {Type: "integer", Description: "Proxmox guest VMID from 100 through 999999999"},
+		"confirm":  {Type: "boolean", Description: "Must be true to confirm the explicit guest action target"},
+	}, Required: []string{"endpoint", "node", "type", "vmid", "confirm"}}
+}
+
+type proxmoxGuestActionRequest struct {
+	Endpoint string
+	Node     string
+	Type     string
+	VMID     int
+	Action   proxmox.GuestAction
+}
+
+type proxmoxGuestActionResult struct {
+	Endpoint string              `json:"endpoint"`
+	Node     string              `json:"node"`
+	Type     string              `json:"type"`
+	VMID     int                 `json:"vmid"`
+	Action   proxmox.GuestAction `json:"action"`
+	Status   string              `json:"status"`
+	UPID     string              `json:"upid"`
+}
+
 func (s *Server) executeProxmox(name string, args map[string]any) (any, error) {
+	actionRequest, isAction, err := proxmoxGuestActionArgs(name, args)
+	if err != nil {
+		return nil, err
+	}
+	var taskStatusEndpoint, taskStatusNode, taskStatusUPID string
+	if name == "proxmox_task_status" {
+		values := make(map[string]string, 3)
+		for _, key := range []string{"endpoint", "node", "upid"} {
+			value, err := strictProxmoxStringArg(args, key)
+			if err != nil {
+				return nil, err
+			}
+			values[key] = value
+		}
+		taskStatusEndpoint, taskStatusNode, taskStatusUPID = values["endpoint"], values["node"], values["upid"]
+		if err := proxmox.ValidateTaskStatusRequest(taskStatusNode, taskStatusUPID); err != nil {
+			return nil, err
+		}
+	}
 	if (name == "proxmox_node" || name == "proxmox_tasks") && stringArg(args, "node") == "" {
 		return nil, fmt.Errorf("missing required parameter: node")
 	}
-	endpoint, err := s.cfg.SelectProxmox(stringArg(args, "endpoint"))
+	endpointName := stringArg(args, "endpoint")
+	if isAction {
+		endpointName = actionRequest.Endpoint
+	} else if name == "proxmox_task_status" {
+		endpointName = taskStatusEndpoint
+	}
+	endpoint, err := s.cfg.SelectProxmox(endpointName)
 	if err != nil {
 		return nil, err
 	}
@@ -47,9 +102,83 @@ func (s *Server) executeProxmox(name string, args map[string]any) (any, error) {
 		return client.NodeStatus(ctx, stringArg(args, "node"))
 	case "proxmox_tasks":
 		return client.Tasks(ctx, stringArg(args, "node"))
+	case "proxmox_guest_start", "proxmox_guest_reboot", "proxmox_guest_shutdown":
+		upid, err := client.ActOnGuest(ctx, actionRequest.Node, actionRequest.Type, actionRequest.VMID, actionRequest.Action)
+		if err != nil {
+			return nil, err
+		}
+		return proxmoxGuestActionResult{
+			Endpoint: endpoint.Name, Node: actionRequest.Node, Type: actionRequest.Type, VMID: actionRequest.VMID,
+			Action: actionRequest.Action, Status: "accepted", UPID: upid,
+		}, nil
+	case "proxmox_task_status":
+		return client.TaskStatus(ctx, taskStatusNode, taskStatusUPID)
 	default:
 		return nil, fmt.Errorf("unknown tool: %s", name)
 	}
+}
+
+func proxmoxGuestActionArgs(name string, args map[string]any) (proxmoxGuestActionRequest, bool, error) {
+	var action proxmox.GuestAction
+	switch name {
+	case "proxmox_guest_start":
+		action = proxmox.GuestActionStart
+	case "proxmox_guest_reboot":
+		action = proxmox.GuestActionReboot
+	case "proxmox_guest_shutdown":
+		action = proxmox.GuestActionShutdown
+	default:
+		return proxmoxGuestActionRequest{}, false, nil
+	}
+
+	endpoint, err := strictProxmoxStringArg(args, "endpoint")
+	if err != nil {
+		return proxmoxGuestActionRequest{}, true, err
+	}
+	node, err := strictProxmoxStringArg(args, "node")
+	if err != nil {
+		return proxmoxGuestActionRequest{}, true, err
+	}
+	guestType, err := strictProxmoxStringArg(args, "type")
+	if err != nil {
+		return proxmoxGuestActionRequest{}, true, err
+	}
+	vmid, err := strictProxmoxVMID(args)
+	if err != nil {
+		return proxmoxGuestActionRequest{}, true, err
+	}
+	if err := proxmox.ValidateGuestAction(node, guestType, vmid, action); err != nil {
+		return proxmoxGuestActionRequest{}, true, err
+	}
+	confirmed, ok := args["confirm"].(bool)
+	if !ok || !confirmed {
+		return proxmoxGuestActionRequest{}, true, fmt.Errorf("confirmation required for Proxmox guest action: endpoint=%q node=%q type=%q vmid=%d action=%q; set confirm to true", endpoint, node, guestType, vmid, action)
+	}
+	return proxmoxGuestActionRequest{Endpoint: endpoint, Node: node, Type: guestType, VMID: vmid, Action: action}, true, nil
+}
+
+func strictProxmoxStringArg(args map[string]any, key string) (string, error) {
+	value, ok := args[key].(string)
+	if !ok || strings.TrimSpace(value) == "" {
+		return "", fmt.Errorf("missing or invalid required parameter: %s", key)
+	}
+	return value, nil
+}
+
+func strictProxmoxVMID(args map[string]any) (int, error) {
+	var value int
+	switch raw := args["vmid"].(type) {
+	case int:
+		value = raw
+	case float64:
+		if math.IsNaN(raw) || math.IsInf(raw, 0) || raw != math.Trunc(raw) || raw < 0 || raw > math.MaxInt {
+			return 0, fmt.Errorf("missing or invalid required parameter: vmid")
+		}
+		value = int(raw)
+	default:
+		return 0, fmt.Errorf("missing or invalid required parameter: vmid")
+	}
+	return value, nil
 }
 
 func filterProxmoxGuests(guests []proxmox.Guest, node, status, kind string) []proxmox.Guest {

--- a/internal/mcp/proxmox_test.go
+++ b/internal/mcp/proxmox_test.go
@@ -166,7 +166,7 @@ func TestProxmoxPhase2Dispatch(t *testing.T) {
 		t.Fatal(err)
 	}
 	task := status.(proxmox.TaskStatus)
-	if task.Status != "stopped" || task.ExitStatus != "OK" || task.Result != "completed successfully" {
+	if task.Status != "stopped" || task.ExitStatus != "OK" || task.Result != "ok" {
 		t.Errorf("task status = %#v", task)
 	}
 }
@@ -215,7 +215,7 @@ func TestProxmoxPhase2ValidationPrecedesCredentials(t *testing.T) {
 		{name: "string VMID", change: func(a map[string]any) { a["vmid"] = "100" }},
 		{name: "fractional VMID", change: func(a map[string]any) { a["vmid"] = 100.5 }},
 		{name: "NaN VMID", change: func(a map[string]any) { a["vmid"] = math.NaN() }},
-		{name: "out of range VMID", change: func(a map[string]any) { a["vmid"] = float64(99) }},
+		{name: "out of range VMID", change: func(a map[string]any) { a["vmid"] = float64(0) }},
 		{name: "missing confirmation", change: func(a map[string]any) { delete(a, "confirm") }},
 		{name: "false confirmation", change: func(a map[string]any) { a["confirm"] = false }},
 		{name: "string confirmation", change: func(a map[string]any) { a["confirm"] = "true" }},
@@ -266,7 +266,7 @@ func TestProxmoxPhase2Demo(t *testing.T) {
 		}
 	}
 	result, err := s.executeDemoTool("proxmox_task_status", map[string]any{"endpoint": "pve", "node": "pve1", "upid": "UPID:opaque"})
-	if err != nil || result.(proxmox.TaskStatus).Result != "completed successfully" {
+	if err != nil || result.(proxmox.TaskStatus).Result != "ok" {
 		t.Errorf("task demo = %#v, %v", result, err)
 	}
 }

--- a/internal/mcp/proxmox_test.go
+++ b/internal/mcp/proxmox_test.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -107,6 +108,166 @@ func TestProxmoxToolDefinitionsAreReadOnlyAPIEndpoints(t *testing.T) {
 		if cap.risk != riskRead || !cap.supports(targetProxmox) || cap.supports(targetLocal) || cap.supports(targetServer) {
 			t.Errorf("%s capability = %#v", name, cap)
 		}
+	}
+}
+
+func TestProxmoxPhase2Dispatch(t *testing.T) {
+	var requests []string
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r.URL.EscapedPath())
+		if got, want := r.Header.Get("Authorization"), "PVEAPIToken=monitoring@pve!readonly=fixture-token"; got != want {
+			t.Errorf("Authorization = %q, want %q", got, want)
+		}
+		if strings.HasSuffix(r.URL.Path, "/status") && strings.Contains(r.URL.Path, "/tasks/") {
+			if r.Method != http.MethodGet {
+				t.Errorf("task method = %q, want GET", r.Method)
+			}
+			_, _ = w.Write(readProxmoxFixture(t, "task-status-stopped-ok.json"))
+			return
+		}
+		if r.Method != http.MethodPost {
+			t.Errorf("action method = %q, want POST", r.Method)
+		}
+		_, _ = w.Write([]byte(`{"data":"UPID:pve1:opaque"}`))
+	}))
+	defer server.Close()
+	s := testProxmoxMCPServer(t, server.URL)
+
+	tests := []struct {
+		name       string
+		action     proxmox.GuestAction
+		guestType  string
+		wantSuffix string
+	}{
+		{name: "proxmox_guest_start", action: proxmox.GuestActionStart, guestType: "qemu", wantSuffix: "/qemu/100/status/start"},
+		{name: "proxmox_guest_reboot", action: proxmox.GuestActionReboot, guestType: "lxc", wantSuffix: "/lxc/100/status/reboot"},
+		{name: "proxmox_guest_shutdown", action: proxmox.GuestActionShutdown, guestType: "qemu", wantSuffix: "/qemu/100/status/shutdown"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := s.executeTool(tt.name, map[string]any{
+				"endpoint": "pve", "node": "pve1", "type": tt.guestType, "vmid": float64(100), "confirm": true,
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			action := result.(proxmoxGuestActionResult)
+			if action.Status != "accepted" || action.Action != tt.action || action.UPID != "UPID:pve1:opaque" || action.Type != tt.guestType {
+				t.Errorf("result = %#v", action)
+			}
+			if got := requests[len(requests)-1]; !strings.HasSuffix(got, tt.wantSuffix) {
+				t.Errorf("path = %q, want suffix %q", got, tt.wantSuffix)
+			}
+		})
+	}
+
+	status, err := s.executeTool("proxmox_task_status", map[string]any{"endpoint": "pve", "node": "pve1", "upid": "UPID:opaque"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	task := status.(proxmox.TaskStatus)
+	if task.Status != "stopped" || task.ExitStatus != "OK" || task.Result != "completed successfully" {
+		t.Errorf("task status = %#v", task)
+	}
+}
+
+func TestProxmoxPhase2CapabilityMetadataAndSchemas(t *testing.T) {
+	tests := []struct {
+		name     string
+		risk     capabilityRisk
+		required []string
+	}{
+		{name: "proxmox_guest_start", risk: riskWrite, required: []string{"endpoint", "node", "type", "vmid", "confirm"}},
+		{name: "proxmox_guest_reboot", risk: riskWrite, required: []string{"endpoint", "node", "type", "vmid", "confirm"}},
+		{name: "proxmox_guest_shutdown", risk: riskDestructive, required: []string{"endpoint", "node", "type", "vmid", "confirm"}},
+		{name: "proxmox_task_status", risk: riskRead, required: []string{"endpoint", "node", "upid"}},
+	}
+	for _, tt := range tests {
+		cap, ok := capabilityFor(tt.name)
+		if !ok {
+			t.Fatalf("%s is not registered", tt.name)
+		}
+		if cap.risk != tt.risk || !cap.supports(targetProxmox) || cap.supports(targetLocal) || cap.supports(targetServer) {
+			t.Errorf("%s capability = %#v", tt.name, cap)
+		}
+		if got := strings.Join(cap.tool.InputSchema.Required, ","); got != strings.Join(tt.required, ",") {
+			t.Errorf("%s required = %q", tt.name, got)
+		}
+	}
+	start, _ := capabilityFor("proxmox_guest_start")
+	if start.tool.InputSchema.Properties["vmid"].Type != "integer" || start.tool.InputSchema.Properties["confirm"].Type != "boolean" {
+		t.Errorf("action schema = %#v", start.tool.InputSchema)
+	}
+}
+
+func TestProxmoxPhase2ValidationPrecedesCredentials(t *testing.T) {
+	s := NewServer(&config.Config{Proxmox: []config.ProxmoxConfig{{
+		Name: "pve", Host: "127.0.0.1", TokenID: "fixture@pve!token", TokenFile: filepath.Join(t.TempDir(), "missing-token"),
+	}}}, "test")
+	valid := map[string]any{"endpoint": "pve", "node": "pve1", "type": "qemu", "vmid": float64(100), "confirm": true}
+	tests := []struct {
+		name   string
+		change func(map[string]any)
+	}{
+		{name: "missing endpoint", change: func(a map[string]any) { delete(a, "endpoint") }},
+		{name: "missing node", change: func(a map[string]any) { delete(a, "node") }},
+		{name: "invalid type", change: func(a map[string]any) { a["type"] = "vm" }},
+		{name: "string VMID", change: func(a map[string]any) { a["vmid"] = "100" }},
+		{name: "fractional VMID", change: func(a map[string]any) { a["vmid"] = 100.5 }},
+		{name: "NaN VMID", change: func(a map[string]any) { a["vmid"] = math.NaN() }},
+		{name: "out of range VMID", change: func(a map[string]any) { a["vmid"] = float64(99) }},
+		{name: "missing confirmation", change: func(a map[string]any) { delete(a, "confirm") }},
+		{name: "false confirmation", change: func(a map[string]any) { a["confirm"] = false }},
+		{name: "string confirmation", change: func(a map[string]any) { a["confirm"] = "true" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			args := make(map[string]any, len(valid))
+			for key, value := range valid {
+				args[key] = value
+			}
+			tt.change(args)
+			if _, err := s.executeTool("proxmox_guest_start", args); err == nil || strings.Contains(err.Error(), "read token") {
+				t.Errorf("error = %v", err)
+			}
+		})
+	}
+
+	for _, args := range []map[string]any{
+		{"node": "pve1", "upid": "UPID:opaque"},
+		{"endpoint": "pve", "upid": "UPID:opaque"},
+		{"endpoint": "pve", "node": "pve1"},
+	} {
+		if _, err := s.executeTool("proxmox_task_status", args); err == nil || strings.Contains(err.Error(), "read token") {
+			t.Errorf("task validation error = %v", err)
+		}
+	}
+}
+
+func TestProxmoxPhase2ConfirmationErrorIdentifiesTarget(t *testing.T) {
+	s := NewServer(&config.Config{}, "test")
+	_, err := s.executeTool("proxmox_guest_shutdown", map[string]any{
+		"endpoint": "pve", "node": "pve1", "type": "lxc", "vmid": float64(101), "confirm": false,
+	})
+	for _, want := range []string{`endpoint="pve"`, `node="pve1"`, `type="lxc"`, "vmid=101", `action="shutdown"`, "confirm to true"} {
+		if err == nil || !strings.Contains(err.Error(), want) {
+			t.Fatalf("confirmation error = %v, want %q", err, want)
+		}
+	}
+}
+
+func TestProxmoxPhase2Demo(t *testing.T) {
+	s := NewServer(&config.Config{}, "test", true)
+	args := map[string]any{"endpoint": "pve", "node": "pve1", "type": "qemu", "vmid": 100, "confirm": true}
+	for _, name := range []string{"proxmox_guest_start", "proxmox_guest_reboot", "proxmox_guest_shutdown"} {
+		result, err := s.executeDemoTool(name, args)
+		if err != nil || result.(proxmoxGuestActionResult).Status != "accepted" {
+			t.Errorf("%s demo = %#v, %v", name, result, err)
+		}
+	}
+	result, err := s.executeDemoTool("proxmox_task_status", map[string]any{"endpoint": "pve", "node": "pve1", "upid": "UPID:opaque"})
+	if err != nil || result.(proxmox.TaskStatus).Result != "completed successfully" {
+		t.Errorf("task demo = %#v, %v", result, err)
 	}
 }
 

--- a/internal/proxmox/client.go
+++ b/internal/proxmox/client.go
@@ -23,7 +23,12 @@ import (
 const defaultTimeout = 10 * time.Second
 
 const (
-	minVMID = 100
+	// minVMID matches the Proxmox API's own vmid schema minimum. 100 is only
+	// the default lower bound of /cluster/nextid's auto-assign range
+	// (datacenter.cfg next-id), not a floor the API enforces on an
+	// explicitly supplied vmid, and a cluster or an older pvesh-created
+	// guest can legitimately sit below it.
+	minVMID = 1
 	maxVMID = 999999999
 )
 
@@ -286,16 +291,16 @@ func ValidateTaskStatusRequest(node, upid string) error {
 	return nil
 }
 
-// TaskResult classifies the asynchronous task state for user-facing output.
+// TaskResult classifies the asynchronous task state as a short, stable token.
 func TaskResult(status, exitStatus string) string {
 	if status == "running" {
-		return "in flight"
+		return "running"
 	}
 	if status == "stopped" && exitStatus == "OK" {
-		return "completed successfully"
+		return "ok"
 	}
 	if status == "stopped" {
-		return "completed with failure"
+		return "failed"
 	}
 	return "unknown"
 }

--- a/internal/proxmox/client.go
+++ b/internal/proxmox/client.go
@@ -1,4 +1,4 @@
-// Package proxmox provides the small read-only Proxmox VE API client used by
+// Package proxmox provides the small Proxmox VE API client used by
 // HomeButler's Proxmox commands.
 package proxmox
 
@@ -22,6 +22,17 @@ import (
 
 const defaultTimeout = 10 * time.Second
 
+const (
+	minVMID = 100
+	maxVMID = 999999999
+)
+
+var guestActionPaths = map[GuestAction]string{
+	GuestActionStart:    "start",
+	GuestActionShutdown: "shutdown",
+	GuestActionReboot:   "reboot",
+}
+
 // Options configures a Proxmox API client. Token is the resolved token value;
 // resolving token files belongs to the configuration layer.
 type Options struct {
@@ -35,7 +46,7 @@ type Options struct {
 	Timeout     time.Duration
 }
 
-// Client is a read-only client for the Proxmox VE JSON API.
+// Client is a client for the Proxmox VE JSON API.
 type Client struct {
 	baseURL string
 	tokenID string
@@ -76,6 +87,12 @@ func New(options Options) (*Client, error) {
 		http: &http.Client{
 			Timeout:   options.Timeout,
 			Transport: &http.Transport{TLSClientConfig: tlsConfig},
+			CheckRedirect: func(_ *http.Request, via []*http.Request) error {
+				if len(via) > 0 && via[0].Method == http.MethodPost {
+					return http.ErrUseLastResponse
+				}
+				return nil
+			},
 		},
 	}, nil
 }
@@ -208,6 +225,81 @@ func (c *Client) TasksLimit(ctx context.Context, node string, limit int) ([]Task
 	return tasks, c.get(ctx, "/api2/json/nodes/"+url.PathEscape(node)+"/tasks", query, &tasks)
 }
 
+// ActOnGuest submits one approved guest power action and returns its opaque UPID.
+func (c *Client) ActOnGuest(ctx context.Context, node, guestType string, vmid int, action GuestAction) (string, error) {
+	if err := ValidateGuestAction(node, guestType, vmid, action); err != nil {
+		return "", err
+	}
+	suffix := guestActionPaths[action]
+	path := fmt.Sprintf("/api2/json/nodes/%s/%s/%d/status/%s",
+		url.PathEscape(node), url.PathEscape(guestType), vmid, url.PathEscape(suffix))
+	var upid string
+	if err := c.post(ctx, path, &upid); err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(upid) == "" {
+		return "", fmt.Errorf("proxmox guest action returned an empty UPID")
+	}
+	return upid, nil
+}
+
+// ValidateGuestAction validates an explicit guest action target without making a request.
+func ValidateGuestAction(node, guestType string, vmid int, action GuestAction) error {
+	if strings.TrimSpace(node) == "" {
+		return fmt.Errorf("proxmox node is required")
+	}
+	if guestType != "qemu" && guestType != "lxc" {
+		return fmt.Errorf("proxmox guest type must be qemu or lxc")
+	}
+	if vmid < minVMID || vmid > maxVMID {
+		return fmt.Errorf("proxmox VMID must be between %d and %d", minVMID, maxVMID)
+	}
+	_, ok := guestActionPaths[action]
+	if !ok {
+		return fmt.Errorf("unsupported Proxmox guest action %q", action)
+	}
+	return nil
+}
+
+// TaskStatus returns the current status of one opaque Proxmox task UPID.
+func (c *Client) TaskStatus(ctx context.Context, node, upid string) (TaskStatus, error) {
+	if err := ValidateTaskStatusRequest(node, upid); err != nil {
+		return TaskStatus{}, err
+	}
+	var status TaskStatus
+	path := "/api2/json/nodes/" + url.PathEscape(node) + "/tasks/" + url.PathEscape(upid) + "/status"
+	if err := c.get(ctx, path, nil, &status); err != nil {
+		return TaskStatus{}, err
+	}
+	status.Result = TaskResult(status.Status, status.ExitStatus)
+	return status, nil
+}
+
+// ValidateTaskStatusRequest validates a task lookup without making a request.
+func ValidateTaskStatusRequest(node, upid string) error {
+	if strings.TrimSpace(node) == "" {
+		return fmt.Errorf("proxmox node is required")
+	}
+	if strings.TrimSpace(upid) == "" {
+		return fmt.Errorf("proxmox UPID is required")
+	}
+	return nil
+}
+
+// TaskResult classifies the asynchronous task state for user-facing output.
+func TaskResult(status, exitStatus string) string {
+	if status == "running" {
+		return "in flight"
+	}
+	if status == "stopped" && exitStatus == "OK" {
+		return "completed successfully"
+	}
+	if status == "stopped" {
+		return "completed with failure"
+	}
+	return "unknown"
+}
+
 // DefaultView performs the three requests used by the default status view.
 func (c *Client) DefaultView(ctx context.Context) (DefaultView, error) {
 	view := DefaultView{}
@@ -233,12 +325,20 @@ func (c *Client) DefaultView(ctx context.Context) (DefaultView, error) {
 }
 
 func (c *Client) get(ctx context.Context, path string, query url.Values, out any) error {
+	return c.request(ctx, http.MethodGet, path, query, out)
+}
+
+func (c *Client) post(ctx context.Context, path string, out any) error {
+	return c.request(ctx, http.MethodPost, path, nil, out)
+}
+
+func (c *Client) request(ctx context.Context, method, path string, query url.Values, out any) error {
 	u, err := url.Parse(c.baseURL + path)
 	if err != nil {
 		return fmt.Errorf("build Proxmox request URL: %w", err)
 	}
 	u.RawQuery = query.Encode()
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	req, err := http.NewRequestWithContext(ctx, method, u.String(), nil)
 	if err != nil {
 		return fmt.Errorf("build Proxmox request: %w", err)
 	}
@@ -260,6 +360,7 @@ func (c *Client) get(ctx context.Context, path string, query url.Values, out any
 		}
 		_ = json.Unmarshal(body, &apiError)
 		if message := strings.TrimSpace(apiError.Message); message != "" {
+			message = strings.ReplaceAll(message, c.token, "[REDACTED]")
 			return fmt.Errorf("proxmox request %s: %s: %s", path, resp.Status, message)
 		}
 		return fmt.Errorf("proxmox request %s: %s", path, resp.Status)

--- a/internal/proxmox/client_test.go
+++ b/internal/proxmox/client_test.go
@@ -190,6 +190,215 @@ func TestResourcesEmptyForInsufficientACLs(t *testing.T) {
 	}
 }
 
+func TestPostUsesSharedAuthenticatedTransport(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %q, want POST", r.Method)
+		}
+		if got, want := r.Header.Get("Authorization"), "PVEAPIToken=monitoring@pve!readonly=fixture-token"; got != want {
+			t.Errorf("Authorization = %q, want %q", got, want)
+		}
+		_, _ = w.Write([]byte(`{"data":"UPID:fixture"}`))
+	}))
+	defer server.Close()
+
+	var upid string
+	if err := newTLSClient(t, server.URL, Options{Insecure: true}).post(context.Background(), "/api2/json/test", &upid); err != nil {
+		t.Fatal(err)
+	}
+	if upid != "UPID:fixture" {
+		t.Errorf("UPID = %q, want UPID:fixture", upid)
+	}
+}
+
+func TestGuestActions(t *testing.T) {
+	tests := []struct {
+		guestType string
+		action    GuestAction
+	}{
+		{guestType: "qemu", action: GuestActionStart},
+		{guestType: "qemu", action: GuestActionShutdown},
+		{guestType: "qemu", action: GuestActionReboot},
+		{guestType: "lxc", action: GuestActionStart},
+		{guestType: "lxc", action: GuestActionShutdown},
+		{guestType: "lxc", action: GuestActionReboot},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.guestType+"/"+string(tt.action), func(t *testing.T) {
+			calls := 0
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				calls++
+				if r.Method != http.MethodPost {
+					t.Errorf("method = %q, want POST", r.Method)
+				}
+				if got, want := r.Header.Get("Authorization"), "PVEAPIToken=monitoring@pve!readonly=fixture-token"; got != want {
+					t.Errorf("Authorization = %q, want %q", got, want)
+				}
+				wantPath := "/api2/json/nodes/pve%2Fedge/" + tt.guestType + "/100/status/" + string(tt.action)
+				if got := r.URL.EscapedPath(); got != wantPath {
+					t.Errorf("path = %q, want %q", got, wantPath)
+				}
+				_, _ = w.Write([]byte(`{"data":"UPID:pve1:opaque"}`))
+			}))
+			defer server.Close()
+
+			upid, err := newTLSClient(t, server.URL, Options{Insecure: true}).ActOnGuest(context.Background(), "pve/edge", tt.guestType, 100, tt.action)
+			if err != nil || upid != "UPID:pve1:opaque" {
+				t.Fatalf("ActOnGuest() = %q, %v", upid, err)
+			}
+			if calls != 1 {
+				t.Errorf("requests = %d, want 1", calls)
+			}
+		})
+	}
+}
+
+func TestGuestActionValidationMakesNoRequest(t *testing.T) {
+	calls := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { calls++ }))
+	defer server.Close()
+	client := newTLSClient(t, server.URL, Options{Insecure: true})
+
+	tests := []struct {
+		name      string
+		node      string
+		guestType string
+		vmid      int
+		action    GuestAction
+	}{
+		{name: "empty node", guestType: "qemu", vmid: 100, action: GuestActionStart},
+		{name: "invalid type", node: "pve1", guestType: "vm", vmid: 100, action: GuestActionStart},
+		{name: "VMID too small", node: "pve1", guestType: "qemu", vmid: minVMID - 1, action: GuestActionStart},
+		{name: "VMID too large", node: "pve1", guestType: "qemu", vmid: maxVMID + 1, action: GuestActionStart},
+		{name: "invalid action", node: "pve1", guestType: "qemu", vmid: 100, action: GuestAction("stop")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := client.ActOnGuest(context.Background(), tt.node, tt.guestType, tt.vmid, tt.action); err == nil {
+				t.Fatal("ActOnGuest() error = nil")
+			}
+		})
+	}
+	for _, target := range []struct{ node, upid string }{
+		{node: "", upid: "UPID:opaque"},
+		{node: " ", upid: "UPID:opaque"},
+		{node: "pve1", upid: ""},
+		{node: "pve1", upid: " "},
+	} {
+		if _, err := client.TaskStatus(context.Background(), target.node, target.upid); err == nil {
+			t.Errorf("TaskStatus(%q, %q) error = nil", target.node, target.upid)
+		}
+	}
+	if calls != 0 {
+		t.Errorf("requests = %d, want 0", calls)
+	}
+}
+
+func TestGuestActionRejectsInvalidUPIDResponse(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"data":""}`))
+	}))
+	defer server.Close()
+
+	if _, err := newTLSClient(t, server.URL, Options{Insecure: true}).ActOnGuest(context.Background(), "pve1", "qemu", 100, GuestActionStart); err == nil || !strings.Contains(err.Error(), "empty UPID") {
+		t.Errorf("ActOnGuest() error = %v", err)
+	}
+}
+
+func TestTaskStatus(t *testing.T) {
+	tests := []struct {
+		fixture    string
+		status     string
+		exitStatus string
+	}{
+		{fixture: "task-status-running.json", status: "running"},
+		{fixture: "task-status-stopped-ok.json", status: "stopped", exitStatus: "OK"},
+		{fixture: "task-status-stopped-error.json", status: "stopped", exitStatus: "guest is locked"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.fixture, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.Method != http.MethodGet {
+					t.Errorf("method = %q, want GET", r.Method)
+				}
+				if got, want := r.URL.EscapedPath(), "/api2/json/nodes/pve%2Fedge/tasks/UPID:pve1%2Fopaque%3Fvalue/status"; got != want {
+					t.Errorf("path = %q, want %q", got, want)
+				}
+				_, _ = w.Write(readFixture(t, tt.fixture))
+			}))
+			defer server.Close()
+
+			status, err := newTLSClient(t, server.URL, Options{Insecure: true}).TaskStatus(context.Background(), "pve/edge", "UPID:pve1/opaque?value")
+			if err != nil {
+				t.Fatal(err)
+			}
+			if status.Status != tt.status || status.ExitStatus != tt.exitStatus || status.Result != TaskResult(tt.status, tt.exitStatus) || status.UPID == "" {
+				t.Errorf("TaskStatus() = %#v", status)
+			}
+		})
+	}
+}
+
+func TestGuestActionDoesNotRetryAmbiguousFailure(t *testing.T) {
+	calls := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		connection, _, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = connection.Close()
+	}))
+	defer server.Close()
+
+	_, err := newTLSClient(t, server.URL, Options{Insecure: true}).ActOnGuest(context.Background(), "pve1", "qemu", 100, GuestActionStart)
+	if err == nil {
+		t.Fatal("ActOnGuest() error = nil")
+	}
+	if calls != 1 {
+		t.Errorf("requests = %d, want 1", calls)
+	}
+	if strings.Contains(err.Error(), "fixture-token") {
+		t.Errorf("error exposes token: %v", err)
+	}
+}
+
+func TestGuestActionDoesNotFollowRedirect(t *testing.T) {
+	targetCalls := 0
+	target := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) { targetCalls++ }))
+	defer target.Close()
+
+	sourceCalls := 0
+	source := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sourceCalls++
+		http.Redirect(w, r, target.URL, http.StatusTemporaryRedirect)
+	}))
+	defer source.Close()
+
+	_, err := newTLSClient(t, source.URL, Options{Insecure: true}).ActOnGuest(context.Background(), "pve1", "qemu", 100, GuestActionStart)
+	if err == nil || !strings.Contains(err.Error(), "307 Temporary Redirect") {
+		t.Fatalf("ActOnGuest() error = %v", err)
+	}
+	if sourceCalls != 1 || targetCalls != 0 {
+		t.Errorf("requests = source:%d target:%d, want source:1 target:0", sourceCalls, targetCalls)
+	}
+}
+
+func TestAPIErrorRedactsReflectedToken(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"message":"credential fixture-token was denied"}`))
+	}))
+	defer server.Close()
+
+	_, err := newTLSClient(t, server.URL, Options{Insecure: true}).ActOnGuest(context.Background(), "pve1", "qemu", 100, GuestActionStart)
+	if err == nil || strings.Contains(err.Error(), "fixture-token") || !strings.Contains(err.Error(), "[REDACTED]") {
+		t.Errorf("ActOnGuest() error = %v", err)
+	}
+}
+
 func TestAPIErrorIncludesMessage(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusForbidden)

--- a/internal/proxmox/testdata/task-status-running.json
+++ b/internal/proxmox/testdata/task-status-running.json
@@ -1,0 +1,1 @@
+{"data":{"upid":"UPID:pve1:00000001:00000002:00000003:qmstart:100:automation@pve:","node":"pve1","pid":1234,"pstart":2,"starttime":1,"type":"qmstart","id":"100","user":"automation@pve","status":"running"}}

--- a/internal/proxmox/testdata/task-status-stopped-error.json
+++ b/internal/proxmox/testdata/task-status-stopped-error.json
@@ -1,0 +1,1 @@
+{"data":{"upid":"UPID:pve1:00000001:00000002:00000003:qmstart:100:automation@pve:","node":"pve1","pid":1234,"pstart":2,"starttime":1,"type":"qmstart","id":"100","user":"automation@pve","status":"stopped","exitstatus":"guest is locked"}}

--- a/internal/proxmox/testdata/task-status-stopped-ok.json
+++ b/internal/proxmox/testdata/task-status-stopped-ok.json
@@ -1,0 +1,1 @@
+{"data":{"upid":"UPID:pve1:00000001:00000002:00000003:qmstart:100:automation@pve:","node":"pve1","pid":1234,"pstart":2,"starttime":1,"type":"qmstart","id":"100","user":"automation@pve","status":"stopped","exitstatus":"OK"}}

--- a/internal/proxmox/types.go
+++ b/internal/proxmox/types.go
@@ -250,6 +250,30 @@ type Task struct {
 	Status    string `json:"status"`
 }
 
+// GuestAction is one approved guest power operation.
+type GuestAction string
+
+const (
+	GuestActionStart    GuestAction = "start"
+	GuestActionShutdown GuestAction = "shutdown"
+	GuestActionReboot   GuestAction = "reboot"
+)
+
+// TaskStatus is returned by /nodes/{node}/tasks/{upid}/status.
+type TaskStatus struct {
+	UPID       string `json:"upid"`
+	Node       string `json:"node"`
+	PID        int64  `json:"pid,omitempty"`
+	PStart     int64  `json:"pstart,omitempty"`
+	StartTime  int64  `json:"starttime,omitempty"`
+	Type       string `json:"type"`
+	ID         string `json:"id,omitempty"`
+	User       string `json:"user,omitempty"`
+	Status     string `json:"status"`
+	ExitStatus string `json:"exitstatus,omitempty"`
+	Result     string `json:"result"`
+}
+
 // DefaultView contains the three responses used by the initial status view.
 type DefaultView struct {
 	Version   Version         `json:"version"`


### PR DESCRIPTION
## Summary

Implements the Phase 2 write actions from #32: start/shutdown/reboot for QEMU and LXC guests, and single-task status lookup, exposed through the CLI and over MCP.

- Shutdown maps to Proxmox's graceful `status/shutdown`, not the hard `status/stop` power-off, per the maintainer's answer on #32: hard stop would make `stop` mean two different things across `homebutler docker stop` (graceful) and `homebutler proxmox guest stop`, and the destructive one would be the verb users reach for. The action→endpoint mapping is centralized in one small table so that decision is cheap to revisit.
- `--endpoint`/`--node`/`--type`/`--vmid`/`--confirm` (and the MCP equivalents) are all required and validated before token resolution or any network call — no unconfirmed action reaches the wire.
- The HTTP client refuses to follow redirects on POST, so a 307/308 can't cause a power action to be silently repeated against a different target.
- No automatic retry after an ambiguous POST failure (e.g. connection dropped mid-request).
- A successful action reports `accepted` with the opaque UPID, never completion — task status is a separate, explicit lookup that distinguishes running / stopped+OK / stopped+failed.

Reused Phase 1's `proxmox:` config, endpoint/token resolution, TLS handling, `targetProxmox`, and sanitized-fixture test approach. No new dependencies.

## Test plan

- [x] `go test ./internal/proxmox ./cmd ./internal/mcp` — 169 passed
- [x] `go test -race ./internal/proxmox ./cmd ./internal/mcp` — 169 passed
- [x] `go vet ./...`, `golangci-lint run`, `gofmt -l .` — clean
- [x] `go build ./...` — clean
- [x] `go test ./...` (full suite) — 1081 passed
- [x] Table-driven tests assert method, auth header, exact escaped path, and that invalid input (bad node/type/vmid/action, missing confirm) makes zero requests
- [x] Redirect-refusal and ambiguous-failure-no-retry covered by dedicated tests
- [x] MCP demo mode and registry-wide demo coverage updated for both new tools
