### PR TITLE
feat(proxmox): classify endpoint failures

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/Higangssh/homebutler/internal/backup"
 	"github.com/Higangssh/homebutler/internal/notify"
+	"github.com/Higangssh/homebutler/internal/proxmox"
 	"github.com/Higangssh/homebutler/internal/watch"
 	"gopkg.in/yaml.v3"
 )
@@ -209,12 +210,12 @@ func (p ProxmoxConfig) TokenValue() (string, error) {
 
 	data, err := os.ReadFile(p.TokenFilePath())
 	if err != nil {
-		return "", fmt.Errorf("read Proxmox token file %s: %w", p.TokenFile, err)
+		return "", proxmox.WithFailureClass(proxmox.FailureAuthentication, fmt.Errorf("read Proxmox token file %s: %w", p.TokenFile, err))
 	}
 	if token := strings.TrimSpace(string(data)); token != "" {
 		return token, nil
 	}
-	return "", fmt.Errorf("proxmox token file %s is empty", p.TokenFile)
+	return "", proxmox.WithFailureClass(proxmox.FailureAuthentication, fmt.Errorf("proxmox token file %s is empty", p.TokenFile))
 }
 
 type WakeTarget struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,8 +3,10 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/Higangssh/homebutler/internal/proxmox"
 	"gopkg.in/yaml.v3"
 )
 
@@ -251,14 +253,18 @@ func TestProxmoxConfigTokenValue(t *testing.T) {
 		t.Error("TokenValue() should fail without a token source")
 	}
 
