### PR TITLE
feat: negotiate the MCP protocol version instead of declaring the oldest one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ All notable changes to this project will be documented in this file.
 
 ### ✨ Features
 
+- negotiate the MCP protocol version instead of declaring the oldest one that exists (#85). Every `initialize` was answered with `2024-11-05`, the first revision ever published, and the client's requested version was never read at all. homebutler now implements `2025-11-25`, `2025-06-18`, `2025-03-26` and `2024-11-05`, answers with the one the client asked for when it is among them, and with the newest otherwise. Nothing was broken by the old behaviour — a server may answer with any version it supports — but it was the oldest thing it could conformantly say, and clients cap their behaviour to it
 - bound the backup directory with `backup.retention` (#102). `backup` wrote an archive on every run and nothing ever deleted one — the largest files homebutler writes, and the only ones with no limit at all, which is fine until somebody puts the command in cron. `max_archives` caps the count and `max_bytes` caps the total, because ten archives can be 200MB or 200GB and a disk guarantee is what the cron case actually wants. Both are off by default: a pruned incident costs some history, while a pruned backup can be the last copy of data that no longer exists, so this is the one store you opt into bounding. Pruning runs only after a backup is written, never after a failed one, and names each archive it removed
 - warn in `doctor` when the backup directory is large and has no retention configured. Keeping everything is only a safe default while something says when the directory has outgrown what was expected, and `doctor` checked that a backup was *recent*, which says nothing about one that has been growing since the day it was created
+
+- answer `ping` (#85). "The receiver **MUST** respond promptly with an empty response" — initiating a ping is optional, answering one is not, and homebutler came back with `-32601 method not found`, which a client is entitled to read as a dead connection
 
 ### 🐛 Fixes
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -142,6 +142,18 @@ AI: "homelab-server /mnt/data is at 87% — consider cleaning up. Everything els
 
 No network ports opened. MCP uses stdio (stdin/stdout) — only the parent AI process can communicate with homebutler.
 
+### Protocol versions
+
+homebutler implements the MCP revisions `2025-11-25`, `2025-06-18`, `2025-03-26`
+and `2024-11-05`. A client's `initialize` gets the version it asked for when
+that is one of them, and `2025-11-25` when it is not, so an older client keeps
+working and a current one is not held back.
+
+For a tools-only stdio server these four describe the same surface. What the
+later revisions added is either out of scope here — resources, prompts,
+sampling, roots, elicitation, tasks, and everything about Streamable HTTP — or
+already how homebutler behaves.
+
 ## Agent Skill
 
 homebutler ships with an [Agent Skill](https://agentskills.io) that works across AI tools:

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -55,8 +55,10 @@ func TestInitialize(t *testing.T) {
 		t.Fatalf("unmarshal initializeResult: %v", err)
 	}
 
-	if init.ProtocolVersion != "2024-11-05" {
-		t.Errorf("protocolVersion = %q, want %q", init.ProtocolVersion, "2024-11-05")
+	// params carried no protocolVersion, so there is nothing to echo and the
+	// newest supported revision is the right answer.
+	if init.ProtocolVersion != supportedProtocolVersions[0] {
+		t.Errorf("protocolVersion = %q, want %q", init.ProtocolVersion, supportedProtocolVersions[0])
 	}
 	if init.ServerInfo.Name != "homebutler" {
 		t.Errorf("serverInfo.name = %q, want %q", init.ServerInfo.Name, "homebutler")
@@ -494,5 +496,109 @@ func TestInitializeVersion(t *testing.T) {
 
 	if init.ServerInfo.Version != "1.2.3" {
 		t.Errorf("version = %q, want %q", init.ServerInfo.Version, "1.2.3")
+	}
+}
+
+// homebutler answered every initialize with 2024-11-05 — the first MCP revision
+// ever published — and never read what the client asked for. That was
+// conformant, because a server may answer with any version it supports, but it
+// was the oldest thing it could conformantly say, and clients cap their
+// behaviour to the version they are handed.
+func TestNegotiateProtocolVersion(t *testing.T) {
+	latest := supportedProtocolVersions[0]
+
+	// "If the server supports the requested protocol version, it MUST respond
+	// with the same version."
+	for _, v := range supportedProtocolVersions {
+		if got := negotiateProtocolVersion(v); got != v {
+			t.Errorf("negotiateProtocolVersion(%q) = %q, want the same version back", v, got)
+		}
+	}
+
+	// "Otherwise, the server MUST respond with another protocol version it
+	// supports. This SHOULD be the latest version supported by the server."
+	for _, v := range []string{"1.0.0", "2099-01-01", ""} {
+		if got := negotiateProtocolVersion(v); got != latest {
+			t.Errorf("negotiateProtocolVersion(%q) = %q, want the latest supported %q", v, got, latest)
+		}
+	}
+
+	if latest == "2024-11-05" {
+		t.Error("the newest supported revision is still the first one ever published")
+	}
+}
+
+func TestInitializeEchoesTheRequestedVersion(t *testing.T) {
+	for _, want := range supportedProtocolVersions {
+		s, out := newTestServer()
+		req := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"` + want + `"}}`
+		resp := sendAndReceive(t, s, out, req)
+		if resp.Error != nil {
+			t.Fatalf("%s: unexpected error: %v", want, resp.Error)
+		}
+
+		result, _ := json.Marshal(resp.Result)
+		var init initializeResult
+		if err := json.Unmarshal(result, &init); err != nil {
+			t.Fatalf("%s: unmarshal: %v", want, err)
+		}
+		if init.ProtocolVersion != want {
+			t.Errorf("client asked for %q, server answered %q", want, init.ProtocolVersion)
+		}
+	}
+}
+
+func TestInitializeAnswersLatestForAVersionItDoesNotSpeak(t *testing.T) {
+	s, out := newTestServer()
+	req := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"1.0.0"}}`
+	resp := sendAndReceive(t, s, out, req)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+
+	result, _ := json.Marshal(resp.Result)
+	var init initializeResult
+	if err := json.Unmarshal(result, &init); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if init.ProtocolVersion != supportedProtocolVersions[0] {
+		t.Errorf("protocolVersion = %q, want the latest supported %q", init.ProtocolVersion, supportedProtocolVersions[0])
+	}
+}
+
+// A client that opens with no params at all still gets a handshake rather than
+// a parse failure.
+func TestInitializeWithoutParams(t *testing.T) {
+	s, out := newTestServer()
+	resp := sendAndReceive(t, s, out, `{"jsonrpc":"2.0","id":1,"method":"initialize"}`)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	result, _ := json.Marshal(resp.Result)
+	var init initializeResult
+	if err := json.Unmarshal(result, &init); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if init.ProtocolVersion != supportedProtocolVersions[0] {
+		t.Errorf("protocolVersion = %q", init.ProtocolVersion)
+	}
+}
+
+// "The receiver MUST respond promptly with an empty response." Sending a ping
+// is optional; answering one is not, and this came back as -32601 method not
+// found, which a client is entitled to read as a dead connection.
+func TestPingIsAnswered(t *testing.T) {
+	s, out := newTestServer()
+	resp := sendAndReceive(t, s, out, `{"jsonrpc":"2.0","id":7,"method":"ping"}`)
+
+	if resp.Error != nil {
+		t.Fatalf("ping returned an error: %v", resp.Error)
+	}
+	result, err := json.Marshal(resp.Result)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if string(result) != "{}" {
+		t.Errorf("ping result = %s, want an empty object", result)
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -60,6 +60,49 @@ type initializeResult struct {
 	ServerInfo      serverInfo `json:"serverInfo"`
 }
 
+// initializeParams is the part of the client's initialize request that this
+// server acts on. Capabilities and clientInfo are read past deliberately: a
+// tools-only server negotiates nothing that depends on them.
+type initializeParams struct {
+	ProtocolVersion string `json:"protocolVersion"`
+}
+
+// supportedProtocolVersions lists the MCP revisions this server implements,
+// newest first.
+//
+// homebutler answered every initialize with "2024-11-05" — the first revision
+// ever published — and never read what the client asked for. That was
+// conformant, because a server may answer with any version it supports, but it
+// was the oldest thing it could conformantly say, and clients cap their
+// behaviour to the version they are given.
+//
+// All four are listed because for a tools-only stdio server they describe the
+// same surface. Everything the later revisions added is either out of scope
+// here (resources, prompts, sampling, roots, elicitation, tasks, Streamable
+// HTTP and its authorization) or already the behaviour: tool input validation
+// errors come back as tool errors with IsError rather than as JSON-RPC errors
+// (SEP-1303), and the generated inputSchema uses no construct outside JSON
+// Schema 2020-12 (SEP-1613).
+var supportedProtocolVersions = []string{
+	"2025-11-25",
+	"2025-06-18",
+	"2025-03-26",
+	"2024-11-05",
+}
+
+// negotiateProtocolVersion answers with the version the client asked for when
+// this server implements it, and with the newest one it does implement when it
+// does not. That is what the lifecycle spec requires, and it is also the only
+// shape that keeps working if a version is ever added or dropped here.
+func negotiateProtocolVersion(requested string) string {
+	for _, v := range supportedProtocolVersions {
+		if v == requested {
+			return requested
+		}
+	}
+	return supportedProtocolVersions[0]
+}
+
 type capInfo struct {
 	Tools *toolsCap `json:"tools,omitempty"`
 }
@@ -159,13 +202,23 @@ func (s *Server) Run() error {
 func (s *Server) handleRequest(req *jsonRPCRequest) {
 	switch req.Method {
 	case "initialize":
+		var params initializeParams
+		// A request with no or unreadable params is not a reason to fail the
+		// handshake; it just means there is nothing to echo, and the newest
+		// supported version is the right answer.
+		_ = json.Unmarshal(req.Params, &params)
 		s.writeResult(req.ID, initializeResult{
-			ProtocolVersion: "2024-11-05",
+			ProtocolVersion: negotiateProtocolVersion(params.ProtocolVersion),
 			Capabilities:    capInfo{Tools: &toolsCap{}},
 			ServerInfo:      serverInfo{Name: "homebutler", Version: s.version},
 		})
 	case "notifications/initialized":
 		// Notification — no response needed
+	case "ping":
+		// "The receiver MUST respond promptly with an empty response." Initiating
+		// a ping is optional; answering one is not, and this used to come back
+		// as -32601 method not found.
+		s.writeResult(req.ID, struct{}{})
 	case "tools/list":
 		s.writeResult(req.ID, toolsListResult{Tools: toolDefinitions()})
 	case "tools/call":


### PR DESCRIPTION
Closes #85.

`initialize` answered `2024-11-05` — the first MCP revision ever published — and never read `req.Params`, so the version the client asked for was discarded before anything looked at it.

Nothing was broken by that, and it is worth being precise about why: a server may answer with any version it supports, and homebutler supported exactly one, so the answer was conformant. It was just the oldest thing it could conformantly say, and a client caps its behaviour to the version it is handed.

Four revisions are now implemented — `2025-11-25`, `2025-06-18`, `2025-03-26`, `2024-11-05` — and the answer follows the lifecycle spec: the requested version when it is one of those, the newest when it is not.

**Listing all four is honest rather than generous.** For a tools-only stdio server they describe the same surface. What the later revisions added is either out of scope here (resources, prompts, sampling, roots, elicitation, tasks, and everything about Streamable HTTP and its authorization) or already the behaviour: input validation errors come back as tool errors with `IsError` rather than JSON-RPC errors (SEP-1303), and the generated `inputSchema` carries no `$schema` and no construct outside JSON Schema 2020-12 (SEP-1613). I checked both rather than assuming.

**`ping` is the reason this is not a one-line change.** #85 left it as an open question — whether any revision makes it mandatory for a server — and the answer is yes, in the sense that matters:

> The receiver **MUST** respond promptly with an empty response.

Initiating a ping is optional; answering one is not. homebutler returned `-32601 method not found`, which a client is entitled to read as a dead connection and act on. Declaring a newer revision is a claim about what the server implements, so this had to be true before the claim could be.

Exercised over real stdio, not only in tests:

```
2025-11-25   → 2025-11-25      requested version echoed
2025-06-18   → 2025-06-18
2025-03-26   → 2025-03-26
2024-11-05   → 2024-11-05      an older client keeps working unchanged
1.0.0        → 2025-11-25      unknown version gets the newest

ping → {"jsonrpc":"2.0","id":2,"result":{}}
initialize → notifications/initialized → ping → tools/list → 40 tools
```

`TestInitialize` was pinning `2024-11-05` for a request whose params carried no version; it now asserts the newest supported revision, which is the correct answer when there is nothing to echo.

#86 — the handshake-free modern protocol — is untouched. That issue calls itself a 1.0 decision and says this one should not wait for it.