### PR TITLE
feat: show actionable errors before details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 
 - add the global `--verbose` / `-v` flag for detailed error output. Human-facing permission errors now include the failed operation and a command that preserves the requested backup options; remote commands receive the flag too
 
+### ⚠️ Behavior changes
+
+- **Human-facing permission errors no longer include the underlying cause by default.** They lead with the failed operation and the command to rerun; use `--verbose` to see the underlying error and hint together
+
 ## [0.24.0](https://github.com/Higangssh/homebutler/compare/v0.23.1...v0.24.0) - 2026-08-31
 
 **The largest files homebutler writes were the only ones nothing ever deleted, and the safety of restoring them belonged to a program homebutler merely invoked.** `backup` wrote an archive on every run with no retention of any kind — fine while a person types the command, and the first thing to hurt whoever puts it in cron. Restore, meanwhile, held its destination only because GNU tar and bsdtar decline dangerous member names on their own; nothing in this repository asserted it and no test covered it. Separately, the MCP server had been answering every handshake with the first protocol revision ever published.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+**Permission failures now lead with the fix while keeping the underlying error available with `--verbose`.**
+
+### ✨ Features
+
+- add the global `--verbose` / `-v` flag for detailed error output. Human-facing permission errors now include the failed operation and a command that preserves the requested backup options; remote commands receive the flag too
+
 ## [0.24.0](https://github.com/Higangssh/homebutler/compare/v0.23.1...v0.24.0) - 2026-08-31
 
 **The largest files homebutler writes were the only ones nothing ever deleted, and the safety of restoring them belonged to a program homebutler merely invoked.** `backup` wrote an archive on every run with no retention of any kind — fine while a person types the command, and the first thing to hurt whoever puts it in cron. Restore, meanwhile, held its destination only because GNU tar and bsdtar decline dangerous member names on their own; nothing in this repository asserted it and no test covered it. Separately, the MCP server had been answering every handshake with the first protocol revision ever published.

--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ Commands:
 
 Flags:
   --json              JSON output (default: human-readable)
+  --verbose, -v       Show detailed error information
   --server <name>     Run on a specific remote server
   --all               Run on all configured servers in parallel
   --port <number>     Port for serve command (default: 8080)
@@ -670,6 +671,7 @@ Commands:
 
 Flags:
   --json              JSON output (default: human-readable)
+  --verbose, -v       Show detailed error information
   --server <name>     Run on a specific remote server
   --all               Run on all configured servers in parallel
   --port <number>     Port for serve command (default: 8080)

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -17,6 +18,7 @@ import (
 	"github.com/Higangssh/homebutler/internal/ports"
 	"github.com/Higangssh/homebutler/internal/remote"
 	"github.com/Higangssh/homebutler/internal/system"
+	"github.com/Higangssh/homebutler/internal/util"
 	"github.com/Higangssh/homebutler/internal/wake"
 )
 
@@ -28,10 +30,11 @@ var (
 
 // Global flags
 var (
-	jsonOutput bool
-	serverName string
-	allServers bool
-	cfgPath    string
+	jsonOutput    bool
+	verboseOutput bool
+	serverName    string
+	allServers    bool
+	cfgPath       string
 )
 
 // cfg holds the loaded config (set in root PersistentPreRun)
@@ -111,6 +114,13 @@ func output(data any, jsonOut bool) error {
 		return enc.Encode(data)
 	}
 	return nil
+}
+
+func formatCommandError(err error) error {
+	if err == nil || jsonOutput {
+		return err
+	}
+	return errors.New(util.FormatError(err, verboseOutput))
 }
 
 // listServerNames returns a formatted list of server names from config.
