### PR TITLE
fix: restore trusted tar to decline the archive members that escape the destination

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### 🔐 Security
+
+- check archive member names in homebutler rather than relying on `tar` to decline them (#87). `restore` and `backup drill` extracted with `tar xzf -C <dir>`, which held the destination only because GNU tar and bsdtar strip a leading `/` and skip members containing `..` of their own accord. Nothing here asserted it and no test covered it, so a host with a different tar would have lost the property with no signal. Extraction is now done in homebutler, and a member that is absolute, that climbs out of the root, that is a hard link to a file outside the tree, or that is written through a symlink an earlier member of the same archive planted, fails the restore instead of being skipped
+
+### ♻️ Refactoring
+
+- derive a mount's archive path in one place (#92). `mountHasPayload`, `restoreMount` and `backup drill` each rebuilt `volDir/sanitizeName(name).tar.gz` independently, and the first two agreeing is load-bearing: `mountHasPayload` decides whether the containment check runs at all, and `restoreMount` decides what gets written. They agreed by identical code rather than by construction
+
+### ⚠️ Behavior changes
+
+- **An archive member that would be written outside its destination now fails the restore**, where `tar` skipped it and reported success. A restore that was quietly dropping members will now stop and name the member it refused. Mounts already restored before the failure stay restored — a mount target that was never permitted is still reported under `refused` and skipped, because that is an operator configuration answer; a member that lies about where it belongs is the archive being untrustworthy, and continuing to read from it is not the safe response
+
+### 🧪 Tests
+
+- cover the four escapes the extractor now refuses, and the behaviour it has to preserve: file modes, modification times, symlinks, ownership when running as root, and a directory stored read-only whose contents must still be written into it
+
 ## [0.23.1](https://github.com/Higangssh/homebutler/compare/v0.23.0...v0.23.1) - 2026-08-30
 
 **`--allow-bind` could be walked out of by the archive it was meant to contain.** The check that a bind target sits inside a permitted root compared paths as text, and text does not follow symlinks. One archive with two bind mounts defeats it without needing anything to exist on the host beforehand: the first restores normally inside the permitted root and its payload plants a symlink there, the second names that symlink as its source, and the extraction follows it wherever it points. Upgrade if you have ever run `homebutler restore --allow-bind` on an archive from anywhere but your own machine.

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -125,8 +125,14 @@ homebutler restore ./backup.tar.gz                       # bind mounts refused, 
 homebutler restore ./backup.tar.gz --allow-bind /srv/app # restores under /srv/app only
 ```
 
-The path is checked after symlinks are resolved, and it is checked again for
-each mount just before that mount is written. Both matter: an archive can
+Member names inside the archive get the same treatment. A member that is an
+absolute path, that climbs out with `..`, or that is written through a symlink
+an earlier member of the same archive planted, fails the restore rather than
+being skipped. `tar` declines most of those on its own; homebutler no longer
+depends on it doing so.
+
+The bind target is checked after symlinks are resolved, and it is checked again
+for each mount just before that mount is written. Both matter: an archive can
 declare two bind mounts, restore the first one normally inside the permitted
 root so its payload plants a symlink there, and then name that symlink as the
 second one's source. It reads as inside the root, and it is not.

--- a/internal/backup/drill.go
+++ b/internal/backup/drill.go
@@ -260,7 +260,7 @@ func verifyArchive(archivePath string) (int, error) {
 }
 
 func extractAndReadManifest(archivePath, tmpDir string) (*Manifest, string, error) {
-	if _, err := util.RunCmd("tar", "xzf", archivePath, "-C", tmpDir); err != nil {
+	if err := extractTarGz(archivePath, tmpDir); err != nil {
 		return nil, "", fmt.Errorf("failed to extract archive: %w", err)
 	}
 
@@ -350,9 +350,9 @@ func bootContainer(svc *ServiceInfo, hc HealthCheck, iso *drillIsolation, extrac
 			return fmt.Errorf("failed to create mount point: %w", err)
 		}
 
-		archivePath := filepath.Join(volDir, safeName+".tar.gz")
+		archivePath := mountArchivePath(m.Name, volDir)
 		if _, err := os.Stat(archivePath); err == nil {
-			if _, err := util.RunCmd("tar", "xzf", archivePath, "-C", mountPoint); err != nil {
+			if err := extractTarGz(archivePath, mountPoint); err != nil {
 				return fmt.Errorf("failed to extract volume %s: %w", m.Name, err)
 			}
 		}

--- a/internal/backup/extract.go
+++ b/internal/backup/extract.go
@@ -1,0 +1,255 @@
+package backup
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// extractTarGz extracts the gzipped tar archive at archivePath into dest.
+//
+// homebutler used to shell out to `tar xzf -C <dest>` for this. That was safe,
+// but only because both GNU tar and bsdtar decline the dangerous member names
+// on their own: a leading "/" is stripped, and a member containing ".." is
+// skipped with a warning. Member names come from whoever built the archive,
+// exactly as manifest paths do, so the destination held because of a default in
+// a program homebutler invokes rather than because of anything in this
+// repository. Nothing here asserted it and no test covered it, so a host with a
+// different tar — or a later switch to an archive library — would have lost the
+// property with no signal at all.
+//
+// Every member is checked here now, and a member that asks to be written
+// outside dest fails the extraction rather than being skipped. Skipping is what
+// tar does, and it means an archive that tried to escape still reports success
+// while having restored less than it said it would.
+func extractTarGz(archivePath, dest string) error {
+	f, err := os.Open(archivePath)
+	if err != nil {
+		return fmt.Errorf("open archive %s: %w", archivePath, err)
+	}
+	defer f.Close()
+
+	gz, err := gzip.NewReader(f)
+	if err != nil {
+		return fmt.Errorf("read archive %s: %w", archivePath, err)
+	}
+	defer gz.Close()
+
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		return fmt.Errorf("create %s: %w", dest, err)
+	}
+	// Resolved once: dest is created above, so it exists, and every member is
+	// compared against where it really is rather than how it was spelled.
+	destReal, err := filepath.EvalSymlinks(dest)
+	if err != nil {
+		return fmt.Errorf("resolve %s: %w", dest, err)
+	}
+
+	// Directory modes are applied after everything is written. A directory
+	// stored read-only would otherwise stop its own contents from being
+	// extracted into it, which is why tar makes the same second pass.
+	type deferredDir struct {
+		path    string
+		mode    os.FileMode
+		modTime time.Time
+		uid     int
+		gid     int
+	}
+	var dirs []deferredDir
+
+	// tar restores ownership when it runs as root and cannot when it does not.
+	// `sudo homebutler restore` is documented for exactly the case where the
+	// target is not writable by the invoking user, so a restore that silently
+	// dropped ownership would break the setups most likely to need it.
+	restoreOwner := os.Geteuid() == 0
+
+	tr := tar.NewReader(gz)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			return fmt.Errorf("read archive %s: %w", archivePath, err)
+		}
+
+		target, err := memberTarget(hdr.Name, destReal)
+		if err != nil {
+			return fmt.Errorf("archive %s: %w", archivePath, err)
+		}
+		if target == destReal {
+			continue // the "./" entry tar writes for the root of the tree
+		}
+
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return fmt.Errorf("create directory %s: %w", target, err)
+			}
+			dirs = append(dirs, deferredDir{target, hdr.FileInfo().Mode().Perm(), hdr.ModTime, hdr.Uid, hdr.Gid})
+		case tar.TypeReg:
+			if err := writeMember(tr, target, hdr.FileInfo().Mode().Perm()); err != nil {
+				return err
+			}
+			if err := applyMetadata(target, hdr.ModTime, hdr.Uid, hdr.Gid, restoreOwner); err != nil {
+				return err
+			}
+		case tar.TypeSymlink:
+			// The link target is not checked, because a backup can legitimately
+			// contain a symlink to an absolute path outside the tree. It is
+			// safe to create because it is never followed: a later member whose
+			// destination goes through it is refused by memberTarget, which
+			// resolves before it compares.
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("create directory for %s: %w", target, err)
+			}
+			if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("replace %s: %w", target, err)
+			}
+			if err := os.Symlink(hdr.Linkname, target); err != nil {
+				return fmt.Errorf("create symlink %s: %w", target, err)
+			}
+			if restoreOwner {
+				if err := os.Lchown(target, hdr.Uid, hdr.Gid); err != nil {
+					return fmt.Errorf("set owner on %s: %w", target, err)
+				}
+			}
+		case tar.TypeLink:
+			// A hard link names a file that already exists. Left unchecked it
+			// is a way to reach content outside the tree without ever naming a
+			// path outside it.
+			source, err := memberTarget(hdr.Linkname, destReal)
+			if err != nil {
+				return fmt.Errorf("archive %s: hard link %q: %w", archivePath, hdr.Name, err)
+			}
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return fmt.Errorf("create directory for %s: %w", target, err)
+			}
+			if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
+				return fmt.Errorf("replace %s: %w", target, err)
+			}
+			if err := os.Link(source, target); err != nil {
+				return fmt.Errorf("create hard link %s: %w", target, err)
+			}
+		default:
+			// Device nodes, FIFOs and sockets. A volume backup has no reason to
+			// carry one, creating them is privileged, and dropping them quietly
+			// would mean a restore that says it succeeded while omitting part of
+			// the archive. Naming what was found is more useful than either.
+			return fmt.Errorf("archive %s: refusing member %q of unsupported type %q",
+				archivePath, hdr.Name, string(hdr.Typeflag))
+		}
+	}
+
+	// Deepest first, so a directory made read-only cannot block the one inside it.
+	for i := len(dirs) - 1; i >= 0; i-- {
+		if err := os.Chmod(dirs[i].path, dirs[i].mode); err != nil {
+			return fmt.Errorf("set mode on %s: %w", dirs[i].path, err)
+		}
+		if err := applyMetadata(dirs[i].path, dirs[i].modTime, dirs[i].uid, dirs[i].gid, restoreOwner); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// applyMetadata restores the modification time, and the ownership when there is
+// any point in trying. Both match what tar does by default.
+func applyMetadata(target string, modTime time.Time, uid, gid int, restoreOwner bool) error {
+	if restoreOwner {
+		if err := os.Lchown(target, uid, gid); err != nil {
+			return fmt.Errorf("set owner on %s: %w", target, err)
+		}
+	}
+	if modTime.IsZero() {
+		return nil
+	}
+	if err := os.Chtimes(target, modTime, modTime); err != nil {
+		return fmt.Errorf("set times on %s: %w", target, err)
+	}
+	return nil
+}
+
+// memberTarget resolves where an archive member wants to be written and refuses
+// it unless that is inside destReal.
+//
+// Two checks, and both are needed. The name is rejected if it is absolute or
+// climbs out with "..", which is the case tar already declines. Then the parent
+// directory is resolved, because an earlier member of the same archive can have
+// been a symlink, and a name that is lexically inside the tree can still resolve
+// out of it — the same weakness that #91 found in bind-mount containment.
+func memberTarget(name, destReal string) (string, error) {
+	if name == "" {
+		return "", fmt.Errorf("refusing member with an empty name")
+	}
+	if filepath.IsAbs(name) || strings.HasPrefix(name, "/") {
+		return "", fmt.Errorf("refusing member %q: absolute path", name)
+	}
+	clean := filepath.Clean(filepath.FromSlash(name))
+	if clean == ".." || strings.HasPrefix(clean, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("refusing member %q: climbs out of the archive root", name)
+	}
+
+	target := filepath.Join(destReal, clean)
+	if target == destReal {
+		// The "./" entry tar writes for the root of the tree. Nothing is
+		// created for it, and it has no parent inside dest to resolve.
+		return target, nil
+	}
+	if !strings.HasPrefix(target, destReal+string(filepath.Separator)) {
+		return "", fmt.Errorf("refusing member %q: resolves outside the destination", name)
+	}
+
+	// Whatever exists of the parent chain is resolved; what does not exist yet
+	// is about to be created here and cannot be a link to somewhere else.
+	parent := filepath.Dir(target)
+	existing := parent
+	for {
+		if _, err := os.Lstat(existing); err == nil {
+			break
+		}
+		next := filepath.Dir(existing)
+		if next == existing {
+			break
+		}
+		existing = next
+	}
+	real, err := filepath.EvalSymlinks(existing)
+	if err != nil {
+		return "", fmt.Errorf("refusing member %q: cannot resolve %s: %w", name, existing, err)
+	}
+	if real != destReal && !strings.HasPrefix(real, destReal+string(filepath.Separator)) {
+		return "", fmt.Errorf("refusing member %q: %s resolves to %s, outside the destination", name, existing, real)
+	}
+	return target, nil
+}
+
+// writeMember writes one regular file, creating its parent directories.
+func writeMember(tr *tar.Reader, target string, mode os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return fmt.Errorf("create directory for %s: %w", target, err)
+	}
+	// O_CREATE without O_EXCL overwrites, which is what a restore means to do,
+	// but the existing entry is removed first so an existing symlink is
+	// replaced rather than written through.
+	if err := os.Remove(target); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("replace %s: %w", target, err)
+	}
+	f, err := os.OpenFile(target, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, mode)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", target, err)
+	}
+	if _, err := io.Copy(f, tr); err != nil {
+		f.Close()
+		return fmt.Errorf("write %s: %w", target, err)
+	}
+	if err := f.Close(); err != nil {
+		return fmt.Errorf("write %s: %w", target, err)
+	}
+	return os.Chmod(target, mode)
+}

--- a/internal/backup/extract_test.go
+++ b/internal/backup/extract_test.go
@@ -1,0 +1,305 @@
+package backup
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// tarMember is one entry to place in a test archive, built with archive/tar so
+// the dangerous names can be written at all — the tar binary declines to create
+// most of them, which is the point of these tests.
+type tarMember struct {
+	name     string
+	typeflag byte
+	linkname string
+	body     string
+	mode     os.FileMode
+}
+
+func writeTarGz(t *testing.T, path string, members []tarMember) {
+	t.Helper()
+
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatalf("create %s: %v", path, err)
+	}
+	defer f.Close()
+	gz := gzip.NewWriter(f)
+	tw := tar.NewWriter(gz)
+
+	for _, m := range members {
+		mode := m.mode
+		if mode == 0 {
+			mode = 0o644
+		}
+		hdr := &tar.Header{
+			Name:     m.name,
+			Typeflag: m.typeflag,
+			Linkname: m.linkname,
+			Mode:     int64(mode),
+			Size:     int64(len(m.body)),
+		}
+		if m.typeflag != tar.TypeReg {
+			hdr.Size = 0
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			t.Fatalf("write header %s: %v", m.name, err)
+		}
+		if m.typeflag == tar.TypeReg {
+			if _, err := tw.Write([]byte(m.body)); err != nil {
+				t.Fatalf("write body %s: %v", m.name, err)
+			}
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+}
+
+func TestExtractTarGz_RestoresAnOrdinaryArchive(t *testing.T) {
+	dir := t.TempDir()
+	archive := filepath.Join(dir, "a.tar.gz")
+	writeTarGz(t, archive, []tarMember{
+		{name: "./", typeflag: tar.TypeDir, mode: 0o755},
+		{name: "conf", typeflag: tar.TypeDir, mode: 0o755},
+		{name: "conf/app.yml", typeflag: tar.TypeReg, body: "key: value", mode: 0o600},
+		{name: "conf/link", typeflag: tar.TypeSymlink, linkname: "app.yml"},
+	})
+
+	dest := filepath.Join(dir, "dest")
+	if err := extractTarGz(archive, dest); err != nil {
+		t.Fatalf("extractTarGz() error = %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(dest, "conf", "app.yml"))
+	if err != nil {
+		t.Fatalf("read extracted file: %v", err)
+	}
+	if string(got) != "key: value" {
+		t.Errorf("content = %q, want %q", got, "key: value")
+	}
+	info, err := os.Stat(filepath.Join(dest, "conf", "app.yml"))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o600 {
+		t.Errorf("mode = %v, want 0600", info.Mode().Perm())
+	}
+	link, err := os.Readlink(filepath.Join(dest, "conf", "link"))
+	if err != nil || link != "app.yml" {
+		t.Errorf("symlink = %q, %v; want \"app.yml\"", link, err)
+	}
+}
+
+// tar strips a leading "/" and carries on. homebutler refuses, because an
+// archive that asked to write to an absolute path is not one whose remaining
+// members should be trusted into the same directory.
+func TestExtractTarGz_RefusesAbsoluteMemberName(t *testing.T) {
+	dir := t.TempDir()
+	archive := filepath.Join(dir, "a.tar.gz")
+	writeTarGz(t, archive, []tarMember{
+		{name: "/etc/homebutler-canary", typeflag: tar.TypeReg, body: "OWNED"},
+	})
+
+	err := extractTarGz(archive, filepath.Join(dir, "dest"))
+	if err == nil {
+		t.Fatal("extractTarGz() accepted an absolute member name")
+	}
+	if !strings.Contains(err.Error(), "absolute path") {
+		t.Errorf("error = %v, want it to name the absolute path", err)
+	}
+	if _, err := os.Stat("/etc/homebutler-canary"); err == nil {
+		t.Fatal("an absolute member was written outside the destination")
+	}
+}
+
+// The ".." climb, which is the case tar skips with a warning.
+func TestExtractTarGz_RefusesMemberClimbingOutOfTheRoot(t *testing.T) {
+	dir := t.TempDir()
+	victim := filepath.Join(dir, "victim")
+	if err := os.MkdirAll(victim, 0o755); err != nil {
+		t.Fatalf("mkdir victim: %v", err)
+	}
+	canary := filepath.Join(victim, "canary")
+	if err := os.WriteFile(canary, []byte("ORIGINAL"), 0o644); err != nil {
+		t.Fatalf("write canary: %v", err)
+	}
+
+	archive := filepath.Join(dir, "a.tar.gz")
+	writeTarGz(t, archive, []tarMember{
+		{name: "../victim/canary", typeflag: tar.TypeReg, body: "OVERWRITTEN"},
+	})
+
+	if err := extractTarGz(archive, filepath.Join(dir, "dest")); err == nil {
+		t.Fatal("extractTarGz() accepted a member climbing out of the root")
+	}
+	got, err := os.ReadFile(canary)
+	if err != nil {
+		t.Fatalf("read canary: %v", err)
+	}
+	if string(got) != "ORIGINAL" {
+		t.Errorf("canary was overwritten: %q", got)
+	}
+}
+
+// The same shape as #91, one level down: an earlier member of the archive is a
+// symlink out of the tree, and a later member is named through it. Every
+// component is relative and none contains "..", so a name check alone accepts
+// it.
+func TestExtractTarGz_RefusesMemberWrittenThroughASymlinkItPlanted(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(dir, "outside")
+	if err := os.MkdirAll(outside, 0o755); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	canary := filepath.Join(outside, "canary")
+	if err := os.WriteFile(canary, []byte("ORIGINAL"), 0o644); err != nil {
+		t.Fatalf("write canary: %v", err)
+	}
+
+	archive := filepath.Join(dir, "a.tar.gz")
+	writeTarGz(t, archive, []tarMember{
+		{name: "hop", typeflag: tar.TypeSymlink, linkname: outside},
+		{name: "hop/canary", typeflag: tar.TypeReg, body: "OVERWRITTEN"},
+	})
+
+	if err := extractTarGz(archive, filepath.Join(dir, "dest")); err == nil {
+		t.Fatal("extractTarGz() wrote through a symlink the archive planted")
+	}
+	got, err := os.ReadFile(canary)
+	if err != nil {
+		t.Fatalf("read canary: %v", err)
+	}
+	if string(got) != "ORIGINAL" {
+		t.Errorf("canary was overwritten through the planted symlink: %q", got)
+	}
+}
+
+// A hard link never names a path outside the tree, so a name check does not see
+// it. What it does is give the extracted tree a second name for a file that
+// already exists somewhere else.
+func TestExtractTarGz_RefusesHardLinkOutOfTheTree(t *testing.T) {
+	dir := t.TempDir()
+	secret := filepath.Join(dir, "secret")
+	if err := os.WriteFile(secret, []byte("SECRET"), 0o600); err != nil {
+		t.Fatalf("write secret: %v", err)
+	}
+
+	archive := filepath.Join(dir, "a.tar.gz")
+	writeTarGz(t, archive, []tarMember{
+		{name: "exposed", typeflag: tar.TypeLink, linkname: "../secret"},
+	})
+
+	dest := filepath.Join(dir, "dest")
+	if err := extractTarGz(archive, dest); err == nil {
+		t.Fatal("extractTarGz() accepted a hard link out of the tree")
+	}
+	if _, err := os.Lstat(filepath.Join(dest, "exposed")); err == nil {
+		t.Error("the hard link was created")
+	}
+}
+
+// Dropping a member quietly would mean a restore reporting success while having
+// left part of the archive on the floor.
+func TestExtractTarGz_RefusesDeviceNodesRatherThanSkippingThem(t *testing.T) {
+	dir := t.TempDir()
+	archive := filepath.Join(dir, "a.tar.gz")
+	writeTarGz(t, archive, []tarMember{
+		{name: "dev/null", typeflag: tar.TypeChar},
+	})
+
+	err := extractTarGz(archive, filepath.Join(dir, "dest"))
+	if err == nil {
+		t.Fatal("extractTarGz() accepted a character device")
+	}
+	if !strings.Contains(err.Error(), "dev/null") {
+		t.Errorf("error = %v, want it to name the member", err)
+	}
+}
+
+// A directory stored read-only must not stop its own contents being written,
+// and must still end up read-only.
+func TestExtractTarGz_AppliesDirectoryModesAfterWriting(t *testing.T) {
+	dir := t.TempDir()
+	archive := filepath.Join(dir, "a.tar.gz")
+	writeTarGz(t, archive, []tarMember{
+		{name: "locked", typeflag: tar.TypeDir, mode: 0o500},
+		{name: "locked/file", typeflag: tar.TypeReg, body: "in a read-only directory"},
+	})
+
+	dest := filepath.Join(dir, "dest")
+	if err := extractTarGz(archive, dest); err != nil {
+		t.Fatalf("extractTarGz() error = %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(filepath.Join(dest, "locked"), 0o755) })
+
+	if _, err := os.ReadFile(filepath.Join(dest, "locked", "file")); err != nil {
+		t.Fatalf("file inside the read-only directory was not written: %v", err)
+	}
+	info, err := os.Stat(filepath.Join(dest, "locked"))
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if info.Mode().Perm() != 0o500 {
+		t.Errorf("directory mode = %v, want 0500", info.Mode().Perm())
+	}
+}
+
+// A restore overwrites, and an existing symlink at the destination must be
+// replaced rather than written through.
+func TestExtractTarGz_ReplacesAnExistingSymlinkRatherThanFollowingIt(t *testing.T) {
+	dir := t.TempDir()
+	outside := filepath.Join(dir, "outside")
+	if err := os.WriteFile(outside, []byte("ORIGINAL"), 0o644); err != nil {
+		t.Fatalf("write outside: %v", err)
+	}
+	dest := filepath.Join(dir, "dest")
+	if err := os.MkdirAll(dest, 0o755); err != nil {
+		t.Fatalf("mkdir dest: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(dest, "file")); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	archive := filepath.Join(dir, "a.tar.gz")
+	writeTarGz(t, archive, []tarMember{
+		{name: "file", typeflag: tar.TypeReg, body: "RESTORED"},
+	})
+
+	if err := extractTarGz(archive, dest); err != nil {
+		t.Fatalf("extractTarGz() error = %v", err)
+	}
+	got, err := os.ReadFile(outside)
+	if err != nil {
+		t.Fatalf("read outside: %v", err)
+	}
+	if string(got) != "ORIGINAL" {
+		t.Errorf("wrote through the existing symlink: %q", got)
+	}
+	restored, err := os.ReadFile(filepath.Join(dest, "file"))
+	if err != nil || string(restored) != "RESTORED" {
+		t.Errorf("member = %q, %v; want %q", restored, err, "RESTORED")
+	}
+}
+
+// #92: one derivation, so mountHasPayload and restoreMount cannot disagree
+// about which archive a mount refers to.
+func TestMountArchivePath_IsSanitizedAndShared(t *testing.T) {
+	volDir := "/backup/volumes"
+	for _, name := range []string{"../../etc/passwd", "data", "/abs/path"} {
+		got := mountArchivePath(name, volDir)
+		if filepath.Dir(got) != volDir {
+			t.Errorf("mountArchivePath(%q) = %q, escaped %q", name, got, volDir)
+		}
+		if !strings.HasSuffix(got, ".tar.gz") {
+			t.Errorf("mountArchivePath(%q) = %q, want a .tar.gz path", name, got)
+		}
+	}
+}

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -131,8 +131,7 @@ func Restore(archivePath string, opts RestoreOptions) (*RestoreResult, error) {
 	defer os.RemoveAll(tmpDir)
 
 	// Extract archive
-	_, err = util.RunCmd("tar", "xzf", archivePath, "-C", tmpDir)
-	if err != nil {
+	if err := extractTarGz(archivePath, tmpDir); err != nil {
 		return nil, fmt.Errorf("failed to extract archive: %w", err)
 	}
 
@@ -229,9 +228,19 @@ func findExtractedDir(tmpDir string) (string, error) {
 // worth refusing: refusing them would report a permission problem where there
 // is only an empty mount.
 func mountHasPayload(m Mount, volDir string) bool {
-	archivePath := filepath.Join(volDir, sanitizeName(m.Name)+".tar.gz")
-	_, err := os.Stat(archivePath)
+	_, err := os.Stat(mountArchivePath(m.Name, volDir))
 	return err == nil
+}
+
+// mountArchivePath is where a mount's payload lives inside an extracted backup.
+//
+// It has one definition because the containment checks are only correct while
+// every caller agrees which archive a mount refers to. mountHasPayload decides
+// whether refuseMount runs at all, and restoreMount decides what to write; if
+// those two ever disagreed about the name, a mount could be cleared as empty
+// and then restored anyway.
+func mountArchivePath(name, volDir string) string {
+	return filepath.Join(volDir, sanitizeName(name)+".tar.gz")
 }
 
 // mountTarget names what a mount would write to, for reporting a refusal.
@@ -280,7 +289,7 @@ func refuseMount(m Mount, opts RestoreOptions) (Mount, string) {
 // assumes m.Name is a volume name and m.Source is an operator-permitted path.
 func restoreMount(m Mount, volDir string) error {
 	safeName := sanitizeName(m.Name)
-	archivePath := filepath.Join(volDir, safeName+".tar.gz")
+	archivePath := mountArchivePath(m.Name, volDir)
 
 	if _, err := os.Stat(archivePath); err != nil {
 		return nil // skip if archive doesn't exist (e.g., empty mount)
@@ -305,8 +314,7 @@ func restoreMount(m Mount, volDir string) error {
 			}
 			return fmt.Errorf("failed to create bind mount dir %s: %w", m.Source, err)
 		}
-		_, err := util.RunCmd("tar", "xzf", archivePath, "-C", m.Source)
-		if err != nil {
+		if err := extractTarGz(archivePath, m.Source); err != nil {
 			return fmt.Errorf("failed to restore bind mount %s: %w", m.Source, err)
 		}
 	}


### PR DESCRIPTION
Closes #87. Closes #92.

`restore` and `backup drill` shelled out to `tar xzf -C <dir>`. That was safe, but for a reason that lives outside this repository: GNU tar and bsdtar strip a leading `/` and skip members containing `..` on their own. Member names come from whoever built the archive, exactly as manifest paths do, so the destination was being held by a default in a program we invoke. Nothing here asserted it, no test covered it, and a host with a different tar — or a later move to an archive library — would have lost it with no signal.

Extraction now happens in `internal/backup/extract.go`, and refuses four things:

- an absolute member name
- a member that climbs out of the root with `..`
- a hard link naming a file outside the tree, which never spells a path outside it but hands the extracted tree a second name for one
- a member written through a symlink an earlier member of the same archive planted — #91 one level down, where every component is relative and none contains `..`, so a name check alone accepts it

**Refusing rather than skipping is the behaviour change worth arguing about.** Skipping is what tar does, and it means an archive that tried to escape still reports success having restored less than it claimed. A bind target that was never permitted stays a reported-and-skipped refusal, because that is an operator configuration answer they can act on. A member that lies about where it belongs is the archive being untrustworthy, and continuing to read from it is not the safe response. Mounts already restored before the failure stay restored.

The extractor keeps what tar was giving us, and one of those is easy to lose: `sudo homebutler restore` is documented in `docs/backup.md` for the case where the target is not writable, and tar restores ownership when it runs as root. A Go rewrite that skipped that would silently break the restores most likely to need it. Directory modes are applied last for the same reason tar makes a second pass — a directory stored `0500` must not block its own contents.

The volume branch still extracts inside an alpine container into a Docker volume and is deliberately untouched: the destination there is the volume, not a host path.

Verified end to end on Linux (aarch64), unprivileged and as root, rather than only in unit tests:

```
round trip, unprivileged  → mode=600  mtime=2020-03-04  symlink intact
                            locked dir mode=500 with its contents written
round trip, uid 0         → owner=1000:1003, not 0:0
planted symlink escape    → error: refusing member "hop/canary":
                              /tmp/evil87/dest/hop resolves to /tmp/victim87,
                              outside the destination
                            exit 1, canary = ORIGINAL
```

#92 rides along because it is the same functions: `mountHasPayload` decides whether the containment check runs at all and `restoreMount` decides what gets written, so those two agreeing about which archive a mount refers to is load-bearing. They agreed by identical code in three places, one of them in a different file.