### PR TITLE
feat: hand watch to the supervisor the host already has

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,20 @@ homebutler watch start                  # Foreground, Ctrl+C to stop
 homebutler watch start --interval 10s   # Custom poll interval (default 30s)
 ```
 
+```bash
+homebutler watch install     # register it with systemd or launchd
+homebutler watch installed   # is it registered?
+homebutler watch uninstall
+```
+
+`watch install` hands the loop to whatever supervises the host — a systemd user
+unit on Linux, a launchd agent on macOS — so monitoring survives logout and
+reboot. Both are user-level and neither is a preference: on Linux the watch list
+lives in your home directory, so a root unit would find an empty list; on macOS
+Docker Desktop only runs inside a logged-in session, so a LaunchDaemon would
+poll a daemon that is not there. On Linux a user unit stops at logout unless you
+run `sudo loginctl enable-linger $USER`, which `watch install` tells you.
+
 `watch start` is the monitoring process. It watches the containers and services
 on the watch list for restarts, checks CPU, memory and disk against your
 thresholds, and runs any remediation rules you have configured — one process,
@@ -606,6 +620,9 @@ Commands:
   watch remove <name> Remove container from watch list
   watch check         One-shot restart check
   watch start         Continuous monitoring: restarts, thresholds, rules
+  watch install       Register watch with systemd or launchd
+  watch installed     Report whether it is registered
+  watch uninstall     Remove the service unit
   watch history       List restart history (alias: incidents)
   watch show <id>     Show restart details with logs
   serve               Web dashboard (browser-based, go:embed)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -210,6 +210,12 @@ func runInit() error {
 	fmt.Println("    homebutler status")
 	fmt.Println("    homebutler tui")
 	fmt.Println()
+	// The second interaction is the one that sells a change-detection tool, and
+	// it only happens if something is running when nothing is watched by hand.
+	fmt.Println("  Then keep it watching, so it can tell you what changed:")
+	fmt.Println("    homebutler watch add <container>")
+	fmt.Println("    homebutler watch install")
+	fmt.Println()
 	return nil
 }
 

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -190,6 +190,9 @@ Examples:
 			}
 
 			fmt.Printf("Added %s %q to watch list.\n", kind, name)
+			if cmdline := service.RestartNote(); cmdline != "" {
+				fmt.Printf("  The running service reads the watch list at startup:\n    %s\n", cmdline)
+			}
 			return nil
 		},
 	}
@@ -268,6 +271,9 @@ func newWatchRemoveCmd() *cobra.Command {
 				return err
 			}
 			fmt.Printf("Removed %q from watch list.\n", name)
+			if cmdline := service.RestartNote(); cmdline != "" {
+				fmt.Printf("  The running service reads the watch list at startup:\n    %s\n", cmdline)
+			}
 			return nil
 		},
 	}
@@ -361,9 +367,14 @@ Docker targets use docker events (real-time). Systemd and PM2 targets use pollin
 			if err != nil {
 				return err
 			}
+			// An empty watch list is not a reason to stop. Since #97 this process
+			// also checks resource thresholds and runs remediation rules, and
+			// neither needs a target. Exiting here made a supervisor restart the
+			// process every ThrottleInterval for as long as the list stayed
+			// empty — a loop found by installing it rather than by any test.
 			if len(targets) == 0 {
-				fmt.Println("No targets being watched. Use 'homebutler watch add <name>' to add one.")
-				return nil
+				fmt.Println("Nothing on the watch list; monitoring thresholds only.")
+				fmt.Println("  Add something with: homebutler watch add <name>")
 			}
 
 			// Load watch config (config.yaml preferred, watch/config.json fallback)
@@ -511,9 +522,15 @@ Docker targets use docker events (real-time). Systemd and PM2 targets use pollin
 				}()
 			}
 
+			// With no restart monitors there is nothing to close incCh, and a
+			// nil channel is never selected — so the loop below waits on the
+			// thresholds and the signal instead of seeing a closed channel and
+			// treating it as "all monitors stopped".
+			var incidents <-chan watch.Incident
 			if monitorCount == 0 {
-				fmt.Println("No monitors to start.")
-				return nil
+				fmt.Println("  No restart monitors to start.")
+			} else {
+				incidents = incCh
 			}
 
 			// Close incCh when all monitors are done
@@ -525,7 +542,7 @@ Docker targets use docker events (real-time). Systemd and PM2 targets use pollin
 			// Print incidents as they arrive
 			for {
 				select {
-				case inc, ok := <-incCh:
+				case inc, ok := <-incidents:
 					if !ok {
 						fmt.Println("\nAll monitors stopped.")
 						return nil

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/Higangssh/homebutler/internal/alerts"
 	"github.com/Higangssh/homebutler/internal/docker"
+	"github.com/Higangssh/homebutler/internal/service"
 	"github.com/Higangssh/homebutler/internal/tui"
 	"github.com/Higangssh/homebutler/internal/util"
 	"github.com/Higangssh/homebutler/internal/watch"
@@ -47,6 +48,9 @@ Subcommands:
 		newWatchCheckCmd(),
 		newWatchStartCmd(),
 		newWatchHistoryCmd(),
+		newWatchInstallCmd(),
+		newWatchUninstallCmd(),
+		newWatchStatusCmd(),
 		newWatchShowCmd(),
 	)
 
@@ -433,6 +437,23 @@ Docker targets use docker events (real-time). Systemd and PM2 targets use pollin
 			// #97 is about. The rules engine matters most here: it holds the
 			// only remediation path there is, and it could not previously see a
 			// restart incident because it ran somewhere else.
+			// Bound the file this process's own output goes into. Only launchd
+			// needs it: journald rotates what systemd collects, and macOS
+			// rotates nothing without a newsyslog.d entry that needs root.
+			var logTick <-chan time.Time
+			var logPath string
+			if kind, err := service.Detect(); err == nil {
+				if home, err := os.UserHomeDir(); err == nil {
+					if lp := service.LogPath(kind, home); lp != "" {
+						logPath = lp
+						_ = service.TrimLog(logPath, service.MaxLogBytes)
+						ticker := time.NewTicker(time.Hour)
+						defer ticker.Stop()
+						logTick = ticker.C
+					}
+				}
+			}
+
 			thresholdCh := alerts.Watch(ctx, alerts.WatchConfig{Interval: dur, Alert: cfg.Alerts})
 
 			var ruleCh <-chan string
@@ -558,6 +579,10 @@ Docker targets use docker events (real-time). Systemd and PM2 targets use pollin
 						continue
 					}
 					fmt.Println(msg)
+				case <-logTick:
+					if err := service.TrimLog(logPath, service.MaxLogBytes); err != nil {
+						fmt.Fprintf(os.Stderr, "warning: trim %s: %v\n", logPath, err)
+					}
 				case <-sig:
 					fmt.Println("\nStopping all monitors.")
 					cancel()

--- a/cmd/watch_install.go
+++ b/cmd/watch_install.go
@@ -43,6 +43,13 @@ logged-in session, so a LaunchDaemon would poll a daemon that is not there.`,
 			if service.Installed(path) && !force {
 				return fmt.Errorf("%s already exists; pass --force to overwrite it", path)
 			}
