### PR TITLE
fix: an incident directory capped in files was not capped in bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,7 +402,9 @@ Legacy `~/.homebutler/watch/config.json` is still read as a fallback for watch-s
 - `watch.notify_on: off` — disable watch notifications without removing provider config
 - `watch.cooldown: 5m` — suppress duplicate notifications for the same event fingerprint during the cooldown window
 - `watch.flapping` — optional advanced tuning for restart-loop detection
-- `watch.retention.max_incidents: 200` — how many incidents to keep on disk, newest first. Each incident stores up to 100 captured log lines, so the directory grows fastest exactly when a service is restarting in a loop. Set `-1` to keep everything.
+- `watch.retention.max_incidents: 200` — how many incidents to keep on disk, newest first. The directory grows fastest exactly when a service is restarting in a loop. Set `-1` to keep everything.
+
+  Each incident keeps up to 100 captured log lines per side, and at most 64 KB of them. Line counts alone do not bound a file: one stack trace or JSON document on a single line is arbitrarily long, and a container being OOM-killed is exactly the one likely to write one. A log that does not fit keeps its end — the last thing a process said is what explains why it stopped — and says how much was dropped.
 
 These settings can also be written under a `watch.notify:` block, which is the
 canonical form:

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -517,8 +517,11 @@ Docker targets use docker events (real-time). Systemd and PM2 targets use pollin
 					summary := watch.Analyze(crashInfo)
 					inc.CrashAnalysis = &summary
 
-					allIncs, _ := watch.ListIncidents(dir)
-					flapResult := watchCfg.Flapping.Check(inc.Container, allIncs, time.Now())
+					// Refs, not incidents: this runs on every save, and the
+					// decision only needs the container and the time, both of
+					// which the filename already carries.
+					refs, _ := watch.ListIncidentRefs(dir)
+					flapResult := watchCfg.Flapping.CheckRefs(inc.Container, refs, time.Now())
 					if flapResult.IsFlapping {
 						inc.Flapping = &flapResult
 					}

--- a/internal/watch/flapping.go
+++ b/internal/watch/flapping.go
@@ -26,14 +26,29 @@ func DefaultFlappingConfig() FlappingConfig {
 	}
 }
 
