### PR TITLE
fix: every Docker incident was analysed as a clean exit

### DIFF
--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -548,9 +548,17 @@ Docker targets use docker events (real-time). Systemd and PM2 targets use pollin
 						return nil
 					}
 
+					// The exit code is the analyser's highest-confidence signal —
+					// 137 is OOM, 139 a segfault, 143 a SIGTERM — and leaving it
+					// unset meant every incident reached `case 0` and was
+					// reported as a clean exit (#108).
 					crashInfo := watch.CrashInfo{
-						ErrorLog: inc.PreLogs,
-						Backend:  getBackendKind(inc.Container, targets),
+						ErrorLog:  inc.PreLogs,
+						Backend:   getBackendKind(inc.Container, targets),
+						OOMKilled: inc.OOMKilled,
+					}
+					if inc.ExitCode != nil {
+						crashInfo.ExitCode = *inc.ExitCode
 					}
 					summary := watch.Analyze(crashInfo)
 					inc.CrashAnalysis = &summary

--- a/internal/watch/docker_monitor.go
+++ b/internal/watch/docker_monitor.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 	"time"
 
@@ -45,6 +46,29 @@ type dockerEvent struct {
 
 type dockerEventActor struct {
 	Attributes map[string]string `json:"Attributes"`
+}
+
+// exitCode reports the status the container exited with, and whether the event
+// carried one. A die event's attributes include it as a decimal string:
+//
+//	{"execDuration":"2","exitCode":"42","image":"alpine","name":"hb-evt"}
+//
+// Its absence is reported rather than defaulted, because zero is a meaningful
+// exit code — treating a missing value as zero is what made every incident read
+// as a clean exit (#108).
+func (e *dockerEvent) exitCode() (int, bool) {
+	if e.Actor.Attributes == nil {
+		return 0, false
+	}
+	raw, ok := e.Actor.Attributes["exitCode"]
+	if !ok {
+		return 0, false
+	}
+	code, err := strconv.Atoi(raw)
+	if err != nil {
+		return 0, false
+	}
+	return code, true
 }
 
 // containerName extracts the container name from a docker event.
@@ -227,6 +251,12 @@ func (dm *DockerMonitor) watchOnce(ctx context.Context, targets []Target, incide
 				CurrStarted: "(post-restart)",
 				PreLogs:     preLogs,
 				PostLogs:    postLogs,
+			}
+			if code, ok := ev.exitCode(); ok {
+				inc.ExitCode = &code
+				// 137 is SIGKILL, which the kernel's OOM killer uses. The
+				// analyser distinguishes the two, so this only reports what
+				// the event actually said.
 			}
 			if dm.Dir != "" {
 				if err := SaveIncident(dm.Dir, &inc, dm.Keep); err != nil {

--- a/internal/watch/exitcode_test.go
+++ b/internal/watch/exitcode_test.go
@@ -1,0 +1,118 @@
+package watch
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// A die event carries the exit status; dropping it meant every incident
+// reached Analyze's `case 0` and was reported as a clean exit (#108).
+func TestDockerEventReportsItsExitCode(t *testing.T) {
+	// Captured from a real `docker events --format '{{json .}}'` die event.
+	const raw = `{"status":"die","id":"abc","Actor":{"Attributes":{"execDuration":"2","exitCode":"137","image":"alpine","name":"hb-evt"}},"time":1788056105}`
+
+	var ev dockerEvent
+	if err := json.Unmarshal([]byte(raw), &ev); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	code, ok := ev.exitCode()
+	if !ok {
+		t.Fatal("a die event's exit code was not read")
+	}
+	if code != 137 {
+		t.Errorf("exit code = %d, want 137", code)
+	}
+}
+
+// Absence and zero are different answers. Reporting a missing exit code as
+// zero is the bug: the analyser reads zero as a clean exit.
+func TestDockerEventDistinguishesMissingFromZero(t *testing.T) {
+	cases := map[string]struct {
+		raw       string
+		wantCode  int
+		wantFound bool
+	}{
+		"reported zero": {`{"Actor":{"Attributes":{"exitCode":"0"}}}`, 0, true},
+		"absent":        {`{"Actor":{"Attributes":{"image":"alpine"}}}`, 0, false},
+		"no attributes": {`{"Actor":{}}`, 0, false},
+		"not a number":  {`{"Actor":{"Attributes":{"exitCode":"oops"}}}`, 0, false},
+	}
+	for name, tc := range cases {
+		var ev dockerEvent
+		if err := json.Unmarshal([]byte(tc.raw), &ev); err != nil {
+			t.Fatalf("%s: unmarshal: %v", name, err)
+		}
+		code, ok := ev.exitCode()
+		if ok != tc.wantFound || code != tc.wantCode {
+			t.Errorf("%s: got (%d, %v), want (%d, %v)", name, code, ok, tc.wantCode, tc.wantFound)
+		}
+	}
+}
+
+// The categories the exit code unlocks are the analyser's highest-confidence
+// rules, and none of them could fire while the code never arrived.
+func TestAnalyzeUsesTheExitCodeItIsGiven(t *testing.T) {
+	cases := []struct {
+		code     int
+		category string
+	}{
+		{137, "oom"},
+		{139, "segfault"},
+		{143, "sigterm"},
+		{0, "clean_restart"},
+	}
+	for _, tc := range cases {
+		got := Analyze(CrashInfo{ExitCode: tc.code, Backend: "docker"})
+		if got.Category != tc.category {
+			t.Errorf("exit %d classified as %q, want %q", tc.code, got.Category, tc.category)
+		}
+	}
+}
+
+// An incident round-trips the exit code, so `watch show` can say how a process
+// ended rather than only what its logs said.
+func TestIncidentCarriesTheExitCodeThroughDisk(t *testing.T) {
+	dir := t.TempDir()
+	code := 137
+	inc := Incident{
+		ID:         GenerateIncidentID("svc", time.Now()),
+		Container:  "svc",
+		DetectedAt: time.Now(),
+		ExitCode:   &code,
+	}
+	if err := SaveIncident(dir, &inc, 0); err != nil {
+		t.Fatalf("SaveIncident: %v", err)
+	}
+	loaded, err := LoadIncident(dir, inc.ID)
+	if err != nil {
+		t.Fatalf("LoadIncident: %v", err)
+	}
+	if loaded.ExitCode == nil {
+		t.Fatal("the exit code did not survive being written and read back")
+	}
+	if *loaded.ExitCode != 137 {
+		t.Errorf("exit code = %d, want 137", *loaded.ExitCode)
+	}
+}
+
+// An incident with no exit code must not serialize one, or a reader cannot
+// tell "exited cleanly" from "nobody said".
+func TestIncidentOmitsAnAbsentExitCode(t *testing.T) {
+	data, err := json.Marshal(Incident{ID: "x", Container: "c"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) == "" || contains(string(data), `"exit_code"`) {
+		t.Errorf("an unreported exit code was serialized anyway: %s", data)
+	}
+}
+
+func contains(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/watch/store.go
+++ b/internal/watch/store.go
@@ -64,14 +64,19 @@ type ContainerState struct {
 }
 
 type Incident struct {
-	ID            string          `json:"id"`
-	Container     string          `json:"container"`
-	DetectedAt    time.Time       `json:"detected_at"`
-	RestartCount  int             `json:"restart_count"`
-	PrevStarted   string          `json:"prev_started_at"`
-	CurrStarted   string          `json:"curr_started_at"`
-	PreLogs       string          `json:"pre_logs"`
-	PostLogs      string          `json:"post_logs"`
+	ID           string    `json:"id"`
+	Container    string    `json:"container"`
+	DetectedAt   time.Time `json:"detected_at"`
+	RestartCount int       `json:"restart_count"`
+	PrevStarted  string    `json:"prev_started_at"`
+	CurrStarted  string    `json:"curr_started_at"`
+	PreLogs      string    `json:"pre_logs"`
+	PostLogs     string    `json:"post_logs"`
+	// ExitCode is how the process ended, when the backend reported it. Nil
+	// means it was not reported — zero is a real exit code, so the two cannot
+	// share a representation (#108).
+	ExitCode      *int            `json:"exit_code,omitempty"`
+	OOMKilled     bool            `json:"oom_killed,omitempty"`
 	Flapping      *FlappingResult `json:"flapping,omitempty"`
 	CrashAnalysis *CrashSummary   `json:"crash_analysis,omitempty"`
 }

--- a/internal/watch/systemd_monitor.go
+++ b/internal/watch/systemd_monitor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
 	"time"
 )
@@ -24,6 +25,9 @@ type SystemdMonitor struct {
 }
 
 type systemdState struct {
+	// ExitStatus is the unit's last exit status, nil when systemd did not
+	// report one. Zero is a real status, so it cannot be the missing value.
+	ExitStatus  *int
 	ActiveState string
 	SubState    string
 	StartTS     string
@@ -39,6 +43,13 @@ func (sm *SystemdMonitor) parseState(output string) systemdState {
 			s.SubState = strings.TrimPrefix(line, "SubState=")
 		} else if strings.HasPrefix(line, "ExecMainStartTimestamp=") {
 			s.StartTS = strings.TrimPrefix(line, "ExecMainStartTimestamp=")
+		} else if strings.HasPrefix(line, "ExecMainStatus=") {
+			// systemd reports the unit's own exit status here. It is absent
+			// for a unit that has never run, so a parse failure means "not
+			// reported" rather than zero (#108).
+			if code, err := strconv.Atoi(strings.TrimPrefix(line, "ExecMainStatus=")); err == nil {
+				s.ExitStatus = &code
+			}
 		}
 	}
 	return s
@@ -68,7 +79,7 @@ func (sm *SystemdMonitor) Watch(ctx context.Context, targets []Target, incidents
 	for _, t := range targets {
 		unit := t.EffectiveUnit()
 		out, err := run("systemctl", "show", unit,
-			"--property=ActiveState,SubState,ExecMainStartTimestamp")
+			"--property=ActiveState,SubState,ExecMainStartTimestamp,ExecMainStatus")
 		if err != nil {
 			continue
 		}
@@ -86,7 +97,7 @@ func (sm *SystemdMonitor) Watch(ctx context.Context, targets []Target, incidents
 			for _, t := range targets {
 				unit := t.EffectiveUnit()
 				out, err := run("systemctl", "show", unit,
-					"--property=ActiveState,SubState,ExecMainStartTimestamp")
+					"--property=ActiveState,SubState,ExecMainStartTimestamp,ExecMainStatus")
 				if err != nil {
 					continue
 				}
@@ -114,6 +125,7 @@ func (sm *SystemdMonitor) Watch(ctx context.Context, targets []Target, incidents
 						CurrStarted: curr.StartTS,
 						PreLogs:     preLogs,
 						PostLogs:    fmt.Sprintf("ActiveState=%s SubState=%s", curr.ActiveState, curr.SubState),
+						ExitCode:    curr.ExitStatus,
 					}
 					if sm.Dir != "" {
 						if err := SaveIncident(sm.Dir, &inc, sm.Keep); err != nil {


### PR DESCRIPTION
`CrashInfo` has `ExitCode`, `OOMKilled` and `Signal`. The incident loop filled `ErrorLog` and `Backend` and left the rest at their zero values, so `Analyze` reached `case 0` and reported `clean_restart` — "Process exited cleanly", confidence low — for every Docker incident whose logs did not happen to match a pattern rule.

The exit-code branches are the analyser's highest-confidence rules: 137 for an OOM kill, 139 a segfault, 143 a SIGTERM. None of them could ever fire.

"Why did this service restart at 3 AM?" is the question the README leads with, and answering "it exited cleanly" for a container the kernel killed is worse than answering nothing — an operator reads that as nothing being wrong and stops looking.

## The value was already in hand

A `die` event carries it, and `dockerEvent` already decodes `Actor.Attributes`:

```json
{"execDuration":"2","exitCode":"137","image":"alpine","name":"hb-evt"}
```

The monitor read the container name out of that map and dropped the exit code next to it.

`Incident` now carries it as `*int`. Zero is a real exit code and cannot share a representation with "not reported" — collapsing those two is the mistake being fixed, so reintroducing it in the storage type would be a poor trade.

## systemd

Same gap, different cause: `systemctl show` reports `ExecMainStatus` and the monitor never asked for it. It does now, parsed to `*int` on the same reasoning.

## pm2 is left alone

The issue said `pm2 jlist` reports an exit code. I wrote that without checking, and the struct here decodes status and restart count. Adding a field on an unverified claim is how this bug started, so pm2 keeps reporting no exit code until someone confirms what `jlist` actually contains.

## Verified on hardware

On a Raspberry Pi running the watch loop, a container killed with `docker kill`:

```
$ docker inspect hb-oom --format '{{.State.ExitCode}}'
137

$ homebutler watch show hb-oom-20260830-140059.532-479c6e
=== Crash Analysis ===
Category:   oom
Reason:     Process received SIGKILL (likely OOM)
Confidence: high
Signal:     SIGKILL
```

Before this branch, the same kill recorded `clean_restart` / "Process exited cleanly" / low. The stored JSON now carries `"exit_code": 137`.

## Tests

That a real captured die event yields 137; that absent, malformed and no-attributes cases report *not found* rather than zero; that `Analyze` produces oom, segfault, sigterm and clean_restart for the four codes; that the exit code survives a write and read back; and that an unreported one is omitted from the JSON rather than serialized as zero.

Closes #108.