-	if _, err := (ProxmoxConfig{TokenFile: filepath.Join(dir, "missing")}).TokenValue(); err == nil {
+	if _, err := (ProxmoxConfig{TokenFile: filepath.Join(dir, "missing"), Token: "inline-secret"}).TokenValue(); err == nil {
 		t.Error("TokenValue() should fail for a missing token file")
+	} else if proxmox.Classify(err) != proxmox.FailureAuthentication || strings.Contains(err.Error(), "inline-secret") {
+		t.Errorf("TokenValue() error = %v, want authentication error without inline token", err)
 	}
 	if err := os.WriteFile(filepath.Join(dir, "empty"), []byte(" \n"), 0600); err != nil {
 		t.Fatalf("write empty token: %v", err)
 	}
-	if _, err := (ProxmoxConfig{TokenFile: filepath.Join(dir, "empty")}).TokenValue(); err == nil {
+	if _, err := (ProxmoxConfig{TokenFile: filepath.Join(dir, "empty"), Token: "inline-secret"}).TokenValue(); err == nil {
 		t.Error("TokenValue() should fail for an empty token file")
+	} else if proxmox.Classify(err) != proxmox.FailureAuthentication || strings.Contains(err.Error(), "inline-secret") {
+		t.Errorf("TokenValue() error = %v, want authentication error without inline token", err)
 	}
 }
 

--- a/internal/proxmox/client.go
+++ b/internal/proxmox/client.go
@@ -153,14 +153,14 @@ func tlsConfig(options Options) (*tls.Config, error) {
 		config.InsecureSkipVerify = true // #nosec G402 -- verified by the callback below.
 		config.VerifyPeerCertificate = func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
 			if len(rawCerts) == 0 {
-				return fmt.Errorf("proxmox TLS peer sent no certificate")
+				return WithFailureClass(FailureTLS, fmt.Errorf("proxmox TLS peer sent no certificate"))
 			}
 			if _, err := x509.ParseCertificate(rawCerts[0]); err != nil {
 				return fmt.Errorf("parse Proxmox TLS certificate: %w", err)
 			}
 			actual := sha256.Sum256(rawCerts[0])
 			if subtle.ConstantTimeCompare(actual[:], expected) != 1 {
-				return fmt.Errorf("proxmox TLS certificate fingerprint mismatch")
+				return WithFailureClass(FailureTLS, fmt.Errorf("proxmox TLS certificate fingerprint mismatch"))
 			}
 			return nil
 		}
@@ -392,7 +392,7 @@ func (c *Client) request(ctx context.Context, method, path string, query url.Val
 	resp, err := c.http.Do(req)
 	if err != nil {
 		class := FailureTransport
-		if Classify(err) == FailureTLS || isTLSFailure(err) || strings.Contains(err.Error(), "proxmox TLS ") {
+		if Classify(err) == FailureTLS || isTLSFailure(err) {
 			class = FailureTLS
 		}
 		return WithFailureClass(class, fmt.Errorf("proxmox request %s: %w", path, err))

--- a/internal/proxmox/client.go
+++ b/internal/proxmox/client.go
@@ -10,6 +10,7 @@ import (
 	"crypto/x509"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -21,6 +22,42 @@ import (
 )
 
 const defaultTimeout = 10 * time.Second
+
+// FailureClass describes an actionable Proxmox endpoint failure.
+// An empty class means the error is not an endpoint failure, or there was none.
+type FailureClass string
+
+const (
+	FailureTLS            FailureClass = "tls"
+	FailureAuthentication FailureClass = "authentication"
+	FailureAuthorization  FailureClass = "authorization"
+	FailureTransport      FailureClass = "transport"
+)
+
+type classifiedError struct {
+	class FailureClass
+	err   error
+}
+
+func (e *classifiedError) Error() string { return e.err.Error() }
+func (e *classifiedError) Unwrap() error { return e.err }
+
+// Classify returns the failure class carried by err, if any.
+func Classify(err error) FailureClass {
+	var classified *classifiedError
+	if errors.As(err, &classified) {
+		return classified.class
+	}
+	return ""
+}
+
+// WithFailureClass carries class outward without changing err's message.
+func WithFailureClass(class FailureClass, err error) error {
+	if err == nil || class == "" || Classify(err) != "" {
+		return err
+	}
+	return &classifiedError{class: class, err: err}
+}
 
 const (
 	// minVMID matches the Proxmox API's own vmid schema minimum. 100 is only
@@ -82,7 +119,7 @@ func New(options Options) (*Client, error) {
 
 	tlsConfig, err := tlsConfig(options)
 	if err != nil {
-		return nil, err
+		return nil, WithFailureClass(FailureTLS, err)
 	}
 
 	return &Client{
@@ -354,13 +391,17 @@ func (c *Client) request(ctx context.Context, method, path string, query url.Val
 
 	resp, err := c.http.Do(req)
 	if err != nil {
-		return fmt.Errorf("proxmox request %s: %w", path, err)
+		class := FailureTransport
+		if Classify(err) == FailureTLS || isTLSFailure(err) || strings.Contains(err.Error(), "proxmox TLS ") {
+			class = FailureTLS
+		}
+		return WithFailureClass(class, fmt.Errorf("proxmox request %s: %w", path, err))
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
 	if err != nil {
-		return fmt.Errorf("read Proxmox response %s: %w", path, err)
+		return WithFailureClass(FailureTransport, fmt.Errorf("read Proxmox response %s: %w", path, err))
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		var apiError struct {
@@ -369,9 +410,9 @@ func (c *Client) request(ctx context.Context, method, path string, query url.Val
 		_ = json.Unmarshal(body, &apiError)
 		if message := strings.TrimSpace(apiError.Message); message != "" {
 			message = strings.ReplaceAll(message, c.token, "[REDACTED]")
-			return fmt.Errorf("proxmox request %s: %s: %s", path, resp.Status, message)
+			return WithFailureClass(httpFailureClass(resp.StatusCode), fmt.Errorf("proxmox request %s: %s: %s", path, resp.Status, message))
 		}
-		return fmt.Errorf("proxmox request %s: %s", path, resp.Status)
+		return WithFailureClass(httpFailureClass(resp.StatusCode), fmt.Errorf("proxmox request %s: %s", path, resp.Status))
 	}
 
 	var envelope struct {
@@ -384,4 +425,23 @@ func (c *Client) request(ctx context.Context, method, path string, query url.Val
 		return fmt.Errorf("decode Proxmox data %s: %w", path, err)
 	}
 	return nil
+}
+
+func httpFailureClass(statusCode int) FailureClass {
+	switch statusCode {
+	case http.StatusUnauthorized:
+		return FailureAuthentication
+	case http.StatusForbidden:
+		return FailureAuthorization
+	default:
+		return ""
+	}
+}
+
+func isTLSFailure(err error) bool {
+	var unknownAuthority x509.UnknownAuthorityError
+	var hostname x509.HostnameError
+	var invalidCertificate x509.CertificateInvalidError
+	var verification *tls.CertificateVerificationError
+	return errors.As(err, &unknownAuthority) || errors.As(err, &hostname) || errors.As(err, &invalidCertificate) || errors.As(err, &verification)
 }

--- a/internal/proxmox/client.go
+++ b/internal/proxmox/client.go
@@ -170,11 +170,11 @@ func tlsConfig(options Options) (*tls.Config, error) {
 	if options.CAFile != "" {
 		pem, err := os.ReadFile(options.CAFile)
 		if err != nil {
-			return nil, fmt.Errorf("read Proxmox CA file: %w", err)
+			return nil, WithFailureClass(FailureAuthentication, fmt.Errorf("read Proxmox CA file: %w", err))
 		}
 		pool := x509.NewCertPool()
 		if !pool.AppendCertsFromPEM(pem) {
-			return nil, fmt.Errorf("proxmox CA file contains no certificates")
+			return nil, WithFailureClass(FailureAuthentication, fmt.Errorf("proxmox CA file contains no certificates"))
 		}
 		config.RootCAs = pool
 		return config, nil
@@ -190,7 +190,7 @@ func parseFingerprint(value string) ([]byte, error) {
 	value = strings.ReplaceAll(strings.TrimSpace(value), ":", "")
 	fingerprint, err := hex.DecodeString(value)
 	if err != nil || len(fingerprint) != sha256.Size {
-		return nil, fmt.Errorf("proxmox fingerprint must be a SHA-256 certificate fingerprint")
+		return nil, WithFailureClass(FailureAuthentication, fmt.Errorf("proxmox fingerprint must be a SHA-256 certificate fingerprint"))
 	}
 	return fingerprint, nil
 }

--- a/internal/proxmox/client_test.go
+++ b/internal/proxmox/client_test.go
@@ -486,10 +486,17 @@ func TestTLSModes(t *testing.T) {
 }
 
 func TestFailureClassification(t *testing.T) {
-	t.Run("TLS setup", func(t *testing.T) {
+	t.Run("CA file unreadable", func(t *testing.T) {
 		_, err := New(Options{Host: "pve.example", TokenID: "id", Token: "secret", CAFile: "missing.pem"})
-		if Classify(err) != FailureTLS {
-			t.Fatalf("Classify(%v) = %q, want %q", err, Classify(err), FailureTLS)
+		if Classify(err) != FailureAuthentication {
+			t.Fatalf("Classify(%v) = %q, want %q", err, Classify(err), FailureAuthentication)
+		}
+	})
+
+	t.Run("fingerprint format", func(t *testing.T) {
+		_, err := New(Options{Host: "pve.example", TokenID: "id", Token: "secret", Fingerprint: "not-hex"})
+		if Classify(err) != FailureAuthentication {
+			t.Fatalf("Classify(%v) = %q, want %q", err, Classify(err), FailureAuthentication)
 		}
 	})
 

--- a/internal/proxmox/client_test.go
+++ b/internal/proxmox/client_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -427,7 +428,7 @@ func TestAPIErrorIncludesMessage(t *testing.T) {
 	defer server.Close()
 
 	_, err := testClient(t, server.URL).Version(context.Background())
-	if err == nil || !strings.Contains(err.Error(), "403 Forbidden") || !strings.Contains(err.Error(), "Permission check failed (/, Sys.Audit)") {
+	if err == nil || !strings.Contains(err.Error(), "403 Forbidden") || !strings.Contains(err.Error(), "Permission check failed (/, Sys.Audit)") || Classify(err) != FailureAuthorization {
 		t.Errorf("Version() error = %v", err)
 	}
 }
@@ -462,8 +463,8 @@ func TestTLSModes(t *testing.T) {
 	})
 	t.Run("fingerprint mismatch", func(t *testing.T) {
 		client := newTLSClient(t, server.URL, Options{Fingerprint: strings.Repeat("00:", 31) + "00"})
-		if _, err := client.Version(context.Background()); err == nil || !strings.Contains(err.Error(), "fingerprint mismatch") {
-			t.Errorf("Version() error = %v", err)
+		if _, err := client.Version(context.Background()); err == nil || !strings.Contains(err.Error(), "fingerprint mismatch") || Classify(err) != FailureTLS {
+			t.Errorf("Version() error = %#v", err)
 		}
 	})
 	t.Run("CA file", func(t *testing.T) {
@@ -483,6 +484,74 @@ func TestTLSModes(t *testing.T) {
 		}
 	})
 }
+
+func TestFailureClassification(t *testing.T) {
+	t.Run("TLS setup", func(t *testing.T) {
+		_, err := New(Options{Host: "pve.example", TokenID: "id", Token: "secret", CAFile: "missing.pem"})
+		if Classify(err) != FailureTLS {
+			t.Fatalf("Classify(%v) = %q, want %q", err, Classify(err), FailureTLS)
+		}
+	})
+
+	t.Run("TLS handshake", func(t *testing.T) {
+		server := httptest.NewTLSServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+		defer server.Close()
+		if _, err := newTLSClient(t, server.URL, Options{}).Version(context.Background()); Classify(err) != FailureTLS {
+			t.Fatalf("Classify(%v) = %q, want %q", err, Classify(err), FailureTLS)
+		}
+	})
+
+	for _, tt := range []struct {
+		name   string
+		status int
+		class  FailureClass
+	}{
+		{name: "authentication", status: http.StatusUnauthorized, class: FailureAuthentication},
+		{name: "authorization", status: http.StatusForbidden, class: FailureAuthorization},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				http.Error(w, "fixture-token denied", tt.status)
+			}))
+			defer server.Close()
+			_, err := testClient(t, server.URL).Version(context.Background())
+			if Classify(err) != tt.class || strings.Contains(err.Error(), "fixture-token") {
+				t.Fatalf("Classify(%v) = %q, want %q", err, Classify(err), tt.class)
+			}
+		})
+	}
+
+	t.Run("transport", func(t *testing.T) {
+		client := testClient(t, "https://pve.example")
+		client.http = &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return nil, errors.New("dial failed")
+		})}
+		_, err := client.Version(context.Background())
+		if Classify(err) != FailureTransport {
+			t.Fatalf("Classify(%v) = %q, want %q", err, Classify(err), FailureTransport)
+		}
+	})
+
+	t.Run("response read", func(t *testing.T) {
+		client := testClient(t, "https://pve.example")
+		client.http = &http.Client{Transport: roundTripperFunc(func(*http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: http.StatusOK, Body: errReader{}}, nil
+		})}
+		_, err := client.Version(context.Background())
+		if Classify(err) != FailureTransport {
+			t.Fatalf("Classify(%v) = %q, want %q", err, Classify(err), FailureTransport)
+		}
+	})
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+type errReader struct{}
+
+func (errReader) Read([]byte) (int, error) { return 0, errors.New("read failed") }
+func (errReader) Close() error             { return nil }
 
 func TestNewValidation(t *testing.T) {
 	for _, options := range []Options{


### PR DESCRIPTION
## What does this PR do?

Adds typed Proxmox failure classes for TLS, authentication, authorization, and transport failures.

The shared class survives error wrapping without changing existing human-facing messages or DefaultView failed collector behavior. Token file read failures are classified as authentication failures.

Closes #111

## Checklist

- [x] `gofmt -w .`
- [x] `go build ./...`
- [x] `go test ./...`
- [x] Tests added for new functionality
- [x] README update not needed for this internal API change