+			// launchctl bootstrap fails on a service that is already loaded, so
+			// overwriting the file is not enough to make launchd read it — the
+			// old configuration stays live. Unload first; the error is ignored
+			// because "was not loaded" is the normal case here.
+			if service.Installed(path) {
+				_ = service.Run(service.StopCommand(kind, path))
+			}
 			if err := service.Write(path, service.Render(kind, exe, home)); err != nil {
 				return err
 			}

--- a/cmd/watch_install.go
+++ b/cmd/watch_install.go
@@ -1,0 +1,141 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Higangssh/homebutler/internal/service"
+	"github.com/Higangssh/homebutler/internal/watch"
+	"github.com/spf13/cobra"
+)
+
+func newWatchInstallCmd() *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "install",
+		Short: "Register watch with the host's service supervisor",
+		Long: `Write a service unit so monitoring survives logout and reboot.
+
+homebutler does not run a daemon of its own. This hands the monitoring loop to
+whatever the host already supervises with: a systemd user unit on Linux, a
+launchd agent on macOS.
+
+Both are user-level, and neither is a preference. On Linux the watch list lives
+under the invoking user's home directory, so a unit running as root would find
+an empty list and monitor nothing. On macOS Docker Desktop only runs inside a
+logged-in session, so a LaunchDaemon would poll a daemon that is not there.`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			kind, err := service.Detect()
+			if err != nil {
+				return err
+			}
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("cannot determine home directory: %w", err)
+			}
+			exe, err := os.Executable()
+			if err != nil {
+				return fmt.Errorf("cannot determine the homebutler binary path: %w", err)
+			}
+
+			path := service.UnitPath(kind, home)
+			if service.Installed(path) && !force {
+				return fmt.Errorf("%s already exists; pass --force to overwrite it", path)
+			}
+			if err := service.Write(path, service.Render(kind, exe, home)); err != nil {
+				return err
+			}
+
+			start := service.StartCommand(kind, path)
+			if err := service.Run(start); err != nil {
+				// The unit is written; only activation failed. Say both, so the
+				// operator knows what to remove and what to run by hand.
+				return fmt.Errorf("wrote %s but could not start it: %w", path, err)
+			}
+
+			out := cmd.OutOrStdout()
+			fmt.Fprintf(out, "✅ %s unit written to %s\n", kind, path)
+			fmt.Fprintf(out, "✅ enabled and started\n")
+			if note := service.LingerNote(kind); note != "" {
+				fmt.Fprintf(out, "\n⚠️  %s\n", note)
+			}
+			if dir, err := watch.WatchDir(); err == nil {
+				if targets, err := watch.LoadTargets(dir); err == nil && len(targets) == 0 {
+					fmt.Fprintf(out, "\nNothing is on the watch list yet — it will monitor nothing until you add something:\n    homebutler watch add <name>\n")
+				}
+			}
+			fmt.Fprintf(out, "\nUndo with: homebutler watch uninstall\n")
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "Overwrite an existing unit")
+	return cmd
+}
+
+func newWatchUninstallCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "uninstall",
+		Short: "Remove the service unit installed by watch install",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			kind, err := service.Detect()
+			if err != nil {
+				return err
+			}
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("cannot determine home directory: %w", err)
+			}
+			path := service.UnitPath(kind, home)
+			if !service.Installed(path) {
+				return fmt.Errorf("no unit installed at %s", path)
+			}
+
+			// Stopping can fail on a unit that is already stopped, which is not
+			// a reason to leave the file behind.
+			stopErr := service.Run(service.StopCommand(kind, path))
+			if err := os.Remove(path); err != nil {
+				return fmt.Errorf("remove %s: %w", path, err)
+			}
+
+			out := cmd.OutOrStdout()
+			if stopErr != nil {
+				fmt.Fprintf(out, "⚠️  could not stop it cleanly: %v\n", stopErr)
+			}
+			fmt.Fprintf(out, "✅ removed %s\n", path)
+			return nil
+		},
+	}
+}
+
+func newWatchStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "installed",
+		Short: "Report whether watch is registered with the supervisor",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			kind, err := service.Detect()
+			if err != nil {
+				return err
+			}
+			home, err := os.UserHomeDir()
+			if err != nil {
+				return fmt.Errorf("cannot determine home directory: %w", err)
+			}
+			path := service.UnitPath(kind, home)
+			plan := service.Plan{Kind: kind, Path: path, Start: service.StartCommand(kind, path)}
+			if jsonOutput {
+				return output(map[string]any{"installed": service.Installed(path), "plan": plan}, true)
+			}
+			out := cmd.OutOrStdout()
+			if service.Installed(path) {
+				fmt.Fprintf(out, "Installed: %s (%s)\n", path, kind)
+				return nil
+			}
+			fmt.Fprintf(out, "Not installed. %s would be written to %s\n", kind, path)
+			fmt.Fprintf(out, "    homebutler watch install\n")
+			return nil
+		},
+	}
+}