+// Check classifies an incident against the history it belongs to.
+//
+// The decision uses two fields, Container and DetectedAt, both of which an
+// incident's filename already carries. Callers on the hot path — every save,
+// and every alert rule evaluation — should use CheckRefs instead so they never
+// read an incident body to answer a question about its name.
 func (fc *FlappingConfig) Check(container string, incidents []Incident, now time.Time) FlappingResult {
+	refs := make([]IncidentRef, len(incidents))
+	for i, inc := range incidents {
+		refs[i] = IncidentRef{ID: inc.ID, Container: inc.Container, DetectedAt: inc.DetectedAt}
+	}
+	return fc.CheckRefs(container, refs, now)
+}
+
+// CheckRefs is Check over incident references.
+func (fc *FlappingConfig) CheckRefs(container string, refs []IncidentRef, now time.Time) FlappingResult {
 	shortCutoff := now.Add(-fc.ShortWindow)
 	longCutoff := now.Add(-fc.LongWindow)
 
 	var shortCount, longCount int
 	var shortOldest, longOldest time.Time
 
-	for _, inc := range incidents {
+	for _, inc := range refs {
 		if inc.Container != container {
 			continue
 		}

--- a/internal/watch/growth_test.go
+++ b/internal/watch/growth_test.go
@@ -1,0 +1,138 @@
+package watch
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// A single log line has no bound of its own — docker logs --tail and
+// journalctl -n count lines, not bytes — so the cap has to be applied where
+// every writer passes. #81.
+func TestSaveIncidentBoundsCapturedLogs(t *testing.T) {
+	dir := t.TempDir()
+	huge := strings.Repeat("x", MaxLogBytes*3)
+
+	inc := Incident{
+		ID:         GenerateIncidentID("svc", time.Now()),
+		Container:  "svc",
+		DetectedAt: time.Now(),
+		PreLogs:    huge,
+		PostLogs:   huge,
+	}
+	if err := SaveIncident(dir, &inc, 0); err != nil {
+		t.Fatalf("SaveIncident: %v", err)
+	}
+
+	loaded, err := LoadIncident(dir, inc.ID)
+	if err != nil {
+		t.Fatalf("LoadIncident: %v", err)
+	}
+	for name, got := range map[string]string{"pre": loaded.PreLogs, "post": loaded.PostLogs} {
+		if len(got) > MaxLogBytes+64 {
+			t.Errorf("%s logs kept %d bytes, cap is %d", name, len(got), MaxLogBytes)
+		}
+		if !strings.HasPrefix(got, "… truncated ") {
+			t.Errorf("%s logs were cut without saying so: %.40q", name, got)
+		}
+	}
+}
+
+// Truncation keeps the end. The last thing a process said is what explains why
+// it stopped; the beginning is what can be spared.
+func TestTruncateLogKeepsTheTail(t *testing.T) {
+	s := strings.Repeat("old\n", MaxLogBytes) + "PANIC: the last line\n"
+	got := TruncateLog(s)
+
+	if !strings.HasSuffix(got, "PANIC: the last line\n") {
+		t.Error("truncation dropped the tail, which is the half that explains the crash")
+	}
+	if len(got) > MaxLogBytes+64 {
+		t.Errorf("kept %d bytes, cap is %d plus the marker", len(got), MaxLogBytes)
+	}
+	// The first surviving line is a whole line, not the back half of one.
+	first, _, _ := strings.Cut(strings.TrimPrefix(got, "… truncated "), "\n")
+	if !strings.HasSuffix(first, "bytes …") {
+		t.Errorf("expected the marker on its own line, got %q", first)
+	}
+}
+
+// A log shorter than the cap is returned untouched — no marker, no copy.
+func TestTruncateLogLeavesShortLogsAlone(t *testing.T) {
+	s := "two\nlines\n"
+	if got := TruncateLog(s); got != s {
+		t.Errorf("TruncateLog rewrote a log that fits: %q", got)
+	}
+}
+
+// Pruning and flapping read the container and the time from the filename, so
+// neither opens an incident. This is what stops one save from costing two full
+// reads of the history.
+func TestListIncidentRefsReadsNoFileBodies(t *testing.T) {
+	dir := t.TempDir()
+	base := time.Date(2026, 8, 30, 9, 0, 0, 0, time.UTC)
+	for i := 0; i < 3; i++ {
+		at := base.Add(time.Duration(i) * time.Minute)
+		inc := Incident{ID: GenerateIncidentID("my-api", at), Container: "my-api", DetectedAt: at}
+		if err := SaveIncident(dir, &inc, 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Make every body unreadable. Refs must still come back complete.
+	idir := filepath.Join(dir, "incidents")
+	entries, err := os.ReadDir(idir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if err := os.WriteFile(filepath.Join(idir, e.Name()), []byte("{ not json"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	refs, err := ListIncidentRefs(dir)
+	if err != nil {
+		t.Fatalf("ListIncidentRefs: %v", err)
+	}
+	if len(refs) != 3 {
+		t.Fatalf("expected 3 refs from filenames alone, got %d", len(refs))
+	}
+	if refs[0].Container != "my-api" {
+		t.Errorf("container not recovered from the filename: %q", refs[0].Container)
+	}
+	if !refs[0].DetectedAt.After(refs[2].DetectedAt) {
+		t.Error("refs are not sorted newest first")
+	}
+}
+
+// A name that is not ours is not deleted. The criterion moved from "cannot be
+// unmarshalled" to "cannot be named"; the policy did not.
+func TestPruneLeavesUnrecognisedFilenames(t *testing.T) {
+	dir := t.TempDir()
+	idir := filepath.Join(dir, "incidents")
+	if err := os.MkdirAll(idir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stranger := filepath.Join(idir, "notes.json")
+	if err := os.WriteFile(stranger, []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	base := time.Date(2026, 8, 30, 9, 0, 0, 0, time.UTC)
+	for i := 0; i < 4; i++ {
+		at := base.Add(time.Duration(i) * time.Minute)
+		inc := Incident{ID: GenerateIncidentID("svc", at), Container: "svc", DetectedAt: at}
+		if err := SaveIncident(dir, &inc, 0); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, err := PruneIncidents(dir, 1); err != nil {
+		t.Fatalf("PruneIncidents: %v", err)
+	}
+	if _, err := os.Stat(stranger); err != nil {
+		t.Errorf("pruning deleted a file it could not name: %v", err)
+	}
+}

--- a/internal/watch/restart.go
+++ b/internal/watch/restart.go
@@ -88,8 +88,11 @@ func (h IncidentHistory) IsFlapping(target string) bool {
 	if h.Dir == "" {
 		return false
 	}
-	incidents, err := ListIncidents(h.Dir)
-	if err != nil || len(incidents) == 0 {
+	// Refs, not incidents: the rules engine asks this before every remediation,
+	// and reading captured logs to count restarts is work the filename already
+	// answers.
+	refs, err := ListIncidentRefs(h.Dir)
+	if err != nil || len(refs) == 0 {
 		return false
 	}
 	now := time.Now
@@ -97,5 +100,5 @@ func (h IncidentHistory) IsFlapping(target string) bool {
 		now = h.Now
 	}
 	cfg := h.Flapping
-	return cfg.Check(target, incidents, now()).IsFlapping
+	return cfg.CheckRefs(target, refs, now()).IsFlapping
 }

--- a/internal/watch/restart_test.go
+++ b/internal/watch/restart_test.go
@@ -113,7 +113,7 @@ func TestIncidentHistoryDetectsARestartLoop(t *testing.T) {
 	cfg := DefaultWatchConfig().Flapping
 	for i := 0; i < cfg.ShortThreshold+1; i++ {
 		inc := Incident{
-			ID:         "loop-" + string(rune('a'+i)),
+			ID:         GenerateIncidentID("nginx", now.Add(-time.Duration(i)*time.Minute)),
 			Container:  "nginx",
 			DetectedAt: now.Add(-time.Duration(i) * time.Minute),
 		}

--- a/internal/watch/store.go
+++ b/internal/watch/store.go
@@ -174,6 +174,14 @@ func SaveIncident(dir string, inc *Incident, keep int) error {
 	if err := ensureDir(idir); err != nil {
 		return err
 	}
+
+	// Bounded here rather than at each capture site. There are five writers —
+	// the three monitors, CheckTargets, and the enrichment re-save in
+	// cmd/watch.go — and a cap each of them had to remember to apply is a cap
+	// one of them eventually forgets. Same reasoning as the file count below.
+	inc.PreLogs = TruncateLog(inc.PreLogs)
+	inc.PostLogs = TruncateLog(inc.PostLogs)
+
 	data, err := json.MarshalIndent(inc, "", "  ")
 	if err != nil {
 		return err
@@ -194,25 +202,27 @@ func SaveIncident(dir string, inc *Incident, keep int) error {
 // PruneIncidents deletes the oldest incidents until at most keep remain, and
 // reports how many it removed. keep of zero or less keeps everything.
 //
-// Incident files that cannot be read or parsed are left alone: ListIncidents
-// skips them, so they are never selected for deletion. Refusing to delete a
-// file we do not understand is the safer half of that trade.
+// Files whose names do not fit the incident format are left alone:
+// ListIncidentRefs skips them, so they are never selected for deletion.
+// Refusing to delete a file we do not understand is the safer half of that
+// trade, and the criterion moved from "cannot be unmarshalled" to "cannot be
+// named" only because pruning no longer opens anything.
 func PruneIncidents(dir string, keep int) (int, error) {
 	if keep <= 0 {
 		return 0, nil
 	}
-	incidents, err := ListIncidents(dir)
+	refs, err := ListIncidentRefs(dir)
 	if err != nil {
 		return 0, err
 	}
-	if len(incidents) <= keep {
+	if len(refs) <= keep {
 		return 0, nil
 	}
 
 	idir := incidentsDir(dir)
 	removed := 0
-	for _, inc := range incidents[keep:] { // ListIncidents sorts newest first
-		if err := os.Remove(filepath.Join(idir, inc.ID+".json")); err != nil {
+	for _, ref := range refs[keep:] { // ListIncidentRefs sorts newest first
+		if err := os.Remove(filepath.Join(idir, ref.ID+".json")); err != nil {
 			if os.IsNotExist(err) {
 				continue
 			}
@@ -221,6 +231,101 @@ func PruneIncidents(dir string, keep int) (int, error) {
 		removed++
 	}
 	return removed, nil
+}
+
+// MaxLogBytes bounds each captured log on an incident. docker logs --tail and
+// journalctl -n bound the number of *lines*, which says nothing about their
+// length: one stack trace, JSON document or base64 payload on a single line
+// makes an incident file arbitrarily large, and a cap on the number of files
+// does not bound a directory whose files have no size.
+//
+// The failure mode selects for itself. A container being OOM-killed is exactly
+// the one likely to dump something enormous on the way out, which is the moment
+// an incident gets written.
+const MaxLogBytes = 64 << 10
+
+// TruncateLog bounds a captured log, keeping the end. The tail is what explains
+// a crash — the last thing a process said before it stopped — so a log too long
+// to keep loses its beginning, and says so where a reader will see it.
+func TruncateLog(s string) string {
+	if len(s) <= MaxLogBytes {
+		return s
+	}
+	dropped := len(s) - MaxLogBytes
+	kept := s[dropped:]
+	// Start at a line boundary so the first surviving line is not a fragment.
+	if i := strings.IndexByte(kept, '\n'); i >= 0 && i < len(kept)-1 {
+		dropped += i + 1
+		kept = kept[i+1:]
+	}
+	return fmt.Sprintf("… truncated %d bytes …\n%s", dropped, kept)
+}
+
+// IncidentRef is what an incident's filename already tells us: which container
+// it belongs to and when it was detected. GenerateIncidentID builds the name as
+// container-timestamp-suffix, so pruning and flapping — the two things that run
+// on every single save — can be answered without opening a file.
+//
+// This matters because those two used to call ListIncidents, which reads and
+// unmarshals every incident in the directory including its captured logs. One
+// incident cost two full reads of the history, and the moment that happens most
+// often is a service restarting in a loop, which is the case flapping detection
+// exists for.
+type IncidentRef struct {
+	ID         string
+	Container  string
+	DetectedAt time.Time
+}
+
+// parseIncidentRef recovers the container and time from an incident filename.
+// A name that does not fit the format is not ours to interpret, so it is
+// reported as unparseable rather than guessed at; callers skip those, which is
+// also what keeps PruneIncidents from deleting a file it does not understand.
+func parseIncidentRef(name string) (IncidentRef, bool) {
+	id := strings.TrimSuffix(name, ".json")
+	if id == name {
+		return IncidentRef{}, false
+	}
+	// The suffix is 6 hex characters and the timestamp is fixed width, so the
+	// container name is whatever precedes them, dashes and all.
+	const tsLayout = "20060102-150405.000"
+	parts := strings.Split(id, "-")
+	if len(parts) < 4 {
+		return IncidentRef{}, false
+	}
+	tsStr := parts[len(parts)-3] + "-" + parts[len(parts)-2]
+	detected, err := time.Parse(tsLayout, tsStr)
+	if err != nil {
+		return IncidentRef{}, false
+	}
+	container := strings.Join(parts[:len(parts)-3], "-")
+	if container == "" {
+		return IncidentRef{}, false
+	}
+	return IncidentRef{ID: id, Container: container, DetectedAt: detected}, true
+}
+
+// ListIncidentRefs returns one ref per parseable incident file, newest first,
+// without opening any of them.
+func ListIncidentRefs(dir string) ([]IncidentRef, error) {
+	entries, err := os.ReadDir(incidentsDir(dir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	refs := make([]IncidentRef, 0, len(entries))
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if ref, ok := parseIncidentRef(e.Name()); ok {
+			refs = append(refs, ref)
+		}
+	}
+	sort.Slice(refs, func(i, j int) bool { return refs[i].DetectedAt.After(refs[j].DetectedAt) })
+	return refs, nil
 }
 
 func ListIncidents(dir string) ([]Incident, error) {

--- a/internal/watch/store_test.go
+++ b/internal/watch/store_test.go
@@ -498,7 +498,10 @@ func TestPruneIncidents_KeepsNewestAndDeletesOldest(t *testing.T) {
 	var ids []string
 	for i := 0; i < 5; i++ {
 		inc := Incident{
-			ID:         fmt.Sprintf("svc-%02d", i),
+			// Real IDs: pruning reads the container and the time from the
+			// filename now, so a synthetic name would exercise a file
+			// production never writes.
+			ID:         GenerateIncidentID("svc", base.Add(time.Duration(i)*time.Minute)),
 			Container:  "svc",
 			DetectedAt: base.Add(time.Duration(i) * time.Minute),
 		}
@@ -588,15 +591,18 @@ func TestSaveIncident_EnforcesCap(t *testing.T) {
 	// explicitly must still not grow the directory without bound.
 	dir := t.TempDir()
 	base := time.Date(2026, 8, 21, 2, 0, 0, 0, time.UTC)
+	var newest string
 	for i := 0; i < 6; i++ {
+		at := base.Add(time.Duration(i) * time.Minute)
 		inc := Incident{
-			ID:         fmt.Sprintf("svc-%02d", i),
+			ID:         GenerateIncidentID("svc", at),
 			Container:  "svc",
-			DetectedAt: base.Add(time.Duration(i) * time.Minute),
+			DetectedAt: at,
 		}
 		if err := SaveIncident(dir, &inc, 3); err != nil {
 			t.Fatal(err)
 		}
+		newest = inc.ID
 	}
 	left, err := ListIncidents(dir)
 	if err != nil {
@@ -605,7 +611,7 @@ func TestSaveIncident_EnforcesCap(t *testing.T) {
 	if len(left) != 3 {
 		t.Fatalf("expected the directory capped at 3, got %d", len(left))
 	}
-	if left[0].ID != "svc-05" {
+	if left[0].ID != newest {
 		t.Errorf("expected newest incident kept, got %s", left[0].ID)
 	}
 }


### PR DESCRIPTION
#50 capped the incident directory at 200 files. Neither of the two things that actually make it grow under load is bounded by counting files, and both get worse in exactly the situation the feature exists for.

## Bytes

`docker logs --tail 100` and `journalctl -n 100` bound *lines*. One stack trace, JSON document or base64 payload on a single line makes an incident file arbitrarily large, and two hundred of those is still arbitrarily large.

The failure mode selects for itself: a container being OOM-killed is the one most likely to write something enormous on the way out, and that is the moment an incident is saved.

Captured logs are now truncated to 64KB, keeping the **end**. The last thing a process said is what explains why it stopped; the beginning is what can be spared. A truncated log says how many bytes went.

The cap is applied in `SaveIncident`, not at each capture site. There are five writers, and a cap each of them has to remember to apply is one that eventually gets forgotten — the same reasoning #50 used for the file count.

## Reads

Saving one incident read the whole history twice: `PruneIncidents` → `ListIncidents`, which unmarshals every file including its logs, and then the incident loop called `ListIncidents` again for the flapping check.

Both only ever used `Container` and `DetectedAt`, and `GenerateIncidentID` has always written both into the filename (`container-timestamp-suffix`). `ListIncidentRefs` recovers them from `os.ReadDir` without opening anything.

At 200 files averaging 50KB that is roughly 20MB of read and parse removed per incident — and the moment it happened most often was a service restarting every thirty seconds, which is the case flapping detection exists for. homebutler was adding load to a host that was already failing.

`watch history` still reads bodies, because it needs them.

## What did not change

Files whose names do not fit the incident format are still never deleted. The criterion moved from "cannot be unmarshalled" to "cannot be named" only because pruning no longer opens anything — the policy, and the docstring's reasoning for it, are the same.

`FlappingConfig.Check` keeps its signature and delegates to `CheckRefs`, so nothing outside the hot paths had to change.

## Tests that had to move

Three existing tests wrote synthetic ids (`svc-00`, `loop-a`). Those were fine while pruning read bodies; they stopped being valid stand-ins once the name became the metadata, so they use `GenerateIncidentID` now — which is also what production does.

New coverage: the byte cap on both log sides, that truncation keeps the tail and marks itself, that a short log is returned untouched, that refs are recovered from filenames with every body deliberately corrupted, and that a file the pruner cannot name survives a prune.

## Why now

#80 makes `watch` run continuously. Bounding this first is what makes that safe: a service restarting every thirty seconds under a supervisor is precisely the workload that turns today's arithmetic into a real problem.

Closes #81.
