### PR TITLE
ci: let a CI run be started by hand

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,12 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Lets a run be started by hand when GitHub never created one for a pull
+  # request. That happened on #90: no run and no check suite existed for the
+  # head commit, and the only way to get the required checks was to close and
+  # reopen the pull request, which leaves a closed/reopened pair on a
+  # contributor's timeline that reads like a rejection.
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
GitHub created no workflow run and no check suite for #90's head commit — not an `action_required` run awaiting approval, nothing at all — so the checks `main` requires had no way to appear. Reopening the pull request fired the `reopened` trigger and CI then ran green, but that leaves a closed/reopened pair on the contributor's timeline that reads like the work was rejected and reinstated.

`workflow_dispatch` gives the same result from the Actions tab without touching the pull request.

Deliberately not added to `release.yml`. A run there publishes binaries, the Homebrew tap, the npm package and the MCP Registry entry, and pushing a tag should stay the only way to reach it.

The trigger only becomes usable once this is on `main` — GitHub reads the dispatch list from the default branch, so the button will not exist on this PR itself.
