### PR TITLE
feat: bound the backup directory, and read the backup.dir the docs documented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### ✨ Features
+
+- bound the backup directory with `backup.retention` (#102). `backup` wrote an archive on every run and nothing ever deleted one — the largest files homebutler writes, and the only ones with no limit at all, which is fine until somebody puts the command in cron. `max_archives` caps the count and `max_bytes` caps the total, because ten archives can be 200MB or 200GB and a disk guarantee is what the cron case actually wants. Both are off by default: a pruned incident costs some history, while a pruned backup can be the last copy of data that no longer exists, so this is the one store you opt into bounding. Pruning runs only after a backup is written, never after a failed one, and names each archive it removed
+- warn in `doctor` when the backup directory is large and has no retention configured. Keeping everything is only a safe default while something says when the directory has outgrown what was expected, and `doctor` checked that a backup was *recent*, which says nothing about one that has been growing since the day it was created
+
+### 🐛 Fixes
+
+- read `backup.dir`, the setting `docs/backup.md` has documented all along. The schema only ever had the top-level `backup_dir`, so a config copied out of the documentation parsed without complaint and then wrote to the home directory — an operator pointing backups at a NAS got neither the destination they asked for nor any sign they had not. Both spellings are read, and `backup_dir` keeps working
+
 ### 🔐 Security
 
 - check archive member names in homebutler rather than relying on `tar` to decline them (#87). `restore` and `backup drill` extracted with `tar xzf -C <dir>`, which held the destination only because GNU tar and bsdtar strip a leading `/` and skip members containing `..` of their own accord. Nothing here asserted it and no test covered it, so a host with a different tar would have lost the property with no signal. Extraction is now done in homebutler, and a member that is absolute, that climbs out of the root, that is a hard link to a file outside the tree, or that is written through a symlink an earlier member of the same archive planted, fails the restore instead of being skipped

--- a/cmd/backup.go
+++ b/cmd/backup.go
@@ -31,7 +31,7 @@ Use --to to specify a custom backup destination.`,
 				backupDir = cfg.ResolveBackupDir()
 			}
 
-			result, err := backup.Run(backupDir, service)
+			result, err := backup.Run(backupDir, service, cfg.ResolveBackupRetention())
 			if err != nil {
 				return err
 			}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -73,6 +73,15 @@ func output(data any, jsonOut bool) error {
 		fmt.Printf("  Services: %s\n", strings.Join(v.Services, ", "))
 		fmt.Printf("  Volumes:  %d\n", v.Volumes)
 		fmt.Printf("  Size:     %s\n", v.Size)
+		if p := v.Pruned; p != nil && len(p.Removed) > 0 {
+			// Named individually. Deleting a backup can be deleting the last
+			// copy of something, so which ones went is not a detail.
+			fmt.Printf("\n  Retention removed %d older backup(s), freeing %s:\n", len(p.Removed), backup.FormatSize(p.Freed))
+			for _, name := range p.Removed {
+				fmt.Printf("    %s\n", name)
+			}
+			fmt.Printf("  %d kept, %s total.\n", p.Kept, backup.FormatSize(p.KeptSum))
+		}
 	case *backup.RestoreResult:
 		fmt.Printf("Restore complete from: %s\n", v.Archive)
 		fmt.Printf("  Services: %s\n", strings.Join(v.Services, ", "))

--- a/docs/backup.md
+++ b/docs/backup.md
@@ -150,9 +150,35 @@ Set a custom backup directory in your `homebutler.yml`:
 ```yaml
 backup:
   dir: /mnt/nas/backups/homebutler
+  retention:
+    max_archives: 7      # keep the 7 newest
+    max_bytes: 20GB      # and no more than 20GB in total
 ```
 
 Default location: `~/.homebutler/backups/`
+
+`backup_dir:` at the top level is the older spelling and still works. A file
+carrying both gets `backup.dir`.
+
+### Nothing is deleted unless you ask
+
+Both retention limits are off by default, which is the opposite of every other
+store homebutler keeps. Incidents and snapshots are bounded out of the box
+because a pruned incident costs some history. A pruned backup can be the only
+remaining copy of data that no longer exists anywhere else, and that is not a
+default anyone chose.
+
+So retention is opt-in, and two things follow from that:
+
+- Pruning runs after a backup is written, never before and never after a failed
+  one, and it names each archive it removed. Deleting a backup is not a detail.
+- The newest archive is never removed, whatever the limits say — including when
+  it exceeds `max_bytes` on its own. A limit that empties the directory has
+  misunderstood what it was asked to bound.
+
+Because the default never deletes, `homebutler doctor` says when the directory
+has grown large and has no limit on it. That warning is how the safe default
+stays safe.
 
 ## Scheduled Backups
 

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -40,6 +40,10 @@ type BackupResult struct {
 	Services []string `json:"services"`
 	Volumes  int      `json:"volumes"`
 	Size     string   `json:"size"`
+
+	// Pruned is what retention removed after this backup was written, and is
+	// absent when retention is not configured — which is the default.
+	Pruned *PruneResult `json:"pruned,omitempty"`
 }
 
 // ListEntry represents a single backup in the list.
@@ -58,7 +62,11 @@ type ComposeProject struct {
 }
 
 // Run performs a backup of all (or filtered) Docker services.
-func Run(backupDir, service string) (*BackupResult, error) {
+//
+// Retention is applied after the archive is written and only if writing it
+// succeeded. Pruning before, or on the way out of a failure, would delete
+// history to make room for a backup that does not exist.
+func Run(backupDir, service string, retention RetentionConfig) (*BackupResult, error) {
 	projects, err := listComposeProjects()
 	if err != nil {
 		return nil, fmt.Errorf("failed to list compose projects: %w", err)
@@ -152,7 +160,7 @@ func Run(backupDir, service string) (*BackupResult, error) {
 	info, err := os.Stat(archivePath)
 	size := "unknown"
 	if err == nil {
-		size = formatSize(info.Size())
+		size = FormatSize(info.Size())
 	}
 
 	svcNames := make([]string, len(allServices))
@@ -160,12 +168,24 @@ func Run(backupDir, service string) (*BackupResult, error) {
 		svcNames[i] = s.Name
 	}
 
-	return &BackupResult{
+	result := &BackupResult{
 		Archive:  archivePath,
 		Services: svcNames,
 		Volumes:  volumeCount,
 		Size:     size,
-	}, nil
+	}
+
+	if !retention.IsZero() {
+		pruned, err := Prune(backupDir, retention)
+		if err != nil {
+			// The backup itself is on disk and valid. Failing the command now
+			// would report a backup that succeeded as a failure, so the
+			// retention problem is surfaced without discarding the result.
+			return result, fmt.Errorf("backup written to %s, but retention failed: %w", archivePath, err)
+		}
+		result.Pruned = pruned
+	}
+	return result, nil
 }
 
 // List returns all backups in the backup directory.
@@ -190,7 +210,7 @@ func List(backupDir string) ([]ListEntry, error) {
 		backups = append(backups, ListEntry{
 			Name:      e.Name(),
 			Path:      filepath.Join(backupDir, e.Name()),
-			Size:      formatSize(info.Size()),
+			Size:      FormatSize(info.Size()),
 			CreatedAt: info.ModTime().Format(time.RFC3339),
 		})
 	}
@@ -381,8 +401,8 @@ func sanitizeName(name string) string {
 	return s
 }
 
-// formatSize formats bytes into human-readable format.
-func formatSize(bytes int64) string {
+// FormatSize renders a byte count the way homebutler shows sizes.
+func FormatSize(bytes int64) string {
 	const (
 		KB = 1024
 		MB = KB * 1024

--- a/internal/backup/backup_test.go
+++ b/internal/backup/backup_test.go
@@ -42,9 +42,9 @@ func TestFormatSize(t *testing.T) {
 		{2684354560, "2.5 GB"},
 	}
 	for _, tt := range tests {
-		got := formatSize(tt.bytes)
+		got := FormatSize(tt.bytes)
 		if got != tt.want {
-			t.Errorf("formatSize(%d) = %q, want %q", tt.bytes, got, tt.want)
+			t.Errorf("FormatSize(%d) = %q, want %q", tt.bytes, got, tt.want)
 		}
 	}
 }

--- a/internal/backup/drill.go
+++ b/internal/backup/drill.go
@@ -77,7 +77,7 @@ func RunDrill(appName string, opts DrillOptions) (result *DrillResult, err error
 	}()
 
 	if info, statErr := os.Stat(archivePath); statErr == nil {
-		result.Size = formatSize(info.Size())
+		result.Size = FormatSize(info.Size())
 	}
 
 	// Stage 1 & 2: Verify archive integrity

--- a/internal/backup/drill_test.go
+++ b/internal/backup/drill_test.go
@@ -935,9 +935,9 @@ func TestFormatSizeEdgeCases(t *testing.T) {
 		{1048577, "1.0 MB"},
 	}
 	for _, tt := range tests {
-		got := formatSize(tt.bytes)
+		got := FormatSize(tt.bytes)
 		if got != tt.want {
-			t.Errorf("formatSize(%d) = %q, want %q", tt.bytes, got, tt.want)
+			t.Errorf("FormatSize(%d) = %q, want %q", tt.bytes, got, tt.want)
 		}
 	}
 }

--- a/internal/backup/retention.go
+++ b/internal/backup/retention.go
@@ -1,0 +1,204 @@
+package backup
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+// RetentionConfig bounds how much backup history is kept on disk.
+//
+// Both limits default to unlimited, which is the opposite of the incident
+// directory and is deliberate. A pruned incident costs some history; a pruned
+// backup can be the only remaining copy of data that no longer exists anywhere
+// else. Deleting that is not a default anyone chose, so retention is something
+// an operator turns on. What homebutler does without being asked is report the
+// size, through `doctor`.
+type RetentionConfig struct {
+	// MaxArchives is how many archives to keep, newest first. Zero, the
+	// default, keeps every archive.
+	MaxArchives int `yaml:"max_archives,omitempty" json:"max_archives"`
+
+	// MaxBytes caps the total size of the directory, as a size with a unit —
+	// "500MB", "20GB". Empty, the default, means no cap.
+	//
+	// Count alone is not a disk guarantee, and a disk guarantee is what someone
+	// running backup from cron actually wants: ten archives can be 200MB or
+	// 200GB depending on what was running when they were taken.
+	MaxBytes string `yaml:"max_bytes,omitempty" json:"max_bytes"`
+}
+
+// IsZero reports whether retention is unconfigured, so callers can skip the
+// work and say nothing rather than reporting a prune that removed nothing.
+func (r RetentionConfig) IsZero() bool {
+	return r.MaxArchives <= 0 && strings.TrimSpace(r.MaxBytes) == ""
+}
+
+// PruneResult describes what a prune removed.
+type PruneResult struct {
+	Removed []string `json:"removed,omitempty"`
+	Freed   int64    `json:"freed_bytes,omitempty"`
+	Kept    int      `json:"kept"`
+	KeptSum int64    `json:"kept_bytes"`
+}
+
+// ParseByteSize reads a size written the way an operator writes one.
+//
+// Both conventions are accepted for the same reason `df` and every dashboard
+// disagree about them: "20GB" and "20GiB" both mean what the person typing
+// meant, and refusing one of them teaches nothing.
+func ParseByteSize(s string) (int64, error) {
+	trimmed := strings.TrimSpace(s)
+	if trimmed == "" {
+		return 0, nil
+	}
+	upper := strings.ToUpper(strings.ReplaceAll(trimmed, " ", ""))
+
+	units := []struct {
+		suffix string
+		mult   int64
+	}{
+		{"TIB", 1 << 40}, {"GIB", 1 << 30}, {"MIB", 1 << 20}, {"KIB", 1 << 10},
+		{"TB", 1 << 40}, {"GB", 1 << 30}, {"MB", 1 << 20}, {"KB", 1 << 10},
+		{"T", 1 << 40}, {"G", 1 << 30}, {"M", 1 << 20}, {"K", 1 << 10},
+		{"B", 1},
+	}
+	for _, u := range units {
+		if !strings.HasSuffix(upper, u.suffix) {
+			continue
+		}
+		num := strings.TrimSuffix(upper, u.suffix)
+		val, err := strconv.ParseFloat(num, 64)
+		if err != nil {
+			return 0, fmt.Errorf("invalid size %q", s)
+		}
+		if val < 0 {
+			return 0, fmt.Errorf("invalid size %q: negative", s)
+		}
+		return int64(val * float64(u.mult)), nil
+	}
+
+	val, err := strconv.ParseInt(upper, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid size %q: want a number and a unit, like \"20GB\"", s)
+	}
+	if val < 0 {
+		return 0, fmt.Errorf("invalid size %q: negative", s)
+	}
+	return val, nil
+}
+
+// archiveFile is one archive on disk, with the size and time prune needs.
+type archiveFile struct {
+	path    string
+	name    string
+	size    int64
+	modTime int64
+}
+
+// listArchiveFiles returns the archives in dir, newest first.
+func listArchiveFiles(dir string) ([]archiveFile, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var files []archiveFile
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), ".tar.gz") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		files = append(files, archiveFile{
+			path:    filepath.Join(dir, e.Name()),
+			name:    e.Name(),
+			size:    info.Size(),
+			modTime: info.ModTime().UnixNano(),
+		})
+	}
+	sort.Slice(files, func(i, j int) bool { return files[i].modTime > files[j].modTime })
+	return files, nil
+}
+
+// DirUsage reports how many archives dir holds and what they total.
+//
+// This is the half of the picture `doctor` was missing: it already checks that
+// a backup is recent, which says nothing about whether the directory has been
+// growing without a bound since the day it was created.
+func DirUsage(dir string) (count int, total int64, err error) {
+	files, err := listArchiveFiles(dir)
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, f := range files {
+		total += f.size
+	}
+	return len(files), total, nil
+}
+
+// Prune deletes the oldest archives until dir is inside cfg.
+//
+// The newest archive is never deleted, whatever the limits say — including when
+// it exceeds MaxBytes by itself. A limit that empties the directory has
+// misunderstood what it was asked to bound, and the operator is left with
+// nothing to restore from.
+func Prune(dir string, cfg RetentionConfig) (*PruneResult, error) {
+	maxBytes, err := ParseByteSize(cfg.MaxBytes)
+	if err != nil {
+		return nil, err
+	}
+
+	files, err := listArchiveFiles(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read backup directory: %w", err)
+	}
+	result := &PruneResult{}
+	if len(files) == 0 {
+		return result, nil
+	}
+
+	// Newest first, so the walk keeps what it should and everything after the
+	// point a limit is reached is what goes.
+	keepUntil := len(files)
+	if cfg.MaxArchives > 0 && cfg.MaxArchives < keepUntil {
+		keepUntil = cfg.MaxArchives
+	}
+	if maxBytes > 0 {
+		var running int64
+		for i := 0; i < keepUntil; i++ {
+			running += files[i].size
+			if running > maxBytes {
+				// The newest archive is kept even when it alone is over.
+				keepUntil = i
+				if keepUntil == 0 {
+					keepUntil = 1
+				}
+				break
+			}
+		}
+	}
+	if keepUntil < 1 {
+		keepUntil = 1
+	}
+
+	for _, f := range files[keepUntil:] {
+		if err := os.Remove(f.path); err != nil {
+			return nil, fmt.Errorf("remove old backup %s: %w", f.name, err)
+		}
+		result.Removed = append(result.Removed, f.name)
+		result.Freed += f.size
+	}
+	for _, f := range files[:keepUntil] {
+		result.KeptSum += f.size
+	}
+	result.Kept = keepUntil
+	return result, nil
+}

--- a/internal/backup/retention_test.go
+++ b/internal/backup/retention_test.go
@@ -1,0 +1,220 @@
+package backup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// writeArchives creates n archives, oldest first, each of the given size.
+func writeArchives(t *testing.T, dir string, sizes []int) []string {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	base := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	var names []string
+	for i, size := range sizes {
+		name := filepath.Join(dir, "backup_"+string(rune('a'+i))+".tar.gz")
+		if err := os.WriteFile(name, make([]byte, size), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+		stamp := base.Add(time.Duration(i) * time.Hour)
+		if err := os.Chtimes(name, stamp, stamp); err != nil {
+			t.Fatalf("chtimes: %v", err)
+		}
+		names = append(names, filepath.Base(name))
+	}
+	return names
+}
+
+func remaining(t *testing.T, dir string) []string {
+	t.Helper()
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	var out []string
+	for _, e := range entries {
+		out = append(out, e.Name())
+	}
+	return out
+}
+
+func TestParseByteSize(t *testing.T) {
+	cases := map[string]int64{
+		"":      0,
+		"1024":  1024,
+		"1KB":   1 << 10,
+		"20GB":  20 << 30,
+		"20 GB": 20 << 30,
+		"20gb":  20 << 30,
+		"1.5GB": 1610612736,
+		"2TiB":  2 << 40,
+		"500MB": 500 << 20,
+		"7G":    7 << 30,
+	}
+	for in, want := range cases {
+		got, err := ParseByteSize(in)
+		if err != nil {
+			t.Errorf("ParseByteSize(%q) error = %v", in, err)
+			continue
+		}
+		if got != want {
+			t.Errorf("ParseByteSize(%q) = %d, want %d", in, got, want)
+		}
+	}
+	for _, bad := range []string{"twenty", "20 gigs", "-5GB", "GB"} {
+		if _, err := ParseByteSize(bad); err == nil {
+			t.Errorf("ParseByteSize(%q) accepted a value it cannot mean", bad)
+		}
+	}
+}
+
+// The default is that nothing is ever deleted. A backup can be the last copy of
+// something, so retention is opted into rather than out of.
+func TestPrune_UnconfiguredKeepsEverything(t *testing.T) {
+	dir := t.TempDir()
+	writeArchives(t, dir, []int{100, 100, 100, 100, 100})
+
+	cfg := RetentionConfig{}
+	if !cfg.IsZero() {
+		t.Fatal("an empty RetentionConfig should read as unconfigured")
+	}
+	res, err := Prune(dir, cfg)
+	if err != nil {
+		t.Fatalf("Prune() error = %v", err)
+	}
+	if len(res.Removed) != 0 {
+		t.Errorf("removed %v with no policy configured", res.Removed)
+	}
+	if got := len(remaining(t, dir)); got != 5 {
+		t.Errorf("%d archives left, want 5", got)
+	}
+}
+
+func TestPrune_ByCountKeepsTheNewest(t *testing.T) {
+	dir := t.TempDir()
+	names := writeArchives(t, dir, []int{10, 10, 10, 10, 10})
+
+	res, err := Prune(dir, RetentionConfig{MaxArchives: 2})
+	if err != nil {
+		t.Fatalf("Prune() error = %v", err)
+	}
+	left := remaining(t, dir)
+	if len(left) != 2 {
+		t.Fatalf("%d archives left, want 2: %v", len(left), left)
+	}
+	// The two newest are the last two written.
+	for _, want := range names[3:] {
+		found := false
+		for _, l := range left {
+			if l == want {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("%s should have been kept; left = %v", want, left)
+		}
+	}
+	if res.Kept != 2 || len(res.Removed) != 3 {
+		t.Errorf("result = %+v, want 2 kept and 3 removed", res)
+	}
+}
+
+func TestPrune_ByTotalSize(t *testing.T) {
+	dir := t.TempDir()
+	writeArchives(t, dir, []int{1000, 1000, 1000, 1000})
+
+	// Room for two, not three.
+	res, err := Prune(dir, RetentionConfig{MaxBytes: "2500"})
+	if err != nil {
+		t.Fatalf("Prune() error = %v", err)
+	}
+	if res.Kept != 2 {
+		t.Errorf("kept %d, want 2", res.Kept)
+	}
+	if res.KeptSum > 2500 {
+		t.Errorf("kept %d bytes, over the 2500 limit", res.KeptSum)
+	}
+	if res.Freed != 2000 {
+		t.Errorf("freed %d, want 2000", res.Freed)
+	}
+}
+
+// A limit smaller than a single archive must not empty the directory. Whatever
+// the operator meant by it, they did not mean "leave me nothing to restore".
+func TestPrune_NeverDeletesTheNewestArchive(t *testing.T) {
+	dir := t.TempDir()
+	writeArchives(t, dir, []int{5000, 5000, 9999})
+
+	res, err := Prune(dir, RetentionConfig{MaxBytes: "1KB"})
+	if err != nil {
+		t.Fatalf("Prune() error = %v", err)
+	}
+	left := remaining(t, dir)
+	if len(left) != 1 {
+		t.Fatalf("%d archives left, want exactly 1: %v", len(left), left)
+	}
+	if res.Kept != 1 {
+		t.Errorf("kept = %d, want 1", res.Kept)
+	}
+	// And it is the newest one, not whichever happened to fit.
+	if left[0] != "backup_c.tar.gz" {
+		t.Errorf("kept %s, want the newest archive", left[0])
+	}
+}
+
+func TestPrune_CountAndSizeTogetherTakeTheStricter(t *testing.T) {
+	dir := t.TempDir()
+	writeArchives(t, dir, []int{1000, 1000, 1000, 1000, 1000})
+
+	res, err := Prune(dir, RetentionConfig{MaxArchives: 4, MaxBytes: "2000"})
+	if err != nil {
+		t.Fatalf("Prune() error = %v", err)
+	}
+	if res.Kept != 2 {
+		t.Errorf("kept %d, want 2 — the size limit is stricter than the count", res.Kept)
+	}
+}
+
+// Retention must not touch anything it did not create.
+func TestPrune_IgnoresFilesThatAreNotArchives(t *testing.T) {
+	dir := t.TempDir()
+	writeArchives(t, dir, []int{10, 10, 10})
+	other := filepath.Join(dir, "notes.txt")
+	if err := os.WriteFile(other, []byte("keep me"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	if _, err := Prune(dir, RetentionConfig{MaxArchives: 1}); err != nil {
+		t.Fatalf("Prune() error = %v", err)
+	}
+	if _, err := os.Stat(other); err != nil {
+		t.Errorf("a file that is not a backup was removed: %v", err)
+	}
+}
+
+func TestPrune_RejectsAnUnparseableSize(t *testing.T) {
+	if _, err := Prune(t.TempDir(), RetentionConfig{MaxBytes: "twenty gigs"}); err == nil {
+		t.Error("Prune() accepted a size it cannot mean")
+	}
+}
+
+func TestDirUsage(t *testing.T) {
+	dir := t.TempDir()
+	writeArchives(t, dir, []int{100, 250})
+	count, total, err := DirUsage(dir)
+	if err != nil {
+		t.Fatalf("DirUsage() error = %v", err)
+	}
+	if count != 2 || total != 350 {
+		t.Errorf("DirUsage() = %d, %d; want 2, 350", count, total)
+	}
+
+	missing, sum, err := DirUsage(filepath.Join(dir, "nope"))
+	if err != nil || missing != 0 || sum != 0 {
+		t.Errorf("a missing directory should read as empty, got %d, %d, %v", missing, sum, err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Higangssh/homebutler/internal/backup"
 	"github.com/Higangssh/homebutler/internal/notify"
 	"github.com/Higangssh/homebutler/internal/watch"
 	"gopkg.in/yaml.v3"
@@ -21,6 +22,7 @@ type Config struct {
 	Alerts    AlertConfig           `yaml:"alerts"`
 	Notify    notify.ProviderConfig `yaml:"notify,omitempty"`
 	Watch     WatchRuntimeConfig    `yaml:"watch,omitempty"`
+	Backup    BackupConfig          `yaml:"backup,omitempty"`
 	BackupDir string                `yaml:"backup_dir,omitempty"`
 }
 
@@ -106,8 +108,33 @@ func hasMappingKey(node *yaml.Node, key string) bool {
 	return false
 }
 
+// BackupConfig groups everything about where backups go and how many are kept.
+//
+// `backup: dir:` is the spelling docs/backup.md has documented all along, and
+// the schema only ever had the top-level `backup_dir`. A config copied from the
+// documentation parsed without complaint and then wrote to the home directory,
+// so an operator pointing backups at a NAS got neither the destination they
+// asked for nor any indication they had not. Both spellings are read; the
+// nested one wins.
+type BackupConfig struct {
+	Dir       string                 `yaml:"dir,omitempty"`
+	Retention backup.RetentionConfig `yaml:"retention,omitempty"`
+}
+
+// ResolveBackupRetention returns the configured retention policy, which is
+// unlimited unless the operator asked for something narrower.
+func (c *Config) ResolveBackupRetention() backup.RetentionConfig {
+	if c == nil {
+		return backup.RetentionConfig{}
+	}
+	return c.Backup.Retention
+}
+
 // ResolveBackupDir returns the backup directory from config or the default ~/.homebutler/backups/.
 func (c *Config) ResolveBackupDir() string {
+	if c.Backup.Dir != "" {
+		return c.Backup.Dir
+	}
 	if c.BackupDir != "" {
 		return c.BackupDir
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"gopkg.in/yaml.v3"
 )
 
 func TestLoadDefaults(t *testing.T) {
@@ -663,5 +665,50 @@ watch:
 	// PruneIncidents understands.
 	if cfg.Watch.Retention.MaxIncidents != 0 {
 		t.Errorf("max_incidents = %d, want 0 (unlimited)", cfg.Watch.Retention.MaxIncidents)
+	}
+}
+
+// docs/backup.md has documented `backup: dir:` all along while the schema only
+// had the top-level `backup_dir`, so a config copied from the documentation
+// parsed without complaint and then wrote to the home directory. Someone
+// pointing backups at a NAS got neither the destination nor any sign of it.
+func TestResolveBackupDir_ReadsBothSpellings(t *testing.T) {
+	nested := &Config{Backup: BackupConfig{Dir: "/mnt/nas/backups"}}
+	if got := nested.ResolveBackupDir(); got != "/mnt/nas/backups" {
+		t.Errorf("backup.dir = %q, want /mnt/nas/backups — the documented spelling is ignored", got)
+	}
+
+	flat := &Config{BackupDir: "/srv/backups"}
+	if got := flat.ResolveBackupDir(); got != "/srv/backups" {
+		t.Errorf("backup_dir = %q, want /srv/backups", got)
+	}
+
+	// A file carrying both gets the nested one; the flat key is compatibility.
+	both := &Config{Backup: BackupConfig{Dir: "/mnt/nas"}, BackupDir: "/srv/old"}
+	if got := both.ResolveBackupDir(); got != "/mnt/nas" {
+		t.Errorf("with both set, got %q, want the nested /mnt/nas", got)
+	}
+
+	empty := &Config{}
+	if got := empty.ResolveBackupDir(); got == "" {
+		t.Error("an unconfigured backup dir should still resolve to the default")
+	}
+}
+
+func TestParseBackupBlockFromYAML(t *testing.T) {
+	var cfg Config
+	data := []byte("backup:\n  dir: /mnt/nas/backups\n  retention:\n    max_archives: 7\n    max_bytes: 20GB\n")
+	if err := yaml.Unmarshal(data, &cfg); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if cfg.ResolveBackupDir() != "/mnt/nas/backups" {
+		t.Errorf("dir = %q", cfg.ResolveBackupDir())
+	}
+	ret := cfg.ResolveBackupRetention()
+	if ret.MaxArchives != 7 || ret.MaxBytes != "20GB" {
+		t.Errorf("retention = %+v, want 7 / 20GB", ret)
+	}
+	if ret.IsZero() {
+		t.Error("a configured retention should not read as unconfigured")
 	}
 }

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Higangssh/homebutler/internal/backup"
 	"gopkg.in/yaml.v3"
 )
 
@@ -79,7 +80,7 @@ func (r *ValidationResult) add(severity, field, message, hint string) {
 }
 
 // topLevelKeys mirrors the yaml tags on Config, in the order they are reported.
-var topLevelKeys = []string{"servers", "proxmox", "wake", "alerts", "notify", "watch", "backup_dir"}
+var topLevelKeys = []string{"servers", "proxmox", "wake", "alerts", "notify", "watch", "backup", "backup_dir"}
 
 // Validate resolves the config the same way every other command does, then
 // reports what it found without applying it. It never contacts a remote
@@ -406,11 +407,11 @@ func sectionSummary(name string, present bool, cfg *Config) string {
 		}
 		return s
 
-	case "backup_dir":
-		if cfg.BackupDir == "" {
+	case "backup", "backup_dir":
+		if cfg.Backup.Dir == "" && cfg.BackupDir == "" {
 			return cfg.ResolveBackupDir() + " (default)"
 		}
-		return cfg.BackupDir
+		return cfg.ResolveBackupDir()
 	}
 	return ""
 }
@@ -650,17 +651,39 @@ func (r *ValidationResult) checkWatch(cfg *Config) {
 }
 
 func (r *ValidationResult) checkBackupDir(cfg *Config) {
-	if cfg.BackupDir == "" {
+	r.checkBackupRetention(cfg)
+
+	configured := cfg.Backup.Dir
+	if configured == "" {
+		configured = cfg.BackupDir
+	}
+	if configured == "" {
 		return
 	}
-	dir := expandHome(cfg.BackupDir)
+	dir := expandHome(configured)
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		parent := filepath.Dir(dir)
 		if _, err := os.Stat(parent); os.IsNotExist(err) {
 			r.add(SeverityWarning, "backup_dir",
-				fmt.Sprintf("Neither %s nor its parent exists.", cfg.BackupDir),
+				fmt.Sprintf("Neither %s nor its parent exists.", configured),
 				"Backups will fail until the parent directory is created.")
 		}
+	}
+}
+
+// checkBackupRetention catches a size that will not parse, here rather than at
+// the end of the first backup that tries to apply it.
+func (r *ValidationResult) checkBackupRetention(cfg *Config) {
+	ret := cfg.Backup.Retention
+	if ret.MaxArchives < 0 {
+		r.add(SeverityWarning, "backup",
+			fmt.Sprintf("backup.retention.max_archives is %d.", ret.MaxArchives),
+			"Use 0, or leave it out, to keep every backup. A negative value is not a way to say unlimited here.")
+	}
+	if _, err := backup.ParseByteSize(ret.MaxBytes); err != nil {
+		r.add(SeverityError, "backup",
+			fmt.Sprintf("backup.retention.max_bytes: %v.", err),
+			"Write a number and a unit, like 20GB or 500MB. Retention will not run until this parses.")
 	}
 }
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -51,8 +51,13 @@ type Summary struct {
 // Options controls doctor behavior.
 type Options struct {
 	BackupMaxAge time.Duration
-	Strict       bool
-	Now          time.Time
+
+	// BackupMaxTotal is the size at which an unbounded backup directory is
+	// worth mentioning. Zero takes the default.
+	BackupMaxTotal int64
+
+	Strict bool
+	Now    time.Time
 }
 
 // CollectFuncs allows tests to inject data sources.
@@ -224,6 +229,57 @@ func checkBackups(r *Result, cfg *config.Config, listFn func(string) ([]backup.L
 	if age > opts.BackupMaxAge {
 		r.add(SeverityWarn, "backup", "Latest backup is older than expected", fmt.Sprintf("Latest backup is %s old; expected within %s.", roundDuration(age), roundDuration(opts.BackupMaxAge)), "Run a fresh backup. If this app matters, follow up with a backup drill.", "homebutler backup")
 	}
+
+	checkBackupSize(r, cfg, backupDir, len(entries), opts)
+}
+
+// checkBackupSize warns when the backup directory has no bound and has grown.
+//
+// Retention defaults to keeping everything, because a pruned backup can be the
+// last copy of data that no longer exists. That default is only defensible if
+// something says when the directory has outgrown what the operator expected,
+// and nothing did: doctor checked that a backup was recent, which says nothing
+// about a directory that has been growing since the day it was created.
+//
+// Nothing is reported while retention is configured, or while the directory is
+// small. doctor's findings are things to look at, and a bounded directory is
+// not one.
+func checkBackupSize(r *Result, cfg *config.Config, backupDir string, count int, opts Options) {
+	if cfg != nil && !cfg.ResolveBackupRetention().IsZero() {
+		return
+	}
+	_, total, err := backup.DirUsage(backupDir)
+	if err != nil {
+		return
+	}
+	warnAt := opts.BackupMaxTotal
+	if warnAt <= 0 {
+		warnAt = defaultBackupWarnBytes
+	}
+	if total < warnAt {
+		return
+	}
+	r.add(SeverityWarn, "backup", "Backups have no retention limit and the directory is large",
+		fmt.Sprintf("%d archive(s) in %s, %s in total, and nothing will ever remove one.", count, backupDir, formatBytes(total)),
+		"Set backup.retention.max_bytes or max_archives. homebutler keeps every backup by default, because one of them may be the last copy of something.",
+		"homebutler backup list")
+}
+
+// defaultBackupWarnBytes is where an unbounded backup directory stops being
+// something nobody needs to think about.
+const defaultBackupWarnBytes = 20 << 30 // 20GB
+
+func formatBytes(b int64) string {
+	const unit = 1024
+	if b < unit {
+		return fmt.Sprintf("%d B", b)
+	}
+	div, exp := int64(unit), 0
+	for n := b / unit; n >= unit && exp < 3; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGT"[exp])
 }
 
 func checkNotifications(r *Result, cfg *config.Config) {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -2,6 +2,7 @@ package doctor
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -202,4 +203,65 @@ func findTitle(findings []Finding, title string) *Finding {
 		}
 	}
 	return nil
+}
+
+func seedBackupDir(t *testing.T, sizes []int) string {
+	t.Helper()
+	dir := t.TempDir()
+	for i, size := range sizes {
+		name := filepath.Join(dir, fmt.Sprintf("backup_%d.tar.gz", i))
+		if err := os.WriteFile(name, make([]byte, size), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+	return dir
+}
+
+func hasFinding(r *Result, title string) bool {
+	for _, f := range r.Findings {
+		if f.Title == title {
+			return true
+		}
+	}
+	return false
+}
+
+const unboundedTitle = "Backups have no retention limit and the directory is large"
+
+// The default keeps every backup, so something has to say when the directory
+// has outgrown what the operator expected. Nothing did before this.
+func TestCheckBackupSize_WarnsWhenUnboundedAndLarge(t *testing.T) {
+	dir := seedBackupDir(t, []int{4000, 4000, 4000})
+	r := &Result{}
+	checkBackupSize(r, &config.Config{}, dir, 3, Options{BackupMaxTotal: 10000})
+
+	if !hasFinding(r, unboundedTitle) {
+		t.Fatalf("no warning for an unbounded directory over the threshold: %+v", r.Findings)
+	}
+}
+
+// A directory nobody needs to think about is not a finding.
+func TestCheckBackupSize_SaysNothingWhenSmall(t *testing.T) {
+	dir := seedBackupDir(t, []int{10, 10})
+	r := &Result{}
+	checkBackupSize(r, &config.Config{}, dir, 2, Options{BackupMaxTotal: 10000})
+
+	if len(r.Findings) != 0 {
+		t.Errorf("a small directory produced findings: %+v", r.Findings)
+	}
+}
+
+// Once retention is configured the size is the operator's decision, and doctor
+// repeating it back is noise.
+func TestCheckBackupSize_SilentOnceRetentionIsConfigured(t *testing.T) {
+	dir := seedBackupDir(t, []int{4000, 4000, 4000})
+	cfg := &config.Config{Backup: config.BackupConfig{
+		Retention: backup.RetentionConfig{MaxArchives: 5},
+	}}
+	r := &Result{}
+	checkBackupSize(r, cfg, dir, 3, Options{BackupMaxTotal: 10000})
+
+	if len(r.Findings) != 0 {
+		t.Errorf("warned about a directory the operator has already bounded: %+v", r.Findings)
+	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -433,7 +433,7 @@ func (s *Server) executeTool(name string, args map[string]any) (any, error) {
 		if backupDir == "" {
 			backupDir = s.cfg.ResolveBackupDir()
 		}
-		return backup.Run(backupDir, stringArg(args, "service"))
+		return backup.Run(backupDir, stringArg(args, "service"), s.cfg.ResolveBackupRetention())
 	case "backup_list":
 		return backup.List(s.cfg.ResolveBackupDir())
 	case "backup_drill":


### PR DESCRIPTION
Closes #102.

`backup` wrote an archive on every run and nothing ever deleted one. These are the largest files homebutler writes and they were the only ones with no bound at all — `watch/incidents/` is capped at 200, `reports/snapshots/` at 30, `alerts-history.json` at 500 entries, and the service log at 4MB. It does not matter while somebody types the command; it starts mattering the moment they put it in cron, which is the obvious thing to do with a backup command.

```yaml
backup:
  dir: /mnt/nas/backups/homebutler
  retention:
    max_archives: 7
    max_bytes: 20GB
```

**Both limits default to off, and that is the decision worth arguing about.** It is the opposite of every other store here. A pruned incident costs some history; a pruned backup can be the last remaining copy of data that no longer exists anywhere else, and deleting that is not a default anyone chose. So this is the one store you opt into bounding.

Two things follow from that default, and they are the parts I would review:

- **The newest archive is never removed**, whatever the limits say, including when it exceeds `max_bytes` on its own. A limit that empties the directory has misunderstood what it was asked to bound, and it leaves the operator nothing to restore from.
- **Because nothing is deleted by default, `doctor` has to say when the directory has grown and has no limit on it.** `doctor` already checked that a backup was *recent*, which says nothing about a directory growing since the day it was created. That warning is what makes the safe default safe rather than merely quiet.

Count and bytes are both there because count alone is not a disk guarantee, and a disk guarantee is what the cron case wants — ten archives can be 200MB or 200GB depending on what was running. Pruning runs after the archive is written and only if writing succeeded; if pruning then fails, the backup is still reported, because it is on disk and valid and calling it a failure would be the wrong answer. Each removed archive is named in the output.

Drill status deliberately does not influence retention. `backup drill` persists nothing, so there is no record to reason from, and tying keep-decisions to verification would mean un-drilled archives are kept forever — a policy that stops bounding anything is worse than no policy.

**Also fixes a documented setting that never worked.** `docs/backup.md` has shown `backup: dir:` all along while the schema only had the top-level `backup_dir`, so a config copied out of the documentation parsed without complaint and then wrote to the home directory — an operator pointing backups at a NAS got neither the destination they asked for nor any sign they had not. Both spellings are read, nested wins, `backup_dir` keeps working. Same shape and same reason as the `watch:` compatibility path from #31.

Verified on Linux against real archives rather than only in unit tests:

```
max_archives: 3   → removed 3 oldest by name, 3 kept, 391.4 KB total
max_bytes: 300KB  → removed 1 more, 2 kept, 196.1 KB total
max_bytes: 1KB    → 1 kept — the newest survives a limit smaller than itself
config validate   → ✓ backup  /tmp/ret/backups
```

Unrelated, found while testing this and worth its own issue: the archive name is minute-resolution, so two backups inside the same minute write to the same path and the first is silently overwritten.