@@ -231,7 +241,7 @@ func runAllServers(c *config.Config, args []string, jsonOut bool) error {
 			if server.Local {
 				out, err := runLocalCommand(remoteArgs)
 				if err != nil {
-					result.Error = err.Error()
+					result.Error = util.FormatError(err, verboseOutput || jsonOut)
 				} else {
 					result.Data = json.RawMessage(out)
 				}

--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -248,7 +248,7 @@ func runAllServers(c *config.Config, args []string, jsonOut bool) error {
 			} else {
 				out, err := remote.Run(&server, remoteArgs...)
 				if err != nil {
-					result.Error = err.Error()
+					result.Error = util.FormatError(err, verboseOutput || jsonOut)
 				} else {
 					result.Data = json.RawMessage(out)
 				}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -29,6 +29,7 @@ Configuration file is resolved in order:
 
 func init() {
 	rootCmd.PersistentFlags().BoolVar(&jsonOutput, "json", false, "Force JSON output")
+	rootCmd.PersistentFlags().BoolVarP(&verboseOutput, "verbose", "v", false, "Show detailed error information")
 	rootCmd.PersistentFlags().StringVar(&serverName, "server", "", "Run on a specific remote server")
 	rootCmd.PersistentFlags().BoolVar(&allServers, "all", false, "Run on all configured servers in parallel")
 	rootCmd.PersistentFlags().StringVar(&cfgPath, "config", "", "Config file path")
@@ -102,5 +103,5 @@ func maybeRouteRemote() (bool, error) {
 func Execute(version, buildDate string) error {
 	Version = version
 	BuildDate = buildDate
-	return rootCmd.Execute()
+	return formatCommandError(rootCmd.Execute())
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -49,6 +49,12 @@ func TestFilterFlags(t *testing.T) {
 			expected: []string{"status", "--json"},
 		},
 		{
+			name:     "keep verbose flag for remote",
+			args:     []string{"status", "--server", "rpi5", "--verbose"},
+			flags:    []string{"--server", "--all", "--config"},
+			expected: []string{"status", "--verbose"},
+		},
+		{
 			name:     "empty args",
 			args:     []string{},
 			flags:    []string{"--server"},

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/Higangssh/homebutler/internal/remote"
+	"github.com/Higangssh/homebutler/internal/util"
 	"github.com/spf13/cobra"
 )
 
@@ -104,6 +105,10 @@ func printUpgradeStatus(r *remote.UpgradeResult) {
 	case "up-to-date":
 		fmt.Fprintf(os.Stderr, "─ %s\n", r.Message)
 	case "error":
-		fmt.Fprintf(os.Stderr, "✗ %s\n", r.Message)
+		message := r.Message
+		if r.Error != nil {
+			message = util.FormatError(r.Error, verboseOutput || jsonOutput)
+		}
+		fmt.Fprintf(os.Stderr, "✗ %s\n", message)
 	}
 }

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -100,13 +100,13 @@ func Run(backupDir, service string, retention RetentionConfig) (*BackupResult, e
 
 	if err := os.MkdirAll(volDir, 0o755); err != nil {
 		if util.IsPermissionError(err) {
-			return nil, util.NewHintError(fmt.Errorf("failed to create backup dir: %w", err), "sudo homebutler backup")
+			return nil, util.NewHintError("cannot create backup dir "+backupDir, err, backupHint(backupDir, service))
 		}
 		return nil, fmt.Errorf("failed to create backup dir: %w", err)
 	}
 	if err := os.MkdirAll(composeDir, 0o755); err != nil {
 		if util.IsPermissionError(err) {
-			return nil, util.NewHintError(fmt.Errorf("failed to create compose dir: %w", err), "sudo homebutler backup")
+			return nil, util.NewHintError("cannot create compose dir "+composeDir, err, backupHint(backupDir, service))
 		}
 		return nil, fmt.Errorf("failed to create compose dir: %w", err)
 	}
@@ -202,6 +202,14 @@ func Run(backupDir, service string, retention RetentionConfig) (*BackupResult, e
 		result.Pruned = pruned
 	}
 	return result, nil
+}
+
+func backupHint(backupDir, service string) string {
+	hint := "sudo homebutler backup --to " + util.ShellQuote(backupDir)
+	if service != "" {
+		hint += " --service " + util.ShellQuote(service)
+	}
+	return hint
 }
 
 // List returns all backups in the backup directory.

--- a/internal/backup/backup.go
+++ b/internal/backup/backup.go
@@ -100,13 +100,13 @@ func Run(backupDir, service string, retention RetentionConfig) (*BackupResult, e
 
 	if err := os.MkdirAll(volDir, 0o755); err != nil {
 		if util.IsPermissionError(err) {
-			return nil, fmt.Errorf("failed to create backup dir: %w\n\n  ⚠️  Try: sudo homebutler backup", err)
+			return nil, util.NewHintError(fmt.Errorf("failed to create backup dir: %w", err), "sudo homebutler backup")
 		}
 		return nil, fmt.Errorf("failed to create backup dir: %w", err)
 	}
 	if err := os.MkdirAll(composeDir, 0o755); err != nil {
 		if util.IsPermissionError(err) {
-			return nil, fmt.Errorf("failed to create compose dir: %w\n\n  ⚠️  Try: sudo homebutler backup", err)
+			return nil, util.NewHintError(fmt.Errorf("failed to create compose dir: %w", err), "sudo homebutler backup")
 		}
 		return nil, fmt.Errorf("failed to create compose dir: %w", err)
 	}

--- a/internal/backup/drill_test.go
+++ b/internal/backup/drill_test.go
@@ -443,7 +443,7 @@ func TestRestoreMountBindExtractsArchive(t *testing.T) {
 	}
 
 	target := filepath.Join(dir, "target")
-	err := restoreMount(Mount{Type: "bind", Name: "data", Source: target}, volDir)
+	err := restoreMount(Mount{Type: "bind", Name: "data", Source: target}, volDir, "backup.tar.gz")
 	if err != nil {
 		t.Fatalf("restoreMount() error = %v", err)
 	}

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -185,7 +185,7 @@ func Restore(archivePath string, opts RestoreOptions) (*RestoreResult, error) {
 				}
 				m = cleared
 			}
-			if err := restoreMount(m, volDir); err != nil {
+			if err := restoreMount(m, volDir, archivePath); err != nil {
 				return nil, fmt.Errorf("failed to restore mount %s: %w", m.Name, err)
 			}
 			volumeCount++
@@ -287,7 +287,7 @@ func refuseMount(m Mount, opts RestoreOptions) (Mount, string) {
 //
 // Callers must have cleared the mount through refuseMount first; this function
 // assumes m.Name is a volume name and m.Source is an operator-permitted path.
-func restoreMount(m Mount, volDir string) error {
+func restoreMount(m Mount, volDir, sourceArchive string) error {
 	safeName := sanitizeName(m.Name)
 	archivePath := mountArchivePath(m.Name, volDir)
 
@@ -310,7 +310,7 @@ func restoreMount(m Mount, volDir string) error {
 		// Restore bind mount to host path
 		if err := os.MkdirAll(m.Source, 0o755); err != nil {
 			if util.IsPermissionError(err) {
-				return util.NewHintError(fmt.Errorf("failed to create bind mount dir %s: %w", m.Source, err), "sudo homebutler restore "+archivePath)
+				return util.NewHintError("cannot create bind mount dir "+m.Source, err, "sudo homebutler restore "+sourceArchive)
 			}
 			return fmt.Errorf("failed to create bind mount dir %s: %w", m.Source, err)
 		}

--- a/internal/backup/restore.go
+++ b/internal/backup/restore.go
@@ -310,7 +310,7 @@ func restoreMount(m Mount, volDir string) error {
 		// Restore bind mount to host path
 		if err := os.MkdirAll(m.Source, 0o755); err != nil {
 			if util.IsPermissionError(err) {
-				return fmt.Errorf("failed to create bind mount dir %s: %w\n\n  ⚠️  Try: sudo homebutler restore %s", m.Source, err, archivePath)
+				return util.NewHintError(fmt.Errorf("failed to create bind mount dir %s: %w", m.Source, err), "sudo homebutler restore "+archivePath)
 			}
 			return fmt.Errorf("failed to create bind mount dir %s: %w", m.Source, err)
 		}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -25,6 +25,10 @@ func registryFile() string {
 	return filepath.Join(BaseDir(), "installed.json")
 }
 
+func fixPermissionsHint(path string) string {
+	return "sudo chown -R $(id -u):$(id -g) " + util.ShellQuote(path)
+}
+
 // saveInstalled records an app's install location.
 func saveInstalled(app installedApp) error {
 	all := loadInstalled()
@@ -36,13 +40,13 @@ func saveInstalled(app installedApp) error {
 	}
 	if err := os.MkdirAll(BaseDir(), 0755); err != nil {
 		if util.IsPermissionError(err) {
-			return util.NewHintError(fmt.Errorf("failed to create registry dir: %w", err), "sudo homebutler install "+app.Name)
+			return util.NewHintError("cannot create registry dir "+BaseDir(), err, fixPermissionsHint(BaseDir()))
 		}
 		return err
 	}
 	if err := os.WriteFile(registryFile(), data, 0644); err != nil {
 		if util.IsPermissionError(err) {
-			return util.NewHintError(fmt.Errorf("failed to write install registry: %w", err), "sudo homebutler install "+app.Name)
+			return util.NewHintError("cannot write install registry "+registryFile(), err, fixPermissionsHint(registryFile()))
 		}
 		return err
 	}
@@ -60,7 +64,7 @@ func removeInstalled(appName string) error {
 	}
 	if err := os.WriteFile(registryFile(), data, 0644); err != nil {
 		if util.IsPermissionError(err) {
-			return util.NewHintError(fmt.Errorf("failed to update install registry: %w", err), "sudo homebutler uninstall "+appName)
+			return util.NewHintError("cannot update install registry "+registryFile(), err, fixPermissionsHint(registryFile()))
 		}
 		return err
 	}
@@ -680,7 +684,7 @@ func Install(app App, opts InstallOptions) error {
 	// Create directories (only for real installs)
 	if err := os.MkdirAll(dataDir, 0755); err != nil {
 		if util.IsPermissionError(err) {
-			return util.NewHintError(fmt.Errorf("failed to create directory %s: %w", dataDir, err), "sudo homebutler install "+app.Name)
+			return util.NewHintError("cannot create directory "+dataDir, err, "sudo homebutler install "+app.Name)
 		}
 		return fmt.Errorf("failed to create directory %s: %w", dataDir, err)
 	}
@@ -689,7 +693,7 @@ func Install(app App, opts InstallOptions) error {
 	f, err := os.Create(composeFile)
 	if err != nil {
 		if util.IsPermissionError(err) {
-			return util.NewHintError(fmt.Errorf("failed to create %s: %w", composeFile, err), "sudo homebutler install "+app.Name)
+			return util.NewHintError("cannot create "+composeFile, err, "sudo homebutler install "+app.Name)
 		}
 		return fmt.Errorf("failed to create %s: %w", composeFile, err)
 	}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -40,7 +40,7 @@ func saveInstalled(app installedApp) error {
 	}
 	if err := os.MkdirAll(BaseDir(), 0755); err != nil {
 		if util.IsPermissionError(err) {
-			return util.NewHintError("cannot create registry dir "+BaseDir(), err, fixPermissionsHint(BaseDir()))
+			return util.NewHintError("cannot create registry dir "+BaseDir(), err, fixPermissionsHint(filepath.Dir(BaseDir())))
 		}
 		return err
 	}

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -36,13 +36,13 @@ func saveInstalled(app installedApp) error {
 	}
 	if err := os.MkdirAll(BaseDir(), 0755); err != nil {
 		if util.IsPermissionError(err) {
-			return fmt.Errorf("failed to create registry dir: %w\n\n  ⚠️  Try: sudo homebutler install %s", err, app.Name)
+			return util.NewHintError(fmt.Errorf("failed to create registry dir: %w", err), "sudo homebutler install "+app.Name)
 		}
 		return err
 	}
 	if err := os.WriteFile(registryFile(), data, 0644); err != nil {
 		if util.IsPermissionError(err) {
-			return fmt.Errorf("failed to write install registry: %w\n\n  ⚠️  Try: sudo homebutler install %s", err, app.Name)
+			return util.NewHintError(fmt.Errorf("failed to write install registry: %w", err), "sudo homebutler install "+app.Name)
 		}
 		return err
 	}
@@ -60,7 +60,7 @@ func removeInstalled(appName string) error {
 	}
 	if err := os.WriteFile(registryFile(), data, 0644); err != nil {
 		if util.IsPermissionError(err) {
-			return fmt.Errorf("failed to update install registry: %w\n\n  ⚠️  Try: sudo homebutler uninstall %s", err, appName)
+			return util.NewHintError(fmt.Errorf("failed to update install registry: %w", err), "sudo homebutler uninstall "+appName)
 		}
 		return err
 	}
@@ -680,7 +680,7 @@ func Install(app App, opts InstallOptions) error {
 	// Create directories (only for real installs)
 	if err := os.MkdirAll(dataDir, 0755); err != nil {
 		if util.IsPermissionError(err) {
-			return fmt.Errorf("failed to create directory %s: %w\n\n  ⚠️  Try: sudo homebutler install %s", dataDir, err, app.Name)
+			return util.NewHintError(fmt.Errorf("failed to create directory %s: %w", dataDir, err), "sudo homebutler install "+app.Name)
 		}
 		return fmt.Errorf("failed to create directory %s: %w", dataDir, err)
 	}
@@ -689,7 +689,7 @@ func Install(app App, opts InstallOptions) error {
 	f, err := os.Create(composeFile)
 	if err != nil {
 		if util.IsPermissionError(err) {
-			return fmt.Errorf("failed to create %s: %w\n\n  ⚠️  Try: sudo homebutler install %s", composeFile, err, app.Name)
+			return util.NewHintError(fmt.Errorf("failed to create %s: %w", composeFile, err), "sudo homebutler install "+app.Name)
 		}
 		return fmt.Errorf("failed to create %s: %w", composeFile, err)
 	}

--- a/internal/remote/upgrade.go
+++ b/internal/remote/upgrade.go
@@ -21,6 +21,7 @@ type UpgradeResult struct {
 	NewVersion  string `json:"new_version"`
 	Status      string `json:"status"` // "upgraded", "up-to-date", "error"
 	Message     string `json:"message,omitempty"`
+	Error       error  `json:"-"`
 }
 
 // UpgradeReport is the overall upgrade result.
@@ -104,7 +105,8 @@ func SelfUpgrade(currentVersion, latestVersion string) *UpgradeResult {
 	if err := os.Rename(execPath, backupPath); err != nil {
 		result.Status = "error"
 		if util.IsPermissionError(err) {
-			result.Message = fmt.Sprintf("cannot backup current binary: %v\n\n  ⚠️  Try: sudo homebutler upgrade", err)
+			result.Error = util.NewHintError(fmt.Errorf("cannot backup current binary: %w", err), "sudo homebutler upgrade")
+			result.Message = util.FormatError(result.Error, true)
 		} else {
 			result.Message = fmt.Sprintf("cannot backup current binary: %v", err)
 		}
@@ -116,7 +118,8 @@ func SelfUpgrade(currentVersion, latestVersion string) *UpgradeResult {
 		os.Rename(backupPath, execPath)
 		result.Status = "error"
 		if util.IsPermissionError(err) {
-			result.Message = fmt.Sprintf("cannot write new binary: %v\n\n  ⚠️  Try: sudo homebutler upgrade", err)
+			result.Error = util.NewHintError(fmt.Errorf("cannot write new binary: %w", err), "sudo homebutler upgrade")
+			result.Message = util.FormatError(result.Error, true)
 		} else {
 			result.Message = fmt.Sprintf("cannot write new binary: %v", err)
 		}

--- a/internal/remote/upgrade.go
+++ b/internal/remote/upgrade.go
@@ -105,7 +105,7 @@ func SelfUpgrade(currentVersion, latestVersion string) *UpgradeResult {
 	if err := os.Rename(execPath, backupPath); err != nil {
 		result.Status = "error"
 		if util.IsPermissionError(err) {
-			result.Error = util.NewHintError(fmt.Errorf("cannot backup current binary: %w", err), "sudo homebutler upgrade")
+			result.Error = util.NewHintError("cannot backup current binary "+backupPath, err, "sudo homebutler upgrade")
 			result.Message = util.FormatError(result.Error, true)
 		} else {
 			result.Message = fmt.Sprintf("cannot backup current binary: %v", err)
@@ -118,7 +118,7 @@ func SelfUpgrade(currentVersion, latestVersion string) *UpgradeResult {
 		os.Rename(backupPath, execPath)
 		result.Status = "error"
 		if util.IsPermissionError(err) {
-			result.Error = util.NewHintError(fmt.Errorf("cannot write new binary: %w", err), "sudo homebutler upgrade")
+			result.Error = util.NewHintError("cannot write new binary "+execPath, err, "sudo homebutler upgrade")
 			result.Message = util.FormatError(result.Error, true)
 		} else {
 			result.Message = fmt.Sprintf("cannot write new binary: %v", err)

--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -1,0 +1,38 @@
+package util
+
+import (
+	"errors"
+	"fmt"
+)
+
+// HintError keeps an actionable suggestion separate from the underlying cause.
+type HintError struct {
+	Cause error
+	Hint  string
+}
+
+func (e *HintError) Error() string {
+	return fmt.Sprintf("%s\n\n  ⚠️  Try: %s", e.Cause, e.Hint)
+}
+
+func (e *HintError) Unwrap() error {
+	return e.Cause
+}
+
+// NewHintError associates an actionable suggestion with an error.
+func NewHintError(cause error, hint string) error {
+	return &HintError{Cause: cause, Hint: hint}
+}
+
+// FormatError returns the actionable message by default and the complete
+// cause plus hint when verbose output was requested.
+func FormatError(err error, verbose bool) string {
+	var hintErr *HintError
+	if errors.As(err, &hintErr) {
+		if verbose {
+			return hintErr.Error()
+		}
+		return "permission denied — rerun with: " + hintErr.Hint
+	}
+	return err.Error()
+}

--- a/internal/util/errors.go
+++ b/internal/util/errors.go
@@ -7,12 +7,13 @@ import (
 
 // HintError keeps an actionable suggestion separate from the underlying cause.
 type HintError struct {
+	Op    string
 	Cause error
 	Hint  string
 }
 
 func (e *HintError) Error() string {
-	return fmt.Sprintf("%s\n\n  ⚠️  Try: %s", e.Cause, e.Hint)
+	return fmt.Sprintf("%s: %v\n\n  ⚠️  Try: %s", e.Op, e.Cause, e.Hint)
 }
 
 func (e *HintError) Unwrap() error {
@@ -20,8 +21,8 @@ func (e *HintError) Unwrap() error {
 }
 
 // NewHintError associates an actionable suggestion with an error.
-func NewHintError(cause error, hint string) error {
-	return &HintError{Cause: cause, Hint: hint}
+func NewHintError(op string, cause error, hint string) error {
+	return &HintError{Op: op, Cause: cause, Hint: hint}
 }
 
 // FormatError returns the actionable message by default and the complete
@@ -32,7 +33,7 @@ func FormatError(err error, verbose bool) string {
 		if verbose {
 			return hintErr.Error()
 		}
-		return "permission denied — rerun with: " + hintErr.Hint
+		return hintErr.Op + " — rerun with: " + hintErr.Hint
 	}
 	return err.Error()
 }

--- a/internal/util/errors_test.go
+++ b/internal/util/errors_test.go
@@ -1,0 +1,33 @@
+package util
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+func TestFormatError(t *testing.T) {
+	cause := errors.New("rename /usr/local/bin/homebutler: permission denied")
+	err := NewHintError(cause, "sudo homebutler upgrade")
+
+	short := FormatError(err, false)
+	if short != "permission denied — rerun with: sudo homebutler upgrade" {
+		t.Fatalf("short error = %q", short)
+	}
+	verbose := FormatError(err, true)
+	if !strings.Contains(verbose, cause.Error()) || !strings.Contains(verbose, "sudo homebutler upgrade") {
+		t.Fatalf("verbose error = %q", verbose)
+	}
+	if !errors.Is(err, cause) {
+		t.Fatal("HintError does not unwrap its cause")
+	}
+}
+
+func TestFormatErrorWrapped(t *testing.T) {
+	err := NewHintError(errors.New("permission denied"), "sudo homebutler backup")
+	wrapped := fmt.Errorf("operation failed: %w", err)
+	if got := FormatError(wrapped, false); got != "permission denied — rerun with: sudo homebutler backup" {
+		t.Fatalf("wrapped short error = %q", got)
+	}
+}

--- a/internal/util/errors_test.go
+++ b/internal/util/errors_test.go
@@ -9,10 +9,10 @@ import (
 
 func TestFormatError(t *testing.T) {
 	cause := errors.New("rename /usr/local/bin/homebutler: permission denied")
-	err := NewHintError(cause, "sudo homebutler upgrade")
+	err := NewHintError("cannot backup current binary /usr/local/bin/homebutler.bak", cause, "sudo homebutler upgrade")
 
 	short := FormatError(err, false)
-	if short != "permission denied — rerun with: sudo homebutler upgrade" {
+	if short != "cannot backup current binary /usr/local/bin/homebutler.bak — rerun with: sudo homebutler upgrade" {
 		t.Fatalf("short error = %q", short)
 	}
 	verbose := FormatError(err, true)
@@ -25,9 +25,9 @@ func TestFormatError(t *testing.T) {
 }
 
 func TestFormatErrorWrapped(t *testing.T) {
-	err := NewHintError(errors.New("permission denied"), "sudo homebutler backup")
+	err := NewHintError("cannot create backup dir /mnt/nas/backups", errors.New("permission denied"), "sudo homebutler backup")
 	wrapped := fmt.Errorf("operation failed: %w", err)
-	if got := FormatError(wrapped, false); got != "permission denied — rerun with: sudo homebutler backup" {
+	if got := FormatError(wrapped, false); got != "cannot create backup dir /mnt/nas/backups — rerun with: sudo homebutler backup" {
 		t.Fatalf("wrapped short error = %q", got)
 	}
 }


### PR DESCRIPTION
Permission errors now lead with the actionable fix instead of the raw filesystem error.

The new global `--verbose/-v` flag preserves the full underlying error when more detail is needed. Structured hint errors are used consistently across backup, restore, install, and upgrade paths.

`--verbose` is preserved when forwarding commands to remote servers, while `--json` output remains unchanged.

Verification:
- `go test ./...`
- `go vet ./...`
- `golangci-lint run`
- `go build ./...`

close #45 