### PR TITLE
feat: watch start is the monitoring process, not half of one

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,12 @@ homebutler watch start                  # Foreground, Ctrl+C to stop
 homebutler watch start --interval 10s   # Custom poll interval (default 30s)
 ```
 
+`watch start` is the monitoring process. It watches the containers and services
+on the watch list for restarts, checks CPU, memory and disk against your
+thresholds, and runs any remediation rules you have configured — one process,
+one set of notification providers. `alerts --watch` still exists and does the
+threshold half on its own.
+
 When a crash is detected, you'll see:
 
 ```
@@ -597,7 +603,7 @@ Commands:
   watch list          Show watched containers
   watch remove <name> Remove container from watch list
   watch check         One-shot restart check
-  watch start         Continuous restart monitoring loop
+  watch start         Continuous monitoring: restarts, thresholds, rules
   watch history       List restart history (alias: incidents)
   watch show <id>     Show restart details with logs
   serve               Web dashboard (browser-based, go:embed)
@@ -626,7 +632,7 @@ Commands:
   ps --limit 20       Show top 20 (default: 10, 0 = all)
   network scan        Discover devices on LAN
   alerts              Show current alert status
-  alerts --watch      Continuous monitoring with real-time alerts
+  alerts --watch      Thresholds only (watch start covers these too)
   trust <server>      Register SSH host key (TOFU)
   backup              Backup Docker volumes, compose files, and env
   backup list         List existing backups

