### PR TITLE
fix: restore wrote macOS metadata sidecars into volumes as files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ All notable changes to this project will be documented in this file.
 
 - check archive member names in homebutler rather than relying on `tar` to decline them (#87). `restore` and `backup drill` extracted with `tar xzf -C <dir>`, which held the destination only because GNU tar and bsdtar strip a leading `/` and skip members containing `..` of their own accord. Nothing here asserted it and no test covered it, so a host with a different tar would have lost the property with no signal. Extraction is now done in homebutler, and a member that is absolute, that climbs out of the root, that is a hard link to a file outside the tree, or that is written through a symlink an earlier member of the same archive planted, fails the restore instead of being skipped
 
+- drop AppleDouble sidecars instead of restoring them as files. Archiving on macOS splits a file carrying extended attributes into the file plus a `._<file>` sibling, and `bsdtar` absorbs the sibling on the way back out — so taking extraction off `tar` meant those siblings started landing in restored volumes as files that were never in the source. A member is only dropped when it actually carries the AppleDouble magic, so a real file named `._notes` still restores
+
 ### ♻️ Refactoring
 
 - derive a mount's archive path in one place (#92). `mountHasPayload`, `restoreMount` and `backup drill` each rebuilt `volDir/sanitizeName(name).tar.gz` independently, and the first two agreeing is load-bearing: `mountHasPayload` decides whether the containment check runs at all, and `restoreMount` decides what gets written. They agreed by identical code rather than by construction

--- a/internal/backup/extract.go
+++ b/internal/backup/extract.go
@@ -2,6 +2,7 @@ package backup
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"fmt"
 	"io"
@@ -93,7 +94,14 @@ func extractTarGz(archivePath, dest string) error {
 			}
 			dirs = append(dirs, deferredDir{target, hdr.FileInfo().Mode().Perm(), hdr.ModTime, hdr.Uid, hdr.Gid})
 		case tar.TypeReg:
-			if err := writeMember(tr, target, hdr.FileInfo().Mode().Perm()); err != nil {
+			body, skip, err := memberBody(tr, filepath.Base(target))
+			if err != nil {
+				return fmt.Errorf("archive %s: read %q: %w", archivePath, hdr.Name, err)
+			}
+			if skip {
+				continue
+			}
+			if err := writeMember(body, target, hdr.FileInfo().Mode().Perm()); err != nil {
 				return err
 			}
 			if err := applyMetadata(target, hdr.ModTime, hdr.Uid, hdr.Gid, restoreOwner); err != nil {
@@ -229,8 +237,38 @@ func memberTarget(name, destReal string) (string, error) {
 	return target, nil
 }
 
+// appleDoubleMagic opens every AppleDouble record.
+var appleDoubleMagic = []byte{0x00, 0x05, 0x16, 0x07}
+
+// memberBody returns the member's contents, and whether to skip it entirely.
+//
+// Archiving on macOS turns a file that carries extended attributes into two
+// members: the file, and a sibling named "._<file>" holding the attributes.
+// bsdtar consumes the second one on the way back out, so it never appears as a
+// file — which is why homebutler never had to know about them while it was
+// shelling out to tar on macOS. Written literally they are junk that was not in
+// the source, and they land in restored volumes.
+//
+// The name alone is not enough to decide: a real file can be called "._notes".
+// The AppleDouble magic is, so only a member that has it is dropped.
+func memberBody(tr *tar.Reader, base string) (io.Reader, bool, error) {
+	if !strings.HasPrefix(base, "._") {
+		return tr, false, nil
+	}
+	head := make([]byte, len(appleDoubleMagic))
+	n, err := io.ReadFull(tr, head)
+	if err != nil && err != io.EOF && err != io.ErrUnexpectedEOF {
+		return nil, false, err
+	}
+	if n == len(appleDoubleMagic) && bytes.Equal(head, appleDoubleMagic) {
+		return nil, true, nil
+	}
+	// Not an AppleDouble record after all, so put back what was read to look.
+	return io.MultiReader(bytes.NewReader(head[:n]), tr), false, nil
+}
+
 // writeMember writes one regular file, creating its parent directories.
-func writeMember(tr *tar.Reader, target string, mode os.FileMode) error {
+func writeMember(tr io.Reader, target string, mode os.FileMode) error {
 	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 		return fmt.Errorf("create directory for %s: %w", target, err)
 	}

--- a/internal/backup/extract_test.go
+++ b/internal/backup/extract_test.go
@@ -303,3 +303,67 @@ func TestMountArchivePath_IsSanitizedAndShared(t *testing.T) {
 		}
 	}
 }
+
+// Archiving on macOS splits a file that carries extended attributes into the
+// file plus a sibling "._<file>" holding the attributes. bsdtar absorbs the
+// sibling on the way back out, so homebutler never saw one while it was
+// shelling out to tar. Written literally they are files that were never in the
+// source, and they end up inside restored volumes.
+func TestExtractTarGz_DropsAppleDoubleSidecars(t *testing.T) {
+	dir := t.TempDir()
+	archive := filepath.Join(dir, "a.tar.gz")
+	writeTarGz(t, archive, []tarMember{
+		{name: "app.yml", typeflag: tar.TypeReg, body: "key: value"},
+		{name: "._app.yml", typeflag: tar.TypeReg, body: "\x00\x05\x16\x07AppleDouble metadata"},
+		{name: "sub", typeflag: tar.TypeDir, mode: 0o755},
+		{name: "sub/._data", typeflag: tar.TypeReg, body: "\x00\x05\x16\x07more metadata"},
+		{name: "sub/data", typeflag: tar.TypeReg, body: "payload"},
+	})
+
+	dest := filepath.Join(dir, "dest")
+	if err := extractTarGz(archive, dest); err != nil {
+		t.Fatalf("extractTarGz() error = %v", err)
+	}
+
+	for _, gone := range []string{"._app.yml", filepath.Join("sub", "._data")} {
+		if _, err := os.Lstat(filepath.Join(dest, gone)); err == nil {
+			t.Errorf("%s was written; it was never in the source tree", gone)
+		}
+	}
+	for name, want := range map[string]string{
+		"app.yml":                    "key: value",
+		filepath.Join("sub", "data"): "payload",
+	} {
+		got, err := os.ReadFile(filepath.Join(dest, name))
+		if err != nil || string(got) != want {
+			t.Errorf("%s = %q, %v; want %q", name, got, err, want)
+		}
+	}
+}
+
+// The name is not the test — a real file can be called "._notes". Only a member
+// that actually carries the AppleDouble magic is dropped.
+func TestExtractTarGz_KeepsAFileMerelyNamedLikeASidecar(t *testing.T) {
+	dir := t.TempDir()
+	archive := filepath.Join(dir, "a.tar.gz")
+	writeTarGz(t, archive, []tarMember{
+		{name: "._notes", typeflag: tar.TypeReg, body: "these are my actual notes"},
+		{name: "._tiny", typeflag: tar.TypeReg, body: "ab"},
+		{name: "._empty", typeflag: tar.TypeReg, body: ""},
+	})
+
+	dest := filepath.Join(dir, "dest")
+	if err := extractTarGz(archive, dest); err != nil {
+		t.Fatalf("extractTarGz() error = %v", err)
+	}
+	for name, want := range map[string]string{
+		"._notes": "these are my actual notes",
+		"._tiny":  "ab",
+		"._empty": "",
+	} {
+		got, err := os.ReadFile(filepath.Join(dest, name))
+		if err != nil || string(got) != want {
+			t.Errorf("%s = %q, %v; want %q — a real file was dropped", name, got, err, want)
+		}
+	}
+}


### PR DESCRIPTION
A regression from #87, found by testing the new extractor against a real 19MB backup rather than only against archives built for the tests.

Archiving on macOS turns a file carrying extended attributes into two members: the file, and a sibling named `._<file>` holding the attributes. `bsdtar` absorbs the sibling on the way back out, so it never appears as a file — which is exactly why homebutler never had to know about them while extraction was `tar`'s job. Taking that off `tar` meant every sidecar started being written out literally, so a restored volume gained files that were never in the source.

Eight of that archive's sixteen members were sidecars. Extracting it with `tar` and with the extractor and diffing the trees is what surfaced it; nothing in the unit tests could, because every archive they build is one I wrote.

A member is dropped only when it actually carries the AppleDouble magic (`00051607`), not when its name merely looks like one — a real file called `._notes` still restores. That distinction is a test.

On Linux this is an improvement rather than a return to the previous behaviour: GNU tar does not understand AppleDouble either, so it wrote those sidecars out as well.

Verified against the real archive — the outer archive and each of its three nested volume archives, `tar` output and extractor output now diffing clean, 3, 20 and 33 files respectively.