--- a/cmd/watch_start_test.go
+++ b/cmd/watch_start_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// watch start used to return when the watch list was empty. Under a supervisor
+// that restarts on exit, that is a loop: the process starts, prints one line,
+// exits, and is started again every throttle interval.
+//
+// It is also wrong on its own merits since #97 — thresholds and remediation
+// rules run in this process and neither needs a watch target.
+func TestWatchStartDoesNotExitOnAnEmptyWatchList(t *testing.T) {
+	src := readSource(t, "watch.go")
+
+	// The empty-list branch must not return; it should say what it is doing.
+	i := strings.Index(src, "Nothing on the watch list")
+	if i < 0 {
+		t.Fatal("watch start no longer reports an empty watch list at all")
+	}
+	// Look at the few lines that follow the message.
+	tail := src[i:]
+	if end := strings.Index(tail, "// Load watch config"); end > 0 {
+		tail = tail[:end]
+	}
+	if strings.Contains(tail, "return nil") {
+		t.Error("watch start still returns on an empty watch list, which a supervisor turns into a restart loop")
+	}
+}

--- a/cmd/watch_unified_test.go
+++ b/cmd/watch_unified_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"os"
 	"strings"
 	"testing"
 
@@ -40,4 +41,15 @@ func TestAlertsHelpDescribesTheOverlapWithWatch(t *testing.T) {
 			t.Errorf("alerts help does not mention %q:\n%s", want, long)
 		}
 	}
