### PR TITLE
fix: two backups in the same minute overwrote each other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Fixes
 
+- name a backup down to the millisecond (#115). The name stopped at the minute, so two backups started inside the same minute resolved to the same path and the second silently replaced the first, both reporting success — `backup --service a` followed by `backup --service b` left only `b`, with nothing to show `a` had been taken. Seconds were not enough either: a small project backs up fast enough that consecutive runs land in the same second. An archive that somehow already exists is now refused rather than overwritten, and the check runs before any work so a refusal leaves nothing behind
 - read `backup.dir`, the setting `docs/backup.md` has documented all along. The schema only ever had the top-level `backup_dir`, so a config copied out of the documentation parsed without complaint and then wrote to the home directory — an operator pointing backups at a NAS got neither the destination they asked for nor any sign they had not. Both spellings are read, and `backup_dir` keeps working
 
 ### 🔐 Security
@@ -25,6 +26,7 @@ All notable changes to this project will be documented in this file.
 
 ### ⚠️ Behavior changes
 
+- **Backup archives are named `backup_<date>_<hhmmss.mmm>.tar.gz`**, where they were `backup_<date>_<hhmm>.tar.gz`. Existing archives are untouched and still list and restore; anything matching on the old name shape will need updating
 - **An archive member that would be written outside its destination now fails the restore**, where `tar` skipped it and reported success. A restore that was quietly dropping members will now stop and name the member it refused. Mounts already restored before the failure stay restored — a mount target that was never permitted is still reported under `refused` and skipped, because that is an operator configuration answer; a member that lies about where it belongs is the archive being untrustworthy, and continuing to read from it is not the safe response
 
 ### 🧪 Tests

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -61,6 +61,15 @@ type ComposeProject struct {
 	ConfigFile string `json:"ConfigFiles"`
 }
 
+// archiveStampLayout names an archive down to the millisecond.
+//
+// It used to stop at the minute, so two backups started inside the same minute
+// resolved to the same path and the second silently replaced the first, both
+// reporting success. Seconds are not enough either: a small project backs up
+// fast enough that consecutive runs land in the same second. watch already
+// writes incidents at this resolution for the same reason.
+const archiveStampLayout = "2006-01-02_150405.000"
+
 // Run performs a backup of all (or filtered) Docker services.
 //
 // Retention is applied after the archive is written and only if writing it
@@ -76,9 +85,16 @@ func Run(backupDir, service string, retention RetentionConfig) (*BackupResult, e
 		return nil, fmt.Errorf("no docker compose projects found")
 	}
 
-	// Create timestamped backup directory
-	stamp := time.Now().Format("2006-01-02_1504")
+	// Create timestamped backup directory.
+	stamp := time.Now().Format(archiveStampLayout)
 	workDir := filepath.Join(backupDir, fmt.Sprintf("backup_%s", stamp))
+
+	// Checked before any work, so a refusal leaves nothing behind. Overwriting
+	// an existing backup is the one outcome that must not happen quietly, and
+	// the stamp makes it unlikely rather than impossible.
+	if _, err := os.Stat(workDir + ".tar.gz"); err == nil {
+		return nil, fmt.Errorf("a backup already exists at %s; refusing to overwrite it", workDir+".tar.gz")
+	}
 	volDir := filepath.Join(workDir, "volumes")
 	composeDir := filepath.Join(workDir, "compose")
 

--- a/internal/backup/retention_test.go
+++ b/internal/backup/retention_test.go
@@ -218,3 +218,20 @@ func TestDirUsage(t *testing.T) {
 		t.Errorf("a missing directory should read as empty, got %d, %d, %v", missing, sum, err)
 	}
 }
+
+// The archive name used to stop at the minute, so two backups started inside
+// the same minute wrote to the same path and the second replaced the first —
+// both reporting success. Retention counts archives, so several runs collapsing
+// into one also quietly changed what a count limit meant.
+func TestArchiveStampSeparatesRapidBackups(t *testing.T) {
+	base := time.Date(2026, 8, 30, 22, 36, 12, 0, time.UTC)
+	// A small project backs up fast enough that consecutive runs land in the
+	// same second, so seconds were not enough either.
+	for _, gap := range []time.Duration{35 * time.Second, 400 * time.Millisecond} {
+		first := base.Format(archiveStampLayout)
+		second := base.Add(gap).Format(archiveStampLayout)
+		if first == second {
+			t.Errorf("two times %s apart produced the same stamp %q", gap, first)
+		}
+	}
+}


### PR DESCRIPTION
Closes #115.

The archive name stopped at the minute, so two backups started inside the same minute resolved to the same path and the second silently replaced the first — both reporting success. `backup --service a` followed by `backup --service b` left only `b`, with nothing to show `a` had been taken. It also interacted with the retention just added in #102: a count limit assumes each run produces an archive, and several runs could collapse into one.

**Seconds were not enough, which I only found by running it.** Five backups of a small project on real hardware landed roughly 200ms apart, so three of the five still collided at second resolution. The stamp is milliseconds now — the resolution `watch` already uses for incidents, for exactly this reason.

An archive that somehow still exists is refused rather than overwritten, and that check runs *before* the work directory is created. My first attempt put it just before the `tar` call, which refused correctly and then left a populated work directory sitting next to the archive it had declined to replace — visible in the same test run.

```
five consecutive backups → five archives, zero leftover directories
  backup_2026-08-30_231212.745.tar.gz
  backup_2026-08-30_231212.948.tar.gz
  backup_2026-08-30_231213.147.tar.gz
  backup_2026-08-30_231213.350.tar.gz
  backup_2026-08-30_231213.552.tar.gz

max_archives: 3 over those → removed 3 by name, 3 kept
```

Behaviour change worth noting for anyone upgrading: archives are now named `backup_<date>_<hhmmss.mmm>.tar.gz`. Existing archives are untouched and still list and restore — nothing parses the name — but anything matching on the old shape will need updating.