### PR TITLE
fix: --allow-bind could be walked out of by the archive it was meant to contain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.23.1](https://github.com/Higangssh/homebutler/compare/v0.23.0...v0.23.1) - 2026-08-30
+
+**`--allow-bind` could be walked out of by the archive it was meant to contain.** The check that a bind target sits inside a permitted root compared paths as text, and text does not follow symlinks. One archive with two bind mounts defeats it without needing anything to exist on the host beforehand: the first restores normally inside the permitted root and its payload plants a symlink there, the second names that symlink as its source, and the extraction follows it wherever it points. Upgrade if you have ever run `homebutler restore --allow-bind` on an archive from anywhere but your own machine.
+
+```bash
+brew upgrade homebutler
+curl -fsSL https://raw.githubusercontent.com/Higangssh/homebutler/main/install.sh | sh
+```
+
+### 🔐 Security
+
+- resolve symlinks before deciding a bind target is inside a permitted root (CWE-59 / CWE-22). The containment check now runs per mount, immediately before that mount is written, because the symlink that breaks it does not exist until an earlier mount in the same archive has created it — a check made once up front cannot see it. The path that was checked is the path extracted into, and a target whose real location cannot be resolved is refused rather than assumed safe. A permitted root that is itself a symlink is resolved too, so naming one keeps working
+
+Found by [@gsaraiva2109](https://github.com/gsaraiva2109) (#91). This defeats the containment added in v0.22.1 for GHSA-v8mc-vpp8-jr4p; versions v0.22.1 through v0.23.0 are affected. Named volumes and `backup drill` were never in scope.
+
+### ⚠️ Behavior changes
+
+- **A bind target that resolves outside every `--allow-bind` root is now refused**, where before only its spelling had to be inside one. A restore that used to write through a symlink out of the permitted root will now list that mount under `refused` and say where it resolved to. This is the intended containment, but it is a restore that will do less than it did before
+
+### 🧪 Tests
+
+- cover the two-mount escape end to end through `Restore`, a bind target that is an existing symlink out of the root, and the case that must keep working: a permitted root that is a symlink, with the target inside what it points to
+
 ## [0.23.0](https://github.com/Higangssh/homebutler/compare/v0.22.1...v0.23.0) - 2026-08-30
 
 **Two things homebutler could see but not act on, and one it could not see at all.** A Proxmox cluster was readable and nothing else — no way to start a guest, no way to shut one down, and invisible in the dashboard entirely. And monitoring ran as two processes that did not know about each other: the loop that detected a container crash had no way to act on it, while the loop that could act never saw crashes.

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -125,6 +125,12 @@ homebutler restore ./backup.tar.gz                       # bind mounts refused, 
 homebutler restore ./backup.tar.gz --allow-bind /srv/app # restores under /srv/app only
 ```
 
+The path is checked after symlinks are resolved, and it is checked again for
+each mount just before that mount is written. Both matter: an archive can
+declare two bind mounts, restore the first one normally inside the permitted
+root so its payload plants a symlink there, and then name that symlink as the
+second one's source. It reads as inside the root, and it is not.
+
 Refusals are printed, and appear in `--json` under `refused`, so a restore that
 did less than you expected says why rather than reporting fewer volumes.
 

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -47,26 +47,68 @@ type RestoreOptions struct {
 // container the daemon runs as root.
 var dockerVolumeName = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9_.-]*$`)
 
-// bindTargetAllowed reports whether target sits inside one of the roots the
-// operator permitted. Both sides are made absolute and lexically cleaned
-// first, so `/srv/app/../../etc` cannot pass as `/srv`.
-func bindTargetAllowed(target string, allowed []string) bool {
+// resolveBindTarget returns the real path target refers to, and an error when
+// that path is not inside a root the operator permitted.
+//
+// A lexical prefix check is not enough, and the reason is that one archive can
+// contain two bind mounts. The first extracts normally inside the allowed root
+// and its payload plants a symlink there; the second names that symlink as its
+// source. Lexically the second is inside the allowed root, so it passes —
+// os.MkdirAll follows the symlink, finds a directory and does nothing, and
+// `tar -C` follows it too and writes wherever it points. That defeats the
+// containment entirely, and neither mount looks unusual on its own.
+//
+// So the check is made against the resolved path, and it is made per mount at
+// the point the mount is about to be restored, because the symlink that breaks
+// it does not exist until an earlier mount in the same archive has created it.
+func resolveBindTarget(target string, allowed []string) (string, error) {
 	abs, err := filepath.Abs(target)
 	if err != nil {
-		return false
+		return "", fmt.Errorf("resolve %s: %w", target, err)
 	}
 	abs = filepath.Clean(abs)
+
+	// The deepest part of the path that exists is the most that can be
+	// resolved; the rest is what restore is about to create, and a path that
+	// does not exist yet cannot be a symlink.
+	existing := abs
+	var pending []string
+	for {
+		if _, err := os.Lstat(existing); err == nil {
+			break
+		}
+		parent := filepath.Dir(existing)
+		if parent == existing {
+			break
+		}
+		pending = append([]string{filepath.Base(existing)}, pending...)
+		existing = parent
+	}
+	resolvedBase, err := filepath.EvalSymlinks(existing)
+	if err != nil {
+		return "", fmt.Errorf("resolve %s: %w", target, err)
+	}
+	resolved := filepath.Join(append([]string{resolvedBase}, pending...)...)
+
 	for _, root := range allowed {
 		rootAbs, err := filepath.Abs(root)
 		if err != nil {
 			continue
 		}
-		rootAbs = filepath.Clean(rootAbs)
-		if abs == rootAbs || strings.HasPrefix(abs, rootAbs+string(filepath.Separator)) {
-			return true
+		// The permitted root is resolved too: an operator who names a path that
+		// is itself a symlink meant the place it points to.
+		rootResolved, err := filepath.EvalSymlinks(filepath.Clean(rootAbs))
+		if err != nil {
+			rootResolved = filepath.Clean(rootAbs)
+		}
+		if resolved == rootResolved || strings.HasPrefix(resolved, rootResolved+string(filepath.Separator)) {
+			return resolved, nil
 		}
 	}
-	return false
+	if resolved != abs {
+		return "", fmt.Errorf("bind target %s resolves to %s, which is outside every permitted root", target, resolved)
+	}
+	return "", fmt.Errorf("bind target %s was not permitted; pass --allow-bind %s to restore it", target, target)
 }
 
 // Restore extracts an archive and restores volumes.
@@ -129,7 +171,11 @@ func Restore(archivePath string, opts RestoreOptions) (*RestoreResult, error) {
 			// nothing to write, so restoreMount no-ops on it either way. Let it
 			// fall through so the volume count keeps its existing meaning.
 			if mountHasPayload(m, volDir) {
-				if reason := refuseMount(m, opts); reason != "" {
+				// Cleared per mount, in order, immediately before the mount is
+				// written: an earlier mount in this same archive can have
+				// created the symlink that would let this one escape.
+				cleared, reason := refuseMount(m, opts)
+				if reason != "" {
 					refused = append(refused, RefusedMount{
 						Service: svc.Name,
 						Type:    m.Type,
@@ -138,6 +184,7 @@ func Restore(archivePath string, opts RestoreOptions) (*RestoreResult, error) {
 					})
 					continue
 				}
+				m = cleared
 			}
 			if err := restoreMount(m, volDir); err != nil {
 				return nil, fmt.Errorf("failed to restore mount %s: %w", m.Name, err)
@@ -198,28 +245,32 @@ func mountTarget(m Mount) string {
 // refuseMount returns a human-readable reason to decline a mount, or "" to
 // allow it. This is the only gate between manifest.json and the filesystem,
 // so it runs before restoreMount for every mount, of every type.
-func refuseMount(m Mount, opts RestoreOptions) string {
+func refuseMount(m Mount, opts RestoreOptions) (Mount, string) {
 	switch m.Type {
 	case "volume":
 		// Anything that is not a bare volume name reaches `docker run -v` as a
 		// host path, and the daemon mounts it as root.
 		if !dockerVolumeName.MatchString(m.Name) {
-			return fmt.Sprintf("%q is not a Docker volume name; the archive may be trying to select a host path", m.Name)
+			return m, fmt.Sprintf("%q is not a Docker volume name; the archive may be trying to select a host path", m.Name)
 		}
-		return ""
+		return m, ""
 	case "bind":
 		if m.Source == "" {
-			return "the archive declares a bind mount with no source path"
+			return m, "the archive declares a bind mount with no source path"
 		}
 		if !filepath.IsAbs(m.Source) {
-			return fmt.Sprintf("bind target %q is not an absolute path", m.Source)
+			return m, fmt.Sprintf("bind target %q is not an absolute path", m.Source)
 		}
-		if !bindTargetAllowed(m.Source, opts.AllowBind) {
-			return fmt.Sprintf("bind target %s was not permitted; pass --allow-bind %s to restore it", m.Source, m.Source)
+		resolved, err := resolveBindTarget(m.Source, opts.AllowBind)
+		if err != nil {
+			return m, err.Error()
 		}
-		return ""
+		// The caller writes to the resolved path, not the declared one, so the
+		// path that was checked is the path that gets extracted into.
+		m.Source = resolved
+		return m, ""
 	default:
-		return fmt.Sprintf("unknown mount type %q", m.Type)
+		return m, fmt.Sprintf("unknown mount type %q", m.Type)
 	}
 }
 

--- a/internal/backup/restore_security_test.go
+++ b/internal/backup/restore_security_test.go
@@ -153,7 +153,7 @@ func TestRestore_RefusesBindTargetEscapingAllowedRootWithDotDot(t *testing.T) {
 func TestRefuseMount_RejectsVolumeNamesThatArePaths(t *testing.T) {
 	paths := []string{"/etc", "/", "../../etc", "/var/run/docker.sock", "-v", "_leading"}
 	for _, name := range paths {
-		if reason := refuseMount(Mount{Type: "volume", Name: name}, RestoreOptions{}); reason == "" {
+		if _, reason := refuseMount(Mount{Type: "volume", Name: name}, RestoreOptions{}); reason == "" {
 			t.Errorf("volume name %q was allowed", name)
 		}
 	}
@@ -163,7 +163,7 @@ func TestRefuseMount_RejectsVolumeNamesThatArePaths(t *testing.T) {
 func TestRefuseMount_AcceptsRealVolumeNames(t *testing.T) {
 	names := []string{"nextcloud_data", "app-db", "vol.1", "a", "0abc"}
 	for _, name := range names {
-		if reason := refuseMount(Mount{Type: "volume", Name: name}, RestoreOptions{}); reason != "" {
+		if _, reason := refuseMount(Mount{Type: "volume", Name: name}, RestoreOptions{}); reason != "" {
 			t.Errorf("volume name %q was refused: %s", name, reason)
 		}
 	}
@@ -171,7 +171,7 @@ func TestRefuseMount_AcceptsRealVolumeNames(t *testing.T) {
 
 // An unrecognised mount type is refused rather than falling through silently.
 func TestRefuseMount_RejectsUnknownType(t *testing.T) {
-	if reason := refuseMount(Mount{Type: "tmpfs", Name: "x"}, RestoreOptions{}); reason == "" {
+	if _, reason := refuseMount(Mount{Type: "tmpfs", Name: "x"}, RestoreOptions{}); reason == "" {
 		t.Error("unknown mount type was allowed")
 	}
 }
@@ -213,5 +213,173 @@ func TestRestore_DoesNotRefuseMountsWithNoPayload(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dir, "gone")); !os.IsNotExist(err) {
 		t.Error("restore created a directory for a mount it had no data for")
+	}
+}
+
+// writeTwoMountArchive builds an archive whose manifest declares two bind
+// mounts in order, each restored from its own payload directory.
+func writeTwoMountArchive(t *testing.T, dir string, mounts []Mount, payloads []string) string {
+	t.Helper()
+
+	backupDir := filepath.Join(dir, "backup_evil")
+	volDir := filepath.Join(backupDir, "volumes")
+	if err := os.MkdirAll(volDir, 0o755); err != nil {
+		t.Fatalf("mkdir volumes: %v", err)
+	}
+	for i, m := range mounts {
+		if _, err := util.RunCmd("tar", "czf",
+			filepath.Join(volDir, sanitizeName(m.Name)+".tar.gz"), "-C", payloads[i], "."); err != nil {
+			t.Fatalf("tar payload %s: %v", m.Name, err)
+		}
+	}
+
+	manifest := Manifest{Services: []ServiceInfo{{
+		Name: "evil", Container: "evil", Image: "evil", Mounts: mounts,
+	}}}
+	data, err := json.Marshal(manifest)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(backupDir, "manifest.json"), data, 0o644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	archive := filepath.Join(dir, "evil.tar.gz")
+	if _, err := util.RunCmd("tar", "czf", archive, "-C", dir, "backup_evil"); err != nil {
+		t.Fatalf("tar archive: %v", err)
+	}
+	return archive
+}
+
+// One archive can defeat a lexical containment check on its own, without any
+// symlink existing on the host beforehand. The first mount restores normally
+// inside the permitted root and its payload plants a symlink there; the second
+// names that symlink as its source, which is lexically inside the root and so
+// passes, and the extraction follows it out. This is #91.
+func TestRestore_RefusesBindTargetThatAnEarlierMountTurnedIntoASymlink(t *testing.T) {
+	dir := t.TempDir()
+
+	allowed := filepath.Join(dir, "allowed")
+	if err := os.MkdirAll(filepath.Join(allowed, "shared"), 0o755); err != nil {
+		t.Fatalf("mkdir allowed: %v", err)
+	}
+	outside := filepath.Join(dir, "outside")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	canary := filepath.Join(outside, "canary")
+	if err := os.WriteFile(canary, []byte("ORIGINAL"), 0o644); err != nil {
+		t.Fatalf("write canary: %v", err)
+	}
+
+	// The first payload is the symlink; the second is what escapes through it.
+	plant := filepath.Join(dir, "payload_plant")
+	if err := os.MkdirAll(plant, 0o755); err != nil {
+		t.Fatalf("mkdir plant: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(plant, "hop")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	escape := filepath.Join(dir, "payload_escape")
+	if err := os.MkdirAll(escape, 0o755); err != nil {
+		t.Fatalf("mkdir escape: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(escape, "canary"), []byte("OVERWRITTEN"), 0o644); err != nil {
+		t.Fatalf("write escape payload: %v", err)
+	}
+
+	hop := filepath.Join(allowed, "shared", "hop")
+	archive := writeTwoMountArchive(t, dir,
+		[]Mount{
+			{Type: "bind", Name: "shared", Source: filepath.Join(allowed, "shared"), Destination: "/shared"},
+			{Type: "bind", Name: "hop", Source: hop, Destination: "/hop"},
+		},
+		[]string{plant, escape},
+	)
+
+	result, err := Restore(archive, RestoreOptions{AllowBind: []string{allowed}})
+	if err != nil {
+		t.Fatalf("Restore() error: %v", err)
+	}
+
+	got, err := os.ReadFile(canary)
+	if err != nil {
+		t.Fatalf("read canary: %v", err)
+	}
+	if string(got) != "ORIGINAL" {
+		t.Errorf("canary outside the permitted root was overwritten: %q", got)
+	}
+	if len(result.Refused) != 1 || result.Refused[0].Target != hop {
+		t.Fatalf("the escaping mount was not refused: %#v", result.Refused)
+	}
+}
+
+// A bind target that is a symlink pointing outside the permitted root is
+// refused even when nothing in the archive created it.
+func TestRestore_RefusesBindTargetThatIsAnExistingSymlinkOutOfTheRoot(t *testing.T) {
+	dir := t.TempDir()
+
+	allowed := filepath.Join(dir, "allowed")
+	if err := os.MkdirAll(allowed, 0o755); err != nil {
+		t.Fatalf("mkdir allowed: %v", err)
+	}
+	outside := filepath.Join(dir, "outside")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	canary := filepath.Join(outside, "canary")
+	if err := os.WriteFile(canary, []byte("ORIGINAL"), 0o644); err != nil {
+		t.Fatalf("write canary: %v", err)
+	}
+	link := filepath.Join(allowed, "link")
+	if err := os.Symlink(outside, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	archive := writeMaliciousArchive(t, dir, Mount{
+		Type: "bind", Name: "pwned", Source: link, Destination: "/data",
+	})
+
+	result, err := Restore(archive, RestoreOptions{AllowBind: []string{allowed}})
+	if err != nil {
+		t.Fatalf("Restore() error: %v", err)
+	}
+	got, err := os.ReadFile(canary)
+	if err != nil {
+		t.Fatalf("read canary: %v", err)
+	}
+	if string(got) != "ORIGINAL" {
+		t.Errorf("canary was overwritten through the symlink: %q", got)
+	}
+	if len(result.Refused) != 1 {
+		t.Fatalf("the symlinked target was not refused: %#v", result.Refused)
+	}
+}
+
+// A permitted root that is itself a symlink is what the operator meant, so a
+// target inside the place it points to still restores.
+func TestRestore_AllowsBindTargetWhenThePermittedRootIsASymlink(t *testing.T) {
+	dir := t.TempDir()
+
+	real := filepath.Join(dir, "real")
+	if err := os.MkdirAll(filepath.Join(real, "data"), 0o755); err != nil {
+		t.Fatalf("mkdir real: %v", err)
+	}
+	link := filepath.Join(dir, "link")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	target := filepath.Join(real, "data")
+	archive := writeMaliciousArchive(t, dir, Mount{
+		Type: "bind", Name: "data", Source: target, Destination: "/data",
+	})
+
+	result, err := Restore(archive, RestoreOptions{AllowBind: []string{link}})
+	if err != nil {
+		t.Fatalf("Restore() error: %v", err)
+	}
+	if result.Volumes != 1 || len(result.Refused) != 0 {
+		t.Fatalf("expected the permitted bind to restore: %#v", result)
 	}
 }


### PR DESCRIPTION
Closes #91.

`--allow-bind` was meant to be the whole containment for restore, and it compared paths as text. Text does not follow symlinks, and that gap is reachable by the archive alone — nothing has to exist on the host first. An archive declares two bind mounts: the first restores normally inside the permitted root and its payload plants a symlink there, the second names that symlink as its source. Lexically it is inside the root, so it passes; `os.MkdirAll` finds a directory and no-ops, and `tar -C` follows the link out.

This is the fix, in the open, because @gsaraiva2109 reported it as a public issue. It defeats the containment added in v0.22.1 for GHSA-v8mc-vpp8-jr4p, so v0.22.1 through v0.23.0 are affected and an advisory follows.

The check now resolves symlinks, and — the part that actually matters — it runs per mount immediately before that mount is written. A check made once up front cannot see a symlink an earlier mount in the same archive has not created yet, so resolving alone would not have been enough. `refuseMount` returns the resolved mount and the caller extracts into that, so the path checked is the path written; a target whose real location cannot be resolved is refused rather than assumed safe. Permitted roots are resolved too, since an operator who names a symlink meant where it points.

Named volumes and `backup drill` are untouched — neither reads `m.Source`.

Verified on Linux (aarch64) against binaries built before and after, since a unit test on macOS is confounded by `/var` being a symlink:

```
before  → Volumes: 2, /tmp/outside91/canary = OVERWRITTEN
after   → Volumes: 1, refused: .../allowed/shared/hop
          → bind target .../allowed/shared/hop resolves to /tmp/outside91,
            which is outside every permitted root
          /tmp/outside91/canary = ORIGINAL
```