+}
+
+var osReadFile = os.ReadFile
+
+func readSource(t *testing.T, name string) string {
+	t.Helper()
+	data, err := osReadFile(name)
+	if err != nil {
+		t.Fatalf("reading %s: %v", name, err)
+	}
+	return string(data)
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -85,6 +85,15 @@ func Render(kind Kind, exe, home string) string {
 	return ""
 }
 
+// servicePATH is the search path a supervised process gets, which is not the
+// one a login shell has. A launchd agent inherits a minimal PATH and would
+// never find docker — it lives in /opt/homebrew/bin or /usr/local/bin on
+// macOS. systemd user units are barely better.
+//
+// The list matches what remote.Run exports before running homebutler over SSH
+// (internal/remote/ssh.go), which is the same problem in a different place.
+const servicePATH = "/usr/local/bin:/usr/local/sbin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin:/snap/bin"
+
 func systemdUnit(exe string) string {
 	return fmt.Sprintf(`[Unit]
 Description=homebutler monitoring
@@ -95,6 +104,7 @@ After=docker.service
 
 [Service]
 Type=simple
+Environment=PATH=%s
 ExecStart=%s watch start
 # The monitor retries a dropped event stream itself, so a restart here means the
 # process actually died. The delay keeps a crash loop from filling the journal.
@@ -103,7 +113,7 @@ RestartSec=10s
 
 [Install]
 WantedBy=default.target
-`, exe)
+`, servicePATH, exe)
 }
 
 func launchdPlist(exe, home string) string {
@@ -120,6 +130,11 @@ func launchdPlist(exe, home string) string {
     <string>watch</string>
     <string>start</string>
   </array>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>PATH</key>
+    <string>%s</string>
+  </dict>
   <key>RunAtLoad</key>
   <true/>
   <key>KeepAlive</key>
@@ -135,7 +150,7 @@ func launchdPlist(exe, home string) string {
   <string>%s/watch.log</string>
 </dict>
 </plist>
-`, Label, exe, logDir, logDir)
+`, Label, exe, servicePATH, logDir, logDir)
 }
 
 // StartCommand activates a written unit.
@@ -267,4 +282,35 @@ func indexByte(b []byte, c byte) int {
 		}
 	}
 	return -1
+}
+
+// RestartCommand reloads a running unit, for after the watch list changes.
+// The monitors read their targets once at startup, so adding a target while
+// the service runs has no effect until it is restarted — and a user who is not
+// told that has a container they believe is watched and is not.
+func RestartCommand(kind Kind) []string {
+	switch kind {
+	case Systemd:
+		return []string{"systemctl", "--user", "restart", Label + ".service"}
+	case Launchd:
+		return []string{"launchctl", "kickstart", "-k", "gui/" + fmt.Sprint(os.Getuid()) + "/" + Label}
+	}
+	return nil
+}
+
+// RestartNote returns the command to pick up a changed watch list, or "" when
+// no unit is installed and the next manual start will read it anyway.
+func RestartNote() string {
+	kind, err := Detect()
+	if err != nil {
+		return ""
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	if !Installed(UnitPath(kind, home)) {
+		return ""
+	}
+	return strings.Join(RestartCommand(kind), " ")
 }

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -1,0 +1,270 @@
+// Package service registers homebutler's monitoring loop with the supervisor
+// the host already has, so nothing here is a daemon of its own.
+//
+// Both platforms are addressed at the user level, and neither is a preference:
+//
+// On Linux, WatchDir resolves ~/.homebutler/watch from the invoking user's home
+// directory. A system unit runs as root, reads /root/.homebutler/watch, finds
+// nothing there, and monitors an empty list without saying so. Lingering is what
+// makes a user unit outlive the session.
+//
+// On macOS, Docker Desktop only runs inside a logged-in user session, so a
+// LaunchDaemon would poll a daemon that is not there.
+package service
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// Kind names the supervisor a host offers.
+type Kind string
+
+const (
+	Systemd Kind = "systemd"
+	Launchd Kind = "launchd"
+)
+
+// Label is the unit and agent name. It doubles as the plist filename.
+const Label = "dev.homebutler.watch"
+
+// Plan is what Install would do, and what Status reports after it has.
+type Plan struct {
+	Kind Kind   `json:"kind"`
+	Path string `json:"path"`
+	// Start is the command that activates the written unit, shown so an
+	// operator can see what was run on their behalf.
+	Start []string `json:"start"`
+}
+
+// Detect reports which supervisor this host offers, or an error naming what was
+// looked for. A host with neither is not a failure to handle quietly: telling
+// someone monitoring is installed when nothing supervises it would be worse
+// than refusing.
+func Detect() (Kind, error) {
+	switch runtime.GOOS {
+	case "linux":
+		if _, err := exec.LookPath("systemctl"); err != nil {
+			return "", fmt.Errorf("systemctl not found; homebutler can only install a service where systemd runs it")
+		}
+		return Systemd, nil
+	case "darwin":
+		if _, err := exec.LookPath("launchctl"); err != nil {
+			return "", fmt.Errorf("launchctl not found, which should not happen on macOS")
+		}
+		return Launchd, nil
+	default:
+		return "", fmt.Errorf("no supported supervisor on %s; homebutler installs a systemd user unit or a launchd agent", runtime.GOOS)
+	}
+}
+
+// UnitPath is where the unit or agent file belongs for kind.
+func UnitPath(kind Kind, home string) string {
+	switch kind {
+	case Systemd:
+		return filepath.Join(home, ".config", "systemd", "user", Label+".service")
+	case Launchd:
+		return filepath.Join(home, "Library", "LaunchAgents", Label+".plist")
+	}
+	return ""
+}
+
+// Render writes the unit text for kind, running the binary at exe.
+func Render(kind Kind, exe, home string) string {
+	switch kind {
+	case Systemd:
+		return systemdUnit(exe)
+	case Launchd:
+		return launchdPlist(exe, home)
+	}
+	return ""
+}
+
+func systemdUnit(exe string) string {
+	return fmt.Sprintf(`[Unit]
+Description=homebutler monitoring
+Documentation=https://github.com/Higangssh/homebutler
+# Docker may not be up yet at login; the monitor reconnects on its own, so this
+# is a hint about ordering rather than a requirement.
+After=docker.service
+
+[Service]
+Type=simple
+ExecStart=%s watch start
+# The monitor retries a dropped event stream itself, so a restart here means the
+# process actually died. The delay keeps a crash loop from filling the journal.
+Restart=always
+RestartSec=10s
+
+[Install]
+WantedBy=default.target
+`, exe)
+}
+
+func launchdPlist(exe, home string) string {
+	logDir := filepath.Join(home, ".homebutler", "logs")
+	return fmt.Sprintf(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key>
+  <string>%s</string>
+  <key>ProgramArguments</key>
+  <array>
+    <string>%s</string>
+    <string>watch</string>
+    <string>start</string>
+  </array>
+  <key>RunAtLoad</key>
+  <true/>
+  <key>KeepAlive</key>
+  <true/>
+  <!-- launchd restarts on exit with no delay of its own; the monitor reconnects
+       internally, so a restart here means the process died, and this keeps that
+       from becoming a spin. -->
+  <key>ThrottleInterval</key>
+  <integer>10</integer>
+  <key>StandardOutPath</key>
+  <string>%s/watch.log</string>
+  <key>StandardErrorPath</key>
+  <string>%s/watch.log</string>
+</dict>
+</plist>
+`, Label, exe, logDir, logDir)
+}
+
+// StartCommand activates a written unit.
+func StartCommand(kind Kind, path string) []string {
+	switch kind {
+	case Systemd:
+		return []string{"systemctl", "--user", "enable", "--now", Label + ".service"}
+	case Launchd:
+		return []string{"launchctl", "bootstrap", "gui/" + fmt.Sprint(os.Getuid()), path}
+	}
+	return nil
+}
+
+// StopCommand deactivates an installed unit.
+func StopCommand(kind Kind, path string) []string {
+	switch kind {
+	case Systemd:
+		return []string{"systemctl", "--user", "disable", "--now", Label + ".service"}
+	case Launchd:
+		return []string{"launchctl", "bootout", "gui/" + fmt.Sprint(os.Getuid()) + "/" + Label}
+	}
+	return nil
+}
+
+// LingerNote returns the advice a systemd user unit needs to outlive the
+// session, or "" where it does not apply. Reported rather than done: enabling
+// lingering is a change to the user account, not to homebutler's own files.
+func LingerNote(kind Kind) string {
+	if kind != Systemd {
+		return ""
+	}
+	user := os.Getenv("USER")
+	if user == "" {
+		user = "$USER"
+	}
+	return fmt.Sprintf("A user unit stops at logout unless lingering is enabled:\n    sudo loginctl enable-linger %s", user)
+}
+
+// Write puts the rendered unit at path, creating the directory it belongs in.
+func Write(path, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		return fmt.Errorf("write %s: %w", path, err)
+	}
+	return nil
+}
+
+// Installed reports whether a unit file is already present at path.
+func Installed(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// Run executes an activation command, returning its combined output on failure
+// so the operator sees what the supervisor said rather than an exit code.
+func Run(argv []string) error {
+	if len(argv) == 0 {
+		return fmt.Errorf("no command to run")
+	}
+	out, err := exec.Command(argv[0], argv[1:]...).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %w\n%s", strings.Join(argv, " "), err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// MaxLogBytes bounds the file launchd redirects this process's output into.
+//
+// systemd sends stderr to journald, which rotates it. launchd writes
+// StandardErrorPath and rotates nothing, and macOS offers no rotation for it
+// without a newsyslog.d entry, which needs root. Bounding it here needs neither.
+const MaxLogBytes = 4 << 20
+
+// LogPath is the file the launchd agent redirects output into. Empty on
+// platforms whose supervisor already handles this.
+func LogPath(kind Kind, home string) string {
+	if kind != Launchd {
+		return ""
+	}
+	return filepath.Join(home, ".homebutler", "logs", "watch.log")
+}
+
+// TrimLog truncates path to its last max bytes, keeping the end, and does
+// nothing if the file is smaller or absent.
+//
+// Rewriting the file underneath the supervisor is safe because launchd opens
+// these paths for append: the next write goes to the end of the file as it is
+// then, not to a remembered offset.
+func TrimLog(path string, max int64) error {
+	if path == "" {
+		return nil
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	if info.Size() <= max {
+		return nil
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	if _, err := f.Seek(info.Size()-max, 0); err != nil {
+		return err
+	}
+	kept, err := io.ReadAll(f)
+	if err != nil {
+		return err
+	}
+	// Start at a line boundary so the first surviving line is whole.
+	if i := indexByte(kept, '\n'); i >= 0 && i < len(kept)-1 {
+		kept = kept[i+1:]
+	}
+	return os.WriteFile(path, kept, info.Mode().Perm())
+}
+
+func indexByte(b []byte, c byte) int {
+	for i := range b {
+		if b[i] == c {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -1,0 +1,125 @@
+package service
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// The unit has to name the binary that wrote it. Rendering a bare "homebutler"
+// would depend on the supervisor's PATH, which is not the shell's.
+func TestRenderUsesTheAbsoluteBinaryPath(t *testing.T) {
+	for _, kind := range []Kind{Systemd, Launchd} {
+		got := Render(kind, "/opt/bin/homebutler", "/home/x")
+		if !strings.Contains(got, "/opt/bin/homebutler") {
+			t.Errorf("%s unit does not name the binary:\n%s", kind, got)
+		}
+	}
+}
+
+// A restart delay is what keeps a failing start from spinning. Without it the
+// supervisor becomes the retry mechanism for a stream the monitor already
+// retries itself.
+func TestRenderSetsARestartDelay(t *testing.T) {
+	if got := Render(Systemd, "/b", "/h"); !strings.Contains(got, "RestartSec=") {
+		t.Errorf("systemd unit has no restart delay:\n%s", got)
+	}
+	if got := Render(Launchd, "/b", "/h"); !strings.Contains(got, "ThrottleInterval") {
+		t.Errorf("launchd agent has no throttle:\n%s", got)
+	}
+}
+
+// Both platforms are user-level: a Linux system unit would read root's home and
+// find an empty watch list, and a macOS LaunchDaemon would poll a Docker
+// Desktop that is not running.
+func TestUnitPathsAreUserLevel(t *testing.T) {
+	home := "/home/x"
+	if got := UnitPath(Systemd, home); !strings.HasPrefix(got, home) {
+		t.Errorf("systemd unit is not under the user's home: %s", got)
+	}
+	if got := UnitPath(Launchd, "/Users/x"); !strings.Contains(got, "LaunchAgents") {
+		t.Errorf("launchd path is not an agent: %s", got)
+	}
+	if strings.Contains(UnitPath(Launchd, "/Users/x"), "LaunchDaemons") {
+		t.Error("launchd path is a daemon; Docker Desktop only runs in a user session")
+	}
+}
+
+// Only launchd needs its log bounded — journald rotates what systemd collects.
+func TestLogPathOnlyAppliesToLaunchd(t *testing.T) {
+	if got := LogPath(Systemd, "/home/x"); got != "" {
+		t.Errorf("systemd should not need a log file, got %q", got)
+	}
+	if got := LogPath(Launchd, "/Users/x"); got == "" {
+		t.Error("launchd writes a file that nothing else rotates")
+	}
+}
+
+func TestTrimLogKeepsTheTail(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "watch.log")
+	body := strings.Repeat("noise\n", 5000) + "LAST LINE\n"
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := TrimLog(path, 1024); err != nil {
+		t.Fatalf("TrimLog: %v", err)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if int64(len(got)) > 1024 {
+		t.Errorf("kept %d bytes, cap is 1024", len(got))
+	}
+	if !strings.HasSuffix(string(got), "LAST LINE\n") {
+		t.Error("trimming dropped the end, which is the half worth keeping")
+	}
+	if strings.HasPrefix(string(got), "oise") {
+		t.Error("trimming left a partial first line")
+	}
+}
+
+func TestTrimLogLeavesSmallAndMissingFilesAlone(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "watch.log")
+	if err := os.WriteFile(path, []byte("short\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := TrimLog(path, 1024); err != nil {
+		t.Fatalf("TrimLog: %v", err)
+	}
+	if got, _ := os.ReadFile(path); string(got) != "short\n" {
+		t.Errorf("a file under the cap was rewritten: %q", got)
+	}
+	if err := TrimLog(filepath.Join(dir, "absent.log"), 1024); err != nil {
+		t.Errorf("a missing log is not an error: %v", err)
+	}
+	if err := TrimLog("", 1024); err != nil {
+		t.Errorf("no log path is not an error: %v", err)
+	}
+}
+
+// A systemd user unit stops at logout unless lingering is enabled, and enabling
+// it changes the user account rather than homebutler's own files — so it is
+// reported, not done.
+func TestLingerNoteIsSystemdOnly(t *testing.T) {
+	if got := LingerNote(Systemd); !strings.Contains(got, "enable-linger") {
+		t.Errorf("systemd note does not mention lingering: %q", got)
+	}
+	if got := LingerNote(Launchd); got != "" {
+		t.Errorf("launchd has no lingering concept, got %q", got)
+	}
+}
+
+func TestWriteCreatesTheDirectory(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "a", "b", "unit.service")
+	if err := Write(path, "hello"); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if !Installed(path) {
+		t.Error("Installed does not see the file Write just made")
+	}
+}

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -123,3 +123,31 @@ func TestWriteCreatesTheDirectory(t *testing.T) {
 		t.Error("Installed does not see the file Write just made")
 	}
 }
+
+// A supervised process does not get a login shell's PATH. Without this a
+// launchd agent never finds docker, which lives in /opt/homebrew/bin or
+// /usr/local/bin — the unit installs, runs, and monitors nothing.
+func TestRenderSetsAPathThatCanFindDocker(t *testing.T) {
+	for _, kind := range []Kind{Systemd, Launchd} {
+		got := Render(kind, "/b", "/h")
+		for _, dir := range []string{"/opt/homebrew/bin", "/usr/local/bin"} {
+			if !strings.Contains(got, dir) {
+				t.Errorf("%s unit's PATH does not include %s:\n%s", kind, dir, got)
+			}
+		}
+	}
+}
+
+// Reinstalling has to unload before it loads: launchctl bootstrap fails on an
+// already-loaded service, so overwriting the file alone leaves the old
+// configuration live.
+func TestStopCommandExistsForEveryKind(t *testing.T) {
+	for _, kind := range []Kind{Systemd, Launchd} {
+		if len(StopCommand(kind, "/p")) == 0 {
+			t.Errorf("%s has no way to unload, so --force cannot reload it", kind)
+		}
+		if len(RestartCommand(kind)) == 0 {
+			t.Errorf("%s has no restart command, so a changed watch list cannot be picked up", kind)
+		}
+	}
+}

--- a/internal/watch/docker_monitor.go
+++ b/internal/watch/docker_monitor.go
@@ -58,11 +58,55 @@ func (e *dockerEvent) containerName() string {
 }
 
 // Watch starts listening to docker die events and sends Incidents for watched containers.
+// reconnectMin and reconnectMax bound how quickly a dropped event stream is
+// retried. The supervisor that will run this process (#80) restarts it on exit,
+// so a monitor that returned on a dropped stream would turn a docker restart
+// into a tight loop of process starts, each writing a line to the log. Retrying
+// here keeps the supervisor for the case it is for: the process actually died.
+const (
+	reconnectMin = time.Second
+	reconnectMax = 30 * time.Second
+)
+
+// Watch follows docker events for the given targets until ctx is cancelled,
+// reconnecting when the stream drops.
+//
+// `docker events` is a long-lived stream, and it ends for ordinary reasons: the
+// daemon restarting, a Docker Desktop update, the socket being recreated. None
+// of those mean monitoring should stop, so the stream ending is a reason to
+// wait and reconnect rather than a reason to return.
 func (dm *DockerMonitor) Watch(ctx context.Context, targets []Target, incidents chan<- Incident) error {
 	if len(targets) == 0 {
 		<-ctx.Done()
 		return ctx.Err()
 	}
+
+	delay := reconnectMin
+	for {
+		err := dm.watchOnce(ctx, targets, incidents)
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
+		fmt.Fprintf(os.Stderr, "[docker-monitor] %v; reconnecting in %s\n", err, delay)
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		// Back off while it keeps failing; a stream that lasted is not evidence
+		// of a problem, but this cannot tell the two apart without timing the
+		// connection, and erring towards the slower retry costs only latency.
+		if delay < reconnectMax {
+			delay *= 2
+			if delay > reconnectMax {
+				delay = reconnectMax
+			}
+		}
+	}
+}
+
+// watchOnce follows one event stream until it ends or ctx is cancelled.
+func (dm *DockerMonitor) watchOnce(ctx context.Context, targets []Target, incidents chan<- Incident) error {
 
 	run := dm.Run
 	if run == nil {

--- a/internal/watch/docker_monitor_test.go
+++ b/internal/watch/docker_monitor_test.go
@@ -138,7 +138,7 @@ func TestDockerMonitor_Watch_MalformedJSON(t *testing.T) {
 	targets := []Target{{Container: "nginx", Kind: "docker"}}
 
 	go func() {
-		_ = dm.Watch(ctx, targets, incCh)
+		_ = dm.watchOnce(ctx, targets, incCh)
 	}()
 
 	select {
@@ -173,7 +173,7 @@ func TestDockerMonitor_Watch_UnwatchedContainer(t *testing.T) {
 	targets := []Target{{Container: "nginx", Kind: "docker"}}
 
 	go func() {
-		_ = dm.Watch(ctx, targets, incCh)
+		_ = dm.watchOnce(ctx, targets, incCh)
 	}()
 
 	select {
@@ -210,7 +210,7 @@ func TestDockerMonitor_Watch_ContextCancel(t *testing.T) {
 
 	done := make(chan error, 1)
 	go func() {
-		done <- dm.Watch(ctx, targets, incCh)
+		done <- dm.watchOnce(ctx, targets, incCh)
 	}()
 
 	cancel()
@@ -236,7 +236,7 @@ func TestDockerMonitor_Watch_EventStreamerError(t *testing.T) {
 	incCh := make(chan Incident, 10)
 	targets := []Target{{Container: "nginx", Kind: "docker"}}
 
-	err := dm.Watch(ctx, targets, incCh)
+	err := dm.watchOnce(ctx, targets, incCh)
 	if err == nil {
 		t.Fatal("expected error from event streamer")
 	}
@@ -266,7 +266,7 @@ func TestDockerMonitor_Watch_CommandRunnerError(t *testing.T) {
 	targets := []Target{{Container: "nginx", Kind: "docker"}}
 
 	go func() {
-		_ = dm.Watch(ctx, targets, incCh)
+		_ = dm.watchOnce(ctx, targets, incCh)
 	}()
 
 	select {
@@ -297,7 +297,7 @@ func TestDockerMonitor_Watch_StreamEnded(t *testing.T) {
 	incCh := make(chan Incident, 10)
 	targets := []Target{{Container: "nginx", Kind: "docker"}}
 
-	err := dm.Watch(ctx, targets, incCh)
+	err := dm.watchOnce(ctx, targets, incCh)
 	if err == nil || !strings.Contains(err.Error(), "docker events stream ended") {
 		t.Errorf("expected stream ended error, got: %v", err)
 	}
@@ -325,7 +325,7 @@ func TestDockerMonitor_Watch_SaveIncident(t *testing.T) {
 	targets := []Target{{Container: "nginx", Kind: "docker"}}
 
 	go func() {
-		_ = dm.Watch(ctx, targets, incCh)
+		_ = dm.watchOnce(ctx, targets, incCh)
 	}()
 
 	select {
@@ -369,7 +369,7 @@ func TestDockerMonitor_Watch_BlankLines(t *testing.T) {
 	targets := []Target{{Container: "nginx", Kind: "docker"}}
 
 	go func() {
-		_ = dm.Watch(ctx, targets, incCh)
+		_ = dm.watchOnce(ctx, targets, incCh)
 	}()
 
 	select {
@@ -421,7 +421,7 @@ func TestDockerMonitor_Watch_ScanError(t *testing.T) {
 	incCh := make(chan Incident, 10)
 	targets := []Target{{Container: "nginx", Kind: "docker"}}
 
-	err := dm.Watch(ctx, targets, incCh)
+	err := dm.watchOnce(ctx, targets, incCh)
 	// Should return the stream ended error (scanner reads 0 bytes, no scan error propagated to errCh)
 	if err == nil {
 		t.Fatal("expected error")
@@ -449,7 +449,7 @@ func TestDockerMonitor_Watch_EffectiveUnit(t *testing.T) {
 	targets := []Target{{Container: "alias", Kind: "docker", Unit: "my-real-container"}}
 
 	go func() {
-		_ = dm.Watch(ctx, targets, incCh)
+		_ = dm.watchOnce(ctx, targets, incCh)
 	}()
 
 	select {

--- a/internal/watch/leak_test.go
+++ b/internal/watch/leak_test.go
@@ -1,0 +1,47 @@
+package watch
+
+import (
+	"context"
+	"io"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Reconnecting is the loop this process spends its life in, so anything it
+// leaks per attempt accumulates for as long as docker is down. Each attempt
+// spawns a scanner goroutine and a child process; both have to be gone before
+// the next attempt starts.
+func TestReconnectingDoesNotLeakGoroutines(t *testing.T) {
+	dm := &DockerMonitor{
+		Dir:          t.TempDir(),
+		PostLogDelay: time.Millisecond,
+		Run:          func(string, ...string) (string, error) { return "", nil },
+		Events: func(context.Context) (io.ReadCloser, func(), error) {
+			return io.NopCloser(strings.NewReader("")), func() {}, nil
+		},
+	}
+	targets := []Target{{Container: "nginx", Kind: "docker"}}
+
+	// Settle, then take a baseline.
+	for i := 0; i < 3; i++ {
+		_ = dm.watchOnce(context.Background(), targets, make(chan Incident, 1))
+	}
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	before := runtime.NumGoroutine()
+
+	for i := 0; i < 200; i++ {
+		_ = dm.watchOnce(context.Background(), targets, make(chan Incident, 1))
+	}
+	runtime.GC()
+	time.Sleep(100 * time.Millisecond)
+	after := runtime.NumGoroutine()
+
+	// A per-attempt leak would show as roughly +200 here; a few in flight is
+	// scheduling noise rather than accumulation.
+	if after-before > 10 {
+		t.Errorf("200 reconnects grew goroutines from %d to %d", before, after)
+	}
+}

--- a/internal/watch/reconnect_test.go
+++ b/internal/watch/reconnect_test.go
@@ -1,0 +1,108 @@
+package watch
+
+import (
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// A dropped event stream is not a reason to stop monitoring. Before #80 this
+// returned, the process exited, and a supervisor restarted it — which turns a
+// docker restart into a loop of process starts.
+func TestDockerMonitorReconnectsAfterTheStreamEnds(t *testing.T) {
+	var opened int32
+	dm := &DockerMonitor{
+		Dir:          t.TempDir(),
+		PostLogDelay: time.Millisecond,
+		Run:          func(string, ...string) (string, error) { return "", nil },
+		Events: func(context.Context) (io.ReadCloser, func(), error) {
+			// Every stream ends immediately, so Watch can only make progress by
+			// reconnecting.
+			atomic.AddInt32(&opened, 1)
+			return io.NopCloser(strings.NewReader("")), func() {}, nil
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*reconnectMin)
+	defer cancel()
+
+	incCh := make(chan Incident, 1)
+	err := dm.Watch(ctx, []Target{{Container: "nginx", Kind: "docker"}}, incCh)
+
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Watch should only return once the context is done, got %v", err)
+	}
+	if n := atomic.LoadInt32(&opened); n < 2 {
+		t.Errorf("stream was opened %d time(s); a dropped stream should be reconnected", n)
+	}
+}
+
+// A stream that cannot be opened at all — docker down — is the same situation
+// and must not return either.
+func TestDockerMonitorReconnectsWhenTheStreamCannotOpen(t *testing.T) {
+	var attempts int32
+	dm := &DockerMonitor{
+		Dir: t.TempDir(),
+		Run: func(string, ...string) (string, error) { return "", nil },
+		Events: func(context.Context) (io.ReadCloser, func(), error) {
+			atomic.AddInt32(&attempts, 1)
+			return nil, nil, errors.New("cannot connect to the Docker daemon")
+		},
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*reconnectMin)
+	defer cancel()
+
+	err := dm.Watch(ctx, []Target{{Container: "nginx", Kind: "docker"}}, make(chan Incident, 1))
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("Watch should only return once the context is done, got %v", err)
+	}
+	if n := atomic.LoadInt32(&attempts); n < 2 {
+		t.Errorf("connect was attempted %d time(s); a daemon that is down should be retried", n)
+	}
+}
+
+// Cancelling has to win over a pending reconnect delay, or shutdown waits for
+// a backoff that can be half a minute.
+func TestDockerMonitorStopsPromptlyWhileWaitingToReconnect(t *testing.T) {
+	dm := &DockerMonitor{
+		Dir: t.TempDir(),
+		Run: func(string, ...string) (string, error) { return "", nil },
+		Events: func(context.Context) (io.ReadCloser, func(), error) {
+			return io.NopCloser(strings.NewReader("")), func() {}, nil
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- dm.Watch(ctx, []Target{{Container: "nginx", Kind: "docker"}}, make(chan Incident, 1))
+	}()
+
+	// Let it drop once and enter the reconnect wait, then cancel.
+	time.Sleep(reconnectMin / 4)
+	cancel()
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Errorf("expected context.Canceled, got %v", err)
+		}
+	case <-time.After(reconnectMin):
+		t.Error("Watch kept waiting on the reconnect delay after the context was cancelled")
+	}
+}
+
+// Watch with nothing to watch still blocks on the context rather than spinning.
+func TestDockerMonitorWithNoTargetsWaitsForCancellation(t *testing.T) {
+	dm := &DockerMonitor{Dir: t.TempDir()}
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if err := dm.Watch(ctx, nil, make(chan Incident, 1)); !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("expected DeadlineExceeded, got %v", err)
+	}
+}


### PR DESCRIPTION
The README leads with "why did this service restart at 3 AM?" and `watch start` was a foreground process, so nothing was running at 3 AM unless someone had left a terminal open. Everything downstream assumed otherwise: `notify` only fires from the incident loop, incident history only fills while it is alive, and `report` only has a snapshot to compare against if something took one.

```bash
homebutler watch install     # systemd user unit, or launchd agent
homebutler watch installed   # what would be written, or what is
homebutler watch uninstall
```

No daemon is added. The host already supervises things; this hands the loop to whatever does it.

## Why both platforms are user-level

Neither is a preference, and the reasons differ.

**Linux.** `WatchDir` resolves `~/.homebutler/watch` from the invoking user's home (`internal/watch/store.go`). A system unit runs as root, reads `/root/.homebutler/watch`, finds nothing, and monitors an empty list without saying so. Lingering is what makes a user unit outlive the session — reported rather than enabled, since it changes the user account rather than homebutler's own files.

**macOS.** Docker Desktop only runs inside a logged-in user session, so a LaunchDaemon would be polling a daemon that is not there.

## The monitor reconnects, which is the part that makes this safe

`docker events` is a long-lived stream and it ends for ordinary reasons: the daemon restarting, a Docker Desktop update, the socket being recreated. `DockerMonitor.Watch` returned on that, which ended the process.

That is invisible in the foreground, where a person sees "All monitors stopped" and runs it again. Under `Restart=always` it becomes:

```
start → stream fails → one line to stderr → exit → start → ...
```

A docker restart would have produced thousands of process starts and log lines. The stream is now retried in place with backoff from 1s to 30s, so the supervisor is left for the case it is for — the process actually died. `Watch` is the retry loop; the previous body is `watchOnce`, unchanged, and the existing tests point at it because single-connection behaviour is what they were testing.

## Logs

systemd sends stderr to journald, which rotates it. launchd writes `StandardErrorPath` and rotates nothing, and macOS offers no rotation for it without a `newsyslog.d` entry that needs root.

`~/.homebutler/logs/watch.log` is trimmed to its last 4MB at startup and hourly, keeping the end. Rewriting the file under launchd is safe because it opens these paths for append. `LogPath` returns empty for systemd, so the trim is a no-op there rather than a special case at the call site.

## init

`init` used to end at "Try it out: homebutler status". A change-detection tool has nothing to show on its first run — there is no baseline yet — so it now points at `watch add` and `watch install`. The second interaction is the one that has to arrive on its own.

## Tests

`internal/service` covers the unit contents (absolute binary path, restart delay present, paths are user-level and not daemon-level), that only launchd gets a log path, that trimming keeps the tail and leaves small or absent files alone, and that the lingering note is systemd-only.

`internal/watch` covers reconnection after a stream ends, reconnection when the stream cannot open at all, and that cancelling wins over a pending reconnect delay rather than waiting out the backoff.

Closes #80.

---

## Installed on a real machine, which found three bugs

Everything above passed its unit tests before any of this. These came from writing the agent to a Mac, watching `~/.homebutler/logs/watch.log`, and reading `launchctl list`.

**`watch start` returned when the watch list was empty**, and a supervisor that restarts on exit turns that into a loop — 8,640 process starts a day at launchd's throttle. The log growing by exactly one line every ten seconds is what gave it away. It was also wrong independently of the daemon: since #97 this process checks thresholds and runs rules, and neither needs a target. It now says the list is empty and keeps running, which during the test meant reporting `✅ All clear (cpu 6%, mem 47%, disk 5%)` every thirty seconds with nothing on the list.

**Neither unit set `PATH`.** A supervised process does not get a login shell's, and docker is in `/opt/homebrew/bin` or `/usr/local/bin`, so the agent installed, ran, and reported `docker: executable file not found in $PATH` forever. `remote.Run` already solves this exact problem the same way before running homebutler over SSH; the units now export the same list.

**`--force` overwrote the file without reloading it.** `launchctl bootstrap` fails with exit 5 on an already-loaded service, so launchd kept the old configuration and the rewrite looked like it had done nothing. Install unloads first now.

## What held up

The reconnection did, under the condition it was written for. With the docker daemon down:

```
[docker-monitor] docker events stream ended; reconnecting in 1s
[docker-monitor] docker events stream ended; reconnecting in 2s
  ⏱️  11:03:14  ✅ All clear (cpu 3%, mem 47%, disk 5%)
[docker-monitor] docker events stream ended; reconnecting in 4s
[docker-monitor] docker events stream ended; reconnecting in 8s
```

One process, backing off, still reporting the monitoring that does work. Before this branch that would have been the process exiting and the supervisor restarting it.

`watch uninstall` was verified too: plist removed, nothing left in `launchctl list`, no process, no log directory.

## Known limitation, not fixed here

The monitors read the watch list once at startup, so `watch add` while the service runs has no effect until it restarts. Rather than leave that silent, `watch add` and `watch remove` now print the reload command when a unit is installed. Re-reading the list without a restart is a larger change and belongs on its own.