--- a/cmd/alerts.go
+++ b/cmd/alerts.go
@@ -31,9 +31,12 @@ func newAlertsCmd() *cobra.Command {
 		Short: "Advanced resource threshold checks (CPU, memory, disk)",
 		Long: `Check system resource thresholds for CPU, memory, and disk usage.
 
-This is an advanced threshold-based workflow. For most users, start with
-'homebutler watch' for restart detection, crash analysis, flapping detection,
-and incident history.
+Without --watch this is a one-shot reading of the current thresholds.
+
+'homebutler watch start' now runs these same checks alongside restart
+detection, through one notifier and one process, so --watch here is the
+narrower option: resources only, nothing about containers or services. Prefer
+'watch start' unless you specifically want thresholds on their own.
 
 Use --watch to continuously monitor resources (Ctrl+C to stop).
 Use --interval to set the monitoring interval (default: 30s).

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -376,17 +376,30 @@ Docker targets use docker events (real-time). Systemd and PM2 targets use pollin
 			}
 			watchCfg.Retention.Normalize()
 
+			// One read serves both the notification providers and the rules
+			// engine. loadAlertsConfig already prefers rules declared in
+			// config.yaml and only falls back to the deprecated
+			// ~/.homebutler/alerts.yaml, so reading it a second time would
+			// print its deprecation and permission warnings twice.
+			//
+			// A configuration that will not load is reported and skipped. The
+			// restart monitors are why this process exists and they should not
+			// fail to start because remediation rules do not parse.
+			alertsCfg, alertsErr := loadAlertsConfig("")
+			if alertsErr != nil {
+				fmt.Fprintf(os.Stderr, "warning: cannot load alerts configuration: %v; continuing without thresholds or rules\n", alertsErr)
+			}
+
+			providers := &alerts.NotifyConfig{}
+			if cfg != nil {
+				providers = &cfg.Notify
+			}
+			if providers.IsEmpty() && alertsCfg != nil {
+				providers = alerts.ResolveNotifyConfig(alertsCfg)
+			}
+
 			var notifier *watch.WatchNotifier
 			if watchCfg.Notify.Enabled {
-				providers := &alerts.NotifyConfig{}
-				if cfg != nil {
-					providers = &cfg.Notify
-				}
-				if providers.IsEmpty() {
-					if alertsCfg, err := loadAlertsConfig(""); err == nil && alertsCfg != nil {
-						providers = alerts.ResolveNotifyConfig(alertsCfg)
-					}
-				}
 				notifier = watch.NewWatchNotifier(watchCfg.Notify, providers)
 			}
 
@@ -412,6 +425,23 @@ Docker targets use docker events (real-time). Systemd and PM2 targets use pollin
 
 			sig := make(chan os.Signal, 1)
 			signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+
+			// Resource thresholds and, when configured, the rules engine run in
+			// this same process. Polling a level is a different detection model
+			// from reacting to a restart, but it is the same job from the
+			// operator's side, and splitting it across two processes is what
+			// #97 is about. The rules engine matters most here: it holds the
+			// only remediation path there is, and it could not previously see a
+			// restart incident because it ran somewhere else.
+			thresholdCh := alerts.Watch(ctx, alerts.WatchConfig{Interval: dur, Alert: cfg.Alerts})
+
+			var ruleCh <-chan string
+			if alertsCfg != nil && len(alertsCfg.Rules) > 0 {
+				warnUnprivilegedSystemdRules(alertsCfg)
+				var flap alerts.FlapChecker = watch.IncidentHistory{Dir: dir, Flapping: watchCfg.Flapping}
+				ruleCh = alerts.WatchRules(ctx, dur, alertsCfg, flap)
+				fmt.Printf("  Rules: %d loaded, remediation active\n", len(alertsCfg.Rules))
+			}
 
 			incCh := make(chan watch.Incident, 64)
 
@@ -505,6 +535,26 @@ Docker targets use docker events (real-time). Systemd and PM2 targets use pollin
 					if flapResult.IsFlapping {
 						fmt.Printf("  ⚠ FLAPPING: %s (%d restarts in %s window)\n", flapResult.Level, flapResult.Count, flapResult.Window)
 					}
+				case e, ok := <-thresholdCh:
+					if !ok {
+						thresholdCh = nil
+						continue
+					}
+					fmt.Println(alerts.FormatEvent(e))
+					if providers != nil && !providers.IsEmpty() {
+						_ = alerts.NotifyAll(providers, alerts.NotifyEvent{
+							RuleName: e.Resource,
+							Status:   e.Severity,
+							Details:  e.Message,
+							Time:     e.Time.Format(time.RFC3339),
+						})
+					}
+				case msg, ok := <-ruleCh:
+					if !ok {
+						ruleCh = nil
+						continue
+					}
+					fmt.Println(msg)
 				case <-sig:
 					fmt.Println("\nStopping all monitors.")
 					cancel()

--- a/cmd/watch_unified_test.go
+++ b/cmd/watch_unified_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Higangssh/homebutler/internal/alerts"
+	"github.com/Higangssh/homebutler/internal/config"
+	"github.com/Higangssh/homebutler/internal/notify"
+)
+
+// watch start resolves notification providers once and uses them for restart
+// incidents and threshold events alike. Before #97 the threshold loop lived in
+// another process with its own path to the same providers.
+func TestWatchStartResolvesProvidersFromConfig(t *testing.T) {
+	saved := cfg
+	t.Cleanup(func() { cfg = saved })
+
+	cfg = &config.Config{Notify: notify.ProviderConfig{
+		Telegram: &notify.TelegramConfig{BotToken: "t", ChatID: "1"},
+	}}
+	providers := &alerts.NotifyConfig{}
+	if cfg != nil {
+		providers = &cfg.Notify
+	}
+	if providers.IsEmpty() {
+		t.Fatal("providers resolved from config.yaml should not be empty")
+	}
+}
+
+// The alerts command should no longer send readers away to watch as though the
+// two were alternatives; they overlap, and the help has to say which is which.
+func TestAlertsHelpDescribesTheOverlapWithWatch(t *testing.T) {
+	long := newAlertsCmd().Long
+	if strings.Contains(long, "For most users, start with") {
+		t.Error("alerts still redirects users to watch as if they were alternatives")
+	}
+	for _, want := range []string{"watch start", "one notifier", "resources only"} {
+		if !strings.Contains(long, want) {
+			t.Errorf("alerts help does not mention %q:\n%s", want, long)
+		}
+	}
+}


### PR DESCRIPTION
Restart detection and resource thresholds ran in two long-running loops that did not know about each other. Being told when something goes wrong took two processes, two notification paths, and — once #80 lands — would have taken two service units.

`watch start` now runs all three detectors in one loop with one notifier: the restart monitors it always had, the threshold checks that have had usable defaults all along (CPU 90, memory 85, disk 90), and the rules engine when rules are configured.

## What this closes that was not the goal

Remediation lives on the rules engine, which ran inside the `alerts` process. So the loop that detected a container crash had no way to act on one, and the loop that could act never saw crashes. #49 fixed which target kinds `restart` understands and stopped there, because the two halves were in different processes.

They are now in the same one. `WatchRules` is given the incident history as its flap checker, so a target already in a restart loop is not restarted further into it.

## Reading the configuration once

`loadAlertsConfig` already prefers rules declared in `config.yaml` and only falls back to the deprecated `~/.homebutler/alerts.yaml`. I first wrote a separate loader for the rules and found out from a smoke test that it printed the deprecation and permission warnings a second time — so the config is read once and serves both the notification providers and the rules.

A configuration that will not parse is reported and skipped rather than fatal. The restart monitors are why the process exists; they should not fail to start because remediation rules are malformed.

## Not in this change

`alerts --watch` is untouched and still does thresholds on its own. Its `Long` text used to say "for most users, start with `homebutler watch`", which was a split being covered for by documentation rather than an advanced mode; it now describes what the two share and which one is narrower.

Configuration keeps its two sections. `watch:` and `alerts:` configure genuinely different things and collapsing them would make both worse — what changes is that starting the monitoring is one command.

## Verification

`gofmt`, `go vet ./...`, `go build ./...` and `go test ./...` clean.

Smoke-tested against a real watch list and a real `~/.homebutler/alerts.yaml`: the process reports its docker targets and `Rules: 4 loaded, remediation active` in one startup, and the deprecation warning appears once.

Part of #97, which also records why this comes before #80.
