### PR TITLE
feat: print a Proxmox Community Script command instead of running one

### DIFF
--- a/cmd/proxmox.go
+++ b/cmd/proxmox.go
@@ -314,9 +314,9 @@ func newProxmoxScriptShowCmd() *cobra.Command {
 			if err != nil {
 				return err
 			}
-			result := proxmoxScriptCommandResult{Slug: args[0], Command: command}
+			result := proxmoxScriptCommandResult{Slug: args[0], Command: command, Warning: proxmox.ScriptWarning}
 			return writeProxmox(cmd, result, jsonOutput, "Community Script command", func(b *strings.Builder) {
-				fmt.Fprintf(b, "Slug: %s\nCommand: %s\n\nReview it, then run it yourself on the Proxmox host; homebutler does not run it for you.\n", result.Slug, result.Command)
+				fmt.Fprintf(b, "Slug: %s\nCommand: %s\n\n⚠️  %s\n\nReview it, then run it yourself on the Proxmox host; homebutler does not run it for you.\n", result.Slug, result.Command, result.Warning)
 			})
 		},
 	}
@@ -326,6 +326,7 @@ func newProxmoxScriptShowCmd() *cobra.Command {
 type proxmoxScriptCommandResult struct {
 	Slug    string `json:"slug"`
 	Command string `json:"command"`
+	Warning string `json:"warning"`
 }
 
 type proxmoxGuestActionResult struct {

--- a/cmd/proxmox.go
+++ b/cmd/proxmox.go
@@ -17,7 +17,7 @@ func newProxmoxCmd() *cobra.Command {
 		Short:        "Inspect Proxmox VE endpoints",
 		SilenceUsage: true,
 	}
-	cmd.AddCommand(newProxmoxStatusCmd(), newProxmoxGuestsCmd(), newProxmoxNodeCmd(), newProxmoxTasksCmd(), newProxmoxGuestCmd(), newProxmoxTaskCmd())
+	cmd.AddCommand(newProxmoxStatusCmd(), newProxmoxGuestsCmd(), newProxmoxNodeCmd(), newProxmoxTasksCmd(), newProxmoxGuestCmd(), newProxmoxTaskCmd(), newProxmoxScriptCmd())
 	return cmd
 }
 
@@ -280,6 +280,52 @@ func newProxmoxTaskCmd() *cobra.Command {
 	cmd.Flags().StringVar(&endpointName, "endpoint", "", "Proxmox endpoint name (required)")
 	cmd.Flags().StringVar(&node, "node", "", "Proxmox node name (required)")
 	return cmd
+}
+
+func newProxmoxScriptCmd() *cobra.Command {
+	cmd := &cobra.Command{Use: "script", Short: "Show Proxmox VE Community Script install commands", Args: cobra.NoArgs}
+	cmd.AddCommand(newProxmoxScriptListCmd(), newProxmoxScriptShowCmd())
+	return cmd
+}
+
+func newProxmoxScriptListCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "list",
+		Short: "List the curated Proxmox VE Community Scripts catalog",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			scripts := proxmox.Scripts()
+			return writeProxmox(cmd, scripts, jsonOutput, "Community Scripts", func(b *strings.Builder) {
+				for _, script := range scripts {
+					fmt.Fprintf(b, "%s\t%s\t%s\n", script.Slug, script.Name, script.Description)
+				}
+			})
+		},
+	}
+}
+
+func newProxmoxScriptShowCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "show <slug>",
+		Short: "Print the install command for one Community Script (does not run it)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			command, err := proxmox.ScriptCommand(args[0])
+			if err != nil {
+				return err
+			}
+			result := proxmoxScriptCommandResult{Slug: args[0], Command: command}
+			return writeProxmox(cmd, result, jsonOutput, "Community Script command", func(b *strings.Builder) {
+				fmt.Fprintf(b, "Slug: %s\nCommand: %s\n\nReview it, then run it yourself on the Proxmox host; homebutler does not run it for you.\n", result.Slug, result.Command)
+			})
+		},
+	}
+	return cmd
+}
+
+type proxmoxScriptCommandResult struct {
+	Slug    string `json:"slug"`
+	Command string `json:"command"`
 }
 
 type proxmoxGuestActionResult struct {

--- a/cmd/proxmox_script_test.go
+++ b/cmd/proxmox_script_test.go
@@ -53,7 +53,7 @@ func TestProxmoxScriptShowNeverExecutes(t *testing.T) {
 		t.Fatal(err)
 	}
 	got := output.String()
-	for _, want := range []string{"Slug: docker", "curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/", "does not run it for you"} {
+	for _, want := range []string{"Slug: docker", "curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/", "does not run it for you", "not reviewed by homebutler", "runs as root"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("script show output missing %q:\n%s", want, got)
 		}
@@ -84,7 +84,7 @@ func TestProxmoxScriptShowJSON(t *testing.T) {
 	if err := json.Unmarshal(output.Bytes(), &result); err != nil {
 		t.Fatal(err)
 	}
-	if result.Slug != "pihole" || !strings.Contains(result.Command, "/ct/pihole.sh") {
+	if result.Slug != "pihole" || !strings.Contains(result.Command, "/ct/pihole.sh") || result.Warning == "" {
 		t.Errorf("script show result = %#v", result)
 	}
 }

--- a/cmd/proxmox_script_test.go
+++ b/cmd/proxmox_script_test.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestProxmoxScriptListJSON(t *testing.T) {
+	oldJSON := jsonOutput
+	defer func() { jsonOutput = oldJSON }()
+	jsonOutput = true
+
+	cmd := newProxmoxScriptListCmd()
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	var scripts []struct {
+		Slug        string `json:"slug"`
+		Name        string `json:"name"`
+		Description string `json:"description"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &scripts); err != nil {
+		t.Fatalf("decode script list JSON: %v\n%s", err, output.String())
+	}
+	if len(scripts) == 0 {
+		t.Fatal("script list is empty")
+	}
+	found := false
+	for _, s := range scripts {
+		if s.Slug == "docker" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("script list = %#v, want a docker entry", scripts)
+	}
+}
+
+func TestProxmoxScriptShowNeverExecutes(t *testing.T) {
+	oldJSON := jsonOutput
+	defer func() { jsonOutput = oldJSON }()
+	jsonOutput = false
+
+	cmd := newProxmoxScriptShowCmd()
+	cmd.SetArgs([]string{"docker"})
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	got := output.String()
+	for _, want := range []string{"Slug: docker", "curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/", "does not run it for you"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("script show output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestProxmoxScriptShowUnknownSlug(t *testing.T) {
+	cmd := newProxmoxScriptShowCmd()
+	cmd.SetArgs([]string{"nope"})
+	if err := cmd.Execute(); err == nil || !strings.Contains(err.Error(), `unknown Proxmox Community Script "nope"`) {
+		t.Fatalf("script show error = %v", err)
+	}
+}
+
+func TestProxmoxScriptShowJSON(t *testing.T) {
+	oldJSON := jsonOutput
+	defer func() { jsonOutput = oldJSON }()
+	jsonOutput = true
+
+	cmd := newProxmoxScriptShowCmd()
+	cmd.SetArgs([]string{"pihole"})
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	if err := cmd.Execute(); err != nil {
+		t.Fatal(err)
+	}
+	var result proxmoxScriptCommandResult
+	if err := json.Unmarshal(output.Bytes(), &result); err != nil {
+		t.Fatal(err)
+	}
+	if result.Slug != "pihole" || !strings.Contains(result.Command, "/ct/pihole.sh") {
+		t.Errorf("script show result = %#v", result)
+	}
+}

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -74,38 +74,48 @@ Restart your AI client — homebutler tools will appear automatically.
 
 ## Available Tools
 
-| Tool | Description |
-|---|---|
-| `system_status` | CPU, memory, disk, uptime |
-| `report` | Butler-style health report with snapshot comparison and suggested actions |
-| `doctor` | Read-only diagnosis of resource pressure, stopped containers, public ports, backup hygiene, and notification readiness |
-| `watch_check` | One-shot restart check on watched targets; reports systemd and pm2 targets as skipped rather than healthy |
-| `watch_history` | Recorded restart incidents, newest first. Captured logs are excluded unless `include_logs` is set |
-| `watch_list` | Targets being watched, with their kind and what the last check recorded |
-| `inventory_scan` | Server inventory/topology: system, containers, app ports, system ports |
-| `inventory_export` | Export inventory as Mermaid (local) or JSON |
-| `docker_list` | List containers |
-| `docker_restart` | Restart a container |
-| `docker_stop` | Stop a container |
-| `docker_logs` | Container log output |
-| `docker_stats` | Running container resource usage |
-| `docker_top` | Processes inside a container, read from the host — no exec, no TTY |
-| `docker_inspect` | Image, state, restart policy, ports, mounts, networks, health. Env values are never included |
-| `wake` | Wake-on-LAN magic packet |
-| `open_ports` | Open ports with process info |
-| `network_scan` | Discover LAN devices |
-| `alerts` | Resource threshold alerts |
-| `backup_create` | Create Docker compose backup archive |
-| `backup_list` | List backup archives |
-| `backup_drill` | Boot a backup in isolation and verify app health |
-| `backup_restore` | Restore volumes from a backup archive |
-| `install_list` | List installable self-hosted apps |
-| `install_app` | Install an app via generated docker-compose.yml |
-| `install_status` | Check installed app status |
-| `install_uninstall` | Stop an app while preserving data |
-| `install_purge` | Stop an app and delete all data |
-| `processes` | Top processes by CPU or memory, with zombies broken out separately |
-| `config_validate` | Check the config file this server is running on |
+| Tool                     | Description                                                                                                            |
+|--------------------------|------------------------------------------------------------------------------------------------------------------------|
+| `system_status`          | CPU, memory, disk, uptime                                                                                              |
+| `report`                 | Butler-style health report with snapshot comparison and suggested actions                                              |
+| `doctor`                 | Read-only diagnosis of resource pressure, stopped containers, public ports, backup hygiene, and notification readiness |
+| `watch_check`            | One-shot restart check on watched targets; reports systemd and pm2 targets as skipped rather than healthy              |
+| `watch_history`          | Recorded restart incidents, newest first. Captured logs are excluded unless `include_logs` is set                      |
+| `watch_list`             | Targets being watched, with their kind and what the last check recorded                                                |
+| `inventory_scan`         | Server inventory/topology: system, containers, app ports, system ports                                                 |
+| `inventory_export`       | Export inventory as Mermaid (local) or JSON                                                                            |
+| `docker_list`            | List containers                                                                                                        |
+| `docker_restart`         | Restart a container                                                                                                    |
+| `docker_stop`            | Stop a container                                                                                                       |
+| `docker_logs`            | Container log output                                                                                                   |
+| `docker_stats`           | Running container resource usage                                                                                       |
+| `docker_top`             | Processes inside a container, read from the host — no exec, no TTY                                                     |
+| `docker_inspect`         | Image, state, restart policy, ports, mounts, networks, health. Env values are never included                           |
+| `wake`                   | Wake-on-LAN magic packet                                                                                               |
+| `open_ports`             | Open ports with process info                                                                                           |
+| `network_scan`           | Discover LAN devices                                                                                                   |
+| `alerts`                 | Resource threshold alerts                                                                                              |
+| `backup_create`          | Create Docker compose backup archive                                                                                   |
+| `backup_list`            | List backup archives                                                                                                   |
+| `backup_drill`           | Boot a backup in isolation and verify app health                                                                       |
+| `backup_restore`         | Restore volumes from a backup archive                                                                                  |
+| `install_list`           | List installable self-hosted apps                                                                                      |
+| `install_app`            | Install an app via generated docker-compose.yml                                                                        |
+| `install_status`         | Check installed app status                                                                                             |
+| `install_uninstall`      | Stop an app while preserving data                                                                                      |
+| `install_purge`          | Stop an app and delete all data                                                                                        |
+| `processes`              | Top processes by CPU or memory, with zombies broken out separately                                                     |
+| `config_validate`        | Check the config file this server is running on                                                                        |
+| `proxmox_status`         | Proxmox VE version, cluster status, and resources                                                                      |
+| `proxmox_guests`         | Unified QEMU/LXC guest list; optional `node`, `status`, `type` filters                                                 |
+| `proxmox_node`           | Node detail; requires `node`                                                                                           |
+| `proxmox_tasks`          | Recent tasks for a node; requires `node`                                                                               |
+| `proxmox_guest_start`    | Start a guest; requires `node`, `type`, `vmid`, and literal `confirm: true`                                            |
+| `proxmox_guest_reboot`   | Reboot a guest; requires `node`, `type`, `vmid`, and literal `confirm: true`                                           |
+| `proxmox_guest_shutdown` | Gracefully shut down a guest; requires `node`, `type`, `vmid`, and literal `confirm: true`                             |
+| `proxmox_task_status`    | Status of one task; requires `node` and the opaque `upid`                                                              |
+| `proxmox_script_list`    | List the curated Proxmox VE Community Scripts catalog                                                                  |
+| `proxmox_script_command` | Render the pinned install command for one Community Script; never fetches or runs it                                   |
 
 Most read/check tools support an optional `server` parameter — manage every server from a single prompt. Destructive tools such as `backup_restore`, `install_purge`, and container stop/restart should only be called after the user clearly confirms intent.
 

--- a/docs/proxmox.md
+++ b/docs/proxmox.md
@@ -153,6 +153,24 @@ QEMU hard stop is equivalent to pulling the power plug and can damage guest
 data; LXC hard stop abruptly terminates container processes. A future hard-stop
 operation, if needed, must use its own unmistakable name and safety contract.
 
+## Community Scripts
+
+```bash
+homebutler proxmox script list
+homebutler proxmox script show docker
+```
+
+`proxmox script show <slug>` prints an install command from the curated
+[Proxmox VE Community Scripts](https://github.com/community-scripts/ProxmoxVE)
+catalog. HomeButler only formats that command; it never fetches or runs it.
+The command is pinned to one commit of the upstream repository rather than
+`main`, so the bytes a script fetches today match a week from now — bumping
+the pin is a deliberate, reviewable one-line change.
+
+The output always carries a warning, in human text, `--json`, and over MCP
+alike: the script is not reviewed by HomeButler, and it runs as root on the
+Proxmox host. Read it, review the command yourself, and run it by hand.
+
 ## MCP tools
 
 The MCP server exposes these read-only Proxmox tools. Each accepts `endpoint`
@@ -179,10 +197,17 @@ Risk metadata helps MCP clients make policy decisions, but it does not replace
 runtime confirmation. Every action tool rejects a missing, false, or non-boolean
 confirmation before HomeButler resolves the token or contacts Proxmox.
 
+Two more tools cover Community Scripts and take no `endpoint`, since neither
+contacts Proxmox:
+
+- `proxmox_script_list` - `riskRead`; lists the curated catalog.
+- `proxmox_script_command` - `riskRead`; requires `slug`; renders the pinned
+  install command and a `warning` field with the same text the CLI prints.
+
 ## Excluded scope
 
 HomeButler does not expose Proxmox hard stop, guest creation or deletion,
 migration, reset, suspend or resume, snapshots, task polling, automatic POST
-retries, arbitrary API actions, or root-only action overrides. The web dashboard
-and Community Scripts provisioning remain separate work; HomeButler does not
-fetch or execute external provisioning scripts.
+retries, arbitrary API actions, or root-only action overrides. The web
+dashboard remains separate work. HomeButler prints Community Script install
+commands for a human to review and run; it never fetches or executes them.

--- a/internal/mcp/capabilities.go
+++ b/internal/mcp/capabilities.go
@@ -159,6 +159,26 @@ var capabilityRegistry = []capability{
 	},
 	{
 		risk:    riskRead,
+		targets: []targetKind{targetLocal},
+		tool: toolDef{
+			Name:        "proxmox_script_list",
+			Description: "List the curated Proxmox VE Community Scripts catalog (community-scripts/ProxmoxVE)",
+			InputSchema: inputSchema{Type: "object"},
+		},
+	},
+	{
+		risk:    riskRead,
+		targets: []targetKind{targetLocal},
+		tool: toolDef{
+			Name:        "proxmox_script_command",
+			Description: "Render the pinned install command for one Proxmox VE Community Script. Never fetches or runs it; the caller reviews and runs it themselves on the Proxmox host",
+			InputSchema: inputSchema{Type: "object", Properties: map[string]propDef{
+				"slug": {Type: "string", Description: "Script slug from proxmox_script_list, such as docker"},
+			}, Required: []string{"slug"}},
+		},
+	},
+	{
+		risk:    riskRead,
 		targets: []targetKind{targetLocal, targetServer},
 		tool: toolDef{
 			Name:        "docker_list",

--- a/internal/mcp/demo.go
+++ b/internal/mcp/demo.go
@@ -244,7 +244,7 @@ func (s *Server) executeDemoTool(name string, args map[string]any) (any, error) 
 		if err != nil {
 			return nil, err
 		}
-		return map[string]any{"slug": slug, "command": command}, nil
+		return map[string]any{"slug": slug, "command": command, "warning": proxmox.ScriptWarning}, nil
 
 	case "install_list":
 		// The catalogue is a static map compiled into the binary, so demo mode

--- a/internal/mcp/demo.go
+++ b/internal/mcp/demo.go
@@ -230,6 +230,22 @@ func (s *Server) executeDemoTool(name string, args map[string]any) (any, error) 
 			return nil, fmt.Errorf("missing required parameter: archive")
 		}
 		return map[string]any{"archive": archive, "services": []string{"demo"}, "volumes": 1}, nil
+	case "proxmox_script_list":
+		// Static catalog compiled into the binary; demo mode answers it
+		// truthfully rather than inventing scripts that would drift from it.
+		return proxmox.Scripts(), nil
+
+	case "proxmox_script_command":
+		slug, ok := requireString(args, "slug")
+		if !ok {
+			return nil, fmt.Errorf("missing required parameter: slug")
+		}
+		command, err := proxmox.ScriptCommand(slug)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{"slug": slug, "command": command}, nil
+
 	case "install_list":
 		// The catalogue is a static map compiled into the binary, so demo mode
 		// can answer this truthfully instead of inventing apps that would drift

--- a/internal/mcp/demo_test.go
+++ b/internal/mcp/demo_test.go
@@ -76,6 +76,7 @@ func TestEveryAdvertisedToolHasADemoImplementation(t *testing.T) {
 		"app":      "uptime-kuma",
 		"target":   "aa:bb:cc:dd:ee:ff",
 		"archive":  "demo.tar.gz",
+		"slug":     "docker",
 	}
 
 	for _, c := range capabilityRegistry {

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -302,6 +302,7 @@ func TestToolDefinitionsHaveRequiredFields(t *testing.T) {
 		"proxmox_guest_reboot":   {"endpoint", "node", "type", "vmid", "confirm"},
 		"proxmox_guest_shutdown": {"endpoint", "node", "type", "vmid", "confirm"},
 		"proxmox_task_status":    {"endpoint", "node", "upid"},
+		"proxmox_script_command": {"slug"},
 	}
 
 	for _, tool := range tools {

--- a/internal/mcp/proxmox_script_test.go
+++ b/internal/mcp/proxmox_script_test.go
@@ -1,0 +1,71 @@
+package mcp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Higangssh/homebutler/internal/config"
+	"github.com/Higangssh/homebutler/internal/proxmox"
+)
+
+func TestProxmoxScriptToolsAreLocalReadOnly(t *testing.T) {
+	for _, name := range []string{"proxmox_script_list", "proxmox_script_command"} {
+		cap, ok := capabilityFor(name)
+		if !ok {
+			t.Fatalf("%s is not registered", name)
+		}
+		if cap.risk != riskRead || !cap.supports(targetLocal) || cap.supports(targetProxmox) || cap.supports(targetServer) {
+			t.Errorf("%s capability = %#v", name, cap)
+		}
+	}
+}
+
+func TestProxmoxScriptListTool(t *testing.T) {
+	s := NewServer(&config.Config{}, "test")
+	result, err := s.executeTool("proxmox_script_list", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	scripts, ok := result.([]proxmox.Script)
+	if !ok || len(scripts) == 0 {
+		t.Fatalf("proxmox_script_list = %#v", result)
+	}
+}
+
+func TestProxmoxScriptCommandTool(t *testing.T) {
+	s := NewServer(&config.Config{}, "test")
+	result, err := s.executeTool("proxmox_script_command", map[string]any{"slug": "docker"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	command, ok := result.(map[string]any)
+	if !ok || command["slug"] != "docker" || !strings.Contains(command["command"].(string), "/ct/docker.sh") {
+		t.Fatalf("proxmox_script_command = %#v", result)
+	}
+
+	if _, err := s.executeTool("proxmox_script_command", map[string]any{}); err == nil || !strings.Contains(err.Error(), "missing required parameter: slug") {
+		t.Errorf("missing slug error = %v", err)
+	}
+	if _, err := s.executeTool("proxmox_script_command", map[string]any{"slug": "nope"}); err == nil || !strings.Contains(err.Error(), "unknown Proxmox Community Script") {
+		t.Errorf("unknown slug error = %v", err)
+	}
+}
+
+func TestProxmoxScriptToolsDemo(t *testing.T) {
+	s := NewServer(&config.Config{}, "test", true)
+	list, err := s.executeDemoTool("proxmox_script_list", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if scripts, ok := list.([]proxmox.Script); !ok || len(scripts) == 0 {
+		t.Fatalf("demo proxmox_script_list = %#v", list)
+	}
+
+	command, err := s.executeDemoTool("proxmox_script_command", map[string]any{"slug": "docker"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if m, ok := command.(map[string]any); !ok || m["slug"] != "docker" {
+		t.Fatalf("demo proxmox_script_command = %#v", command)
+	}
+}

--- a/internal/mcp/proxmox_script_test.go
+++ b/internal/mcp/proxmox_script_test.go
@@ -39,7 +39,7 @@ func TestProxmoxScriptCommandTool(t *testing.T) {
 		t.Fatal(err)
 	}
 	command, ok := result.(map[string]any)
-	if !ok || command["slug"] != "docker" || !strings.Contains(command["command"].(string), "/ct/docker.sh") {
+	if !ok || command["slug"] != "docker" || !strings.Contains(command["command"].(string), "/ct/docker.sh") || command["warning"] != proxmox.ScriptWarning {
 		t.Fatalf("proxmox_script_command = %#v", result)
 	}
 
@@ -65,7 +65,7 @@ func TestProxmoxScriptToolsDemo(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if m, ok := command.(map[string]any); !ok || m["slug"] != "docker" {
+	if m, ok := command.(map[string]any); !ok || m["slug"] != "docker" || m["warning"] != proxmox.ScriptWarning {
 		t.Fatalf("demo proxmox_script_command = %#v", command)
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -419,7 +419,7 @@ func (s *Server) executeTool(name string, args map[string]any) (any, error) {
 		if err != nil {
 			return nil, err
 		}
-		return map[string]any{"slug": slug, "command": command}, nil
+		return map[string]any{"slug": slug, "command": command, "warning": proxmox.ScriptWarning}, nil
 
 	case "install_list":
 		return install.List(), nil

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -18,6 +18,7 @@ import (
 	"github.com/Higangssh/homebutler/internal/inventory"
 	"github.com/Higangssh/homebutler/internal/network"
 	"github.com/Higangssh/homebutler/internal/ports"
+	"github.com/Higangssh/homebutler/internal/proxmox"
 	"github.com/Higangssh/homebutler/internal/remote"
 	"github.com/Higangssh/homebutler/internal/report"
 	"github.com/Higangssh/homebutler/internal/system"
@@ -405,6 +406,20 @@ func (s *Server) executeTool(name string, args map[string]any) (any, error) {
 		// permitted to write to, so bind mounts declared by the archive are
 		// always refused here and reported in the result.
 		return backup.Restore(archive, backup.RestoreOptions{Service: stringArg(args, "service")})
+
+	case "proxmox_script_list":
+		return proxmox.Scripts(), nil
+
+	case "proxmox_script_command":
+		slug, ok := requireString(args, "slug")
+		if !ok {
+			return nil, fmt.Errorf("missing required parameter: slug")
+		}
+		command, err := proxmox.ScriptCommand(slug)
+		if err != nil {
+			return nil, err
+		}
+		return map[string]any{"slug": slug, "command": command}, nil
 
 	case "install_list":
 		return install.List(), nil

--- a/internal/proxmox/scripts.go
+++ b/internal/proxmox/scripts.go
@@ -1,0 +1,46 @@
+package proxmox
+
+import "fmt"
+
+// scriptCatalogRef pins every generated command to one commit of
+// community-scripts/ProxmoxVE instead of tracking main, so a script fetched
+// today is the same bytes a week from now. Bump it deliberately when the
+// catalog below needs a newer script.
+//
+// See #62: homebutler stops at generating this command for a human to review
+// and run themselves. It never fetches or executes the script.
+const scriptCatalogRef = "fadcb0c375547861f991c09ff8dec196c380d428"
+
+// Script is one curated entry from the Proxmox VE Community Scripts catalog
+// (https://github.com/community-scripts/ProxmoxVE).
+type Script struct {
+	Slug        string `json:"slug"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+var scriptCatalog = []Script{
+	{Slug: "docker", Name: "Docker", Description: "Docker CE and Docker Compose in an LXC"},
+	{Slug: "homeassistant", Name: "Home Assistant", Description: "Home Assistant Core in an LXC"},
+	{Slug: "nginxproxymanager", Name: "Nginx Proxy Manager", Description: "Nginx Proxy Manager in an LXC"},
+	{Slug: "pihole", Name: "Pi-hole", Description: "Pi-hole DNS ad-blocker in an LXC"},
+	{Slug: "postgresql", Name: "PostgreSQL", Description: "PostgreSQL database server in an LXC"},
+}
+
+// Scripts returns the curated Proxmox VE Community Scripts catalog.
+func Scripts() []Script {
+	return scriptCatalog
+}
+
+// ScriptCommand renders the pinned shell command for a cataloged script slug.
+// It only builds text: homebutler never fetches or runs the script itself,
+// and the caller is responsible for reviewing the command before running it
+// on the Proxmox host.
+func ScriptCommand(slug string) (string, error) {
+	for _, script := range scriptCatalog {
+		if script.Slug == slug {
+			return fmt.Sprintf(`bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/%s/ct/%s.sh)"`, scriptCatalogRef, slug), nil
+		}
+	}
+	return "", fmt.Errorf("unknown Proxmox Community Script %q; use the script catalog to see available slugs", slug)
+}

--- a/internal/proxmox/scripts.go
+++ b/internal/proxmox/scripts.go
@@ -11,6 +11,12 @@ import "fmt"
 // and run themselves. It never fetches or executes the script.
 const scriptCatalogRef = "fadcb0c375547861f991c09ff8dec196c380d428"
 
+// ScriptWarning is carried alongside every rendered command, in the human
+// output, --json, and MCP alike, so a caller relaying the command elsewhere
+// cannot drop the two facts #62 asked it to state: the script is not
+// reviewed by homebutler, and it runs as root on the Proxmox host.
+const ScriptWarning = "This script is not reviewed by homebutler. It is fetched from community-scripts/ProxmoxVE and runs as root on the Proxmox host."
+
 // Script is one curated entry from the Proxmox VE Community Scripts catalog
 // (https://github.com/community-scripts/ProxmoxVE).
 type Script struct {

--- a/internal/proxmox/scripts_test.go
+++ b/internal/proxmox/scripts_test.go
@@ -1,0 +1,39 @@
+package proxmox
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestScriptsCatalogHasNoDuplicateSlugs(t *testing.T) {
+	seen := make(map[string]bool, len(scriptCatalog))
+	for _, script := range Scripts() {
+		if seen[script.Slug] {
+			t.Errorf("duplicate script slug %q", script.Slug)
+		}
+		seen[script.Slug] = true
+		if script.Name == "" || script.Description == "" {
+			t.Errorf("script %q missing name or description: %#v", script.Slug, script)
+		}
+	}
+}
+
+func TestScriptCommandPinsRefAndSlug(t *testing.T) {
+	cmd, err := ScriptCommand("docker")
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := `bash -c "$(curl -fsSL https://raw.githubusercontent.com/community-scripts/ProxmoxVE/` + scriptCatalogRef + `/ct/docker.sh)"`
+	if cmd != want {
+		t.Errorf("ScriptCommand(docker) = %q, want %q", cmd, want)
+	}
+	if strings.Contains(cmd, "main/ct") {
+		t.Errorf("ScriptCommand must pin a commit, not track main: %q", cmd)
+	}
+}
+
+func TestScriptCommandUnknownSlug(t *testing.T) {
+	if _, err := ScriptCommand("nope"); err == nil || !strings.Contains(err.Error(), `unknown Proxmox Community Script "nope"`) {
+		t.Errorf("ScriptCommand(nope) error = %v", err)
+	}
+}

--- a/skills/SKILL.md
+++ b/skills/SKILL.md
@@ -183,6 +183,7 @@ Current MCP tools:
 - `wake`, `open_ports`, `network_scan`, `alerts`
 - `backup_create`, `backup_list`, `backup_drill`, `backup_restore`
 - `install_list`, `install_app`, `install_status`, `install_uninstall`, `install_purge`
+- `proxmox_status`, `proxmox_guests`, `proxmox_node`, `proxmox_tasks`, `proxmox_guest_start`, `proxmox_guest_reboot`, `proxmox_guest_shutdown`, `proxmox_task_status`, `proxmox_script_list`, `proxmox_script_command`
 
 ### Version
 ```bash


### PR DESCRIPTION
## Summary

Closes the narrowest slice of #62: whether homebutler runs externally-authored code at all. It doesn't — this generates and prints the install command for a curated Proxmox VE Community Script and stops there. The operator reviews it and runs it by hand on the Proxmox host.

- `internal/proxmox/scripts.go`: a small curated catalog (`docker`, `homeassistant`, `nginxproxymanager`, `pihole`, `postgresql`) with `Scripts()` and `ScriptCommand(slug)`. The rendered command is pinned to one commit of `community-scripts/ProxmoxVE` (`fadcb0c3...`) rather than tracking `main`, so the bytes a script fetches today match a week from now — addresses the pinning question #62 raised. Bumping the pin is a deliberate, reviewable one-line change.
- CLI: `proxmox script list`, `proxmox script show <slug>`.
- MCP: `proxmox_script_list`, `proxmox_script_command` (both `riskRead`, `targetLocal` — no endpoint or credentials involved, since nothing is executed or contacted).

## Notes for reviewers

- No execution path was added anywhere — `ScriptCommand` only formats a string. `proxmox_guest_start/reboot/shutdown` (Phase 2, already merged) remain the only guest-affecting Proxmox actions.
- Catalog and pinned ref checked live against `community-scripts/ProxmoxVE` (`gh api`) rather than invented.
- #62's remaining questions — whether homebutler ever executes such a script, and what that needs from the permission model — are untouched by this PR.

## Test plan

- [x] `gofmt -w .`, `go vet ./...`, `golangci-lint run`, `go test ./...` (1092 tests), `go build ./...`
- [x] Manually ran `proxmox script list` / `proxmox script show docker|nope` (human + `--json`)
- [x] Exercised `proxmox_script_command` through the real MCP server (`mcp --demo`) over stdio