### PR TITLE
doctor: add read only Proxmox endpoint preflight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### ✨ Features
+
+- diagnose each configured Proxmox endpoint in `doctor` with read-only requests (#105). `doctor` said nothing about Proxmox before this; now every endpoint gets one finding, using the same `DefaultView` call `proxmox status` makes, so the two never disagree about what a token can reach. TLS, authentication, authorization, and transport failures stay distinguishable, and the action `doctor` prints never suggests widening a token to Administrator to make a check pass — it names the read-only PVEAuditor role instead
+
+### ⚠️ Behavior changes
+
+- **`doctor` now makes outbound network calls, one per configured Proxmox endpoint.** A host that is slow to answer or unreachable makes `doctor` take noticeably longer, and `--strict` cron jobs now exit non-zero for a Proxmox host that is merely rebooting or firewalled, not only for problems on the local machine
+
 ## [0.25.0](https://github.com/Higangssh/homebutler/compare/v0.24.0...v0.25.0) - 2026-09-02
 
 **Every permission failure homebutler can hit printed the operator's next command last.** `backup`, `restore`, `install` and `upgrade` all led with the raw syscall error and put the one line that mattered underneath it — and the detail could not simply be dropped, because there was no way to ask for it back. This release inverts the order and adds the flag that makes dropping it safe.

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ homebutler report --json
 
 - **Install apps** — deploy Uptime Kuma, Jellyfin, Pi-hole, Gitea, Portainer, and more with one command
 - **Map your server** — see containers, exposed ports, system ports, and service topology
-- **Run a doctor check** — diagnose resource pressure, stopped containers, public ports, backup hygiene, notifications, and report baseline readiness
+- **Run a doctor check** — diagnose resource pressure, stopped containers, public ports, backup hygiene, notifications, report baseline readiness, and configured Proxmox endpoint reachability
 - **Catch crashes** — save logs before/after Docker, systemd, or PM2 restarts and detect flapping loops
 - **Verify backups** — boot backups in isolated containers before you trust them
 - **See a Proxmox cluster** — nodes, QEMU and LXC guests, storage, and task status, with power actions that name their target explicitly
@@ -134,7 +134,7 @@ homebutler doctor --json            # automation / MCP friendly
   <img src="assets/doctor-card.svg" alt="homebutler doctor reporting a full disk, a stopped container, and a missing report baseline, each with the command to run next" width="700">
 </p>
 
-`doctor` is a read-only preflight for the problems homelab users usually discover too late: high disk or memory usage, stopped containers, public bind ports, stale or missing backups, missing notifications, and whether `report` has a baseline for change detection. Every finding names the next command to run, so `--strict` makes it usable from cron or CI.
+`doctor` is a read-only preflight for the problems homelab users usually discover too late: high disk or memory usage, stopped containers, public bind ports, stale or missing backups, missing notifications, whether `report` has a baseline for change detection, and whether each configured Proxmox endpoint is reachable with the token it has. Every finding names the next command to run, so `--strict` makes it usable from cron or CI — including a Proxmox host that is unreachable or rebooting.
 
 ### 🗂 Config Validation
 

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -17,7 +17,8 @@ func newDoctorCmd() *cobra.Command {
 		Short: "Diagnose homelab health, exposure, backups, and readiness",
 		Long: `Run a read-only diagnosis for the things that usually hurt self-hosted servers:
 resource pressure, stopped containers, public bind ports, backup hygiene,
-notification readiness, and report baseline status.`,
+notification readiness, report baseline status, and configured Proxmox
+endpoint reachability.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := loadConfig(); err != nil {
 				return err

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -78,7 +78,7 @@ Restart your AI client — homebutler tools will appear automatically.
 |--------------------------|------------------------------------------------------------------------------------------------------------------------|
 | `system_status`          | CPU, memory, disk, uptime                                                                                              |
 | `report`                 | Butler-style health report with snapshot comparison and suggested actions                                              |
-| `doctor`                 | Read-only diagnosis of resource pressure, stopped containers, public ports, backup hygiene, and notification readiness |
+| `doctor`                 | Read-only diagnosis of resource pressure, stopped containers, public ports, backup hygiene, notification readiness, and configured Proxmox endpoint reachability |
 | `watch_check`            | One-shot restart check on watched targets; reports systemd and pm2 targets as skipped rather than healthy              |
 | `watch_history`          | Recorded restart incidents, newest first. Captured logs are excluded unless `include_logs` is set                      |
 | `watch_list`             | Targets being watched, with their kind and what the last check recorded                                                |

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 	"github.com/Higangssh/homebutler/internal/config"
 	"github.com/Higangssh/homebutler/internal/inventory"
 	"github.com/Higangssh/homebutler/internal/ports"
+	"github.com/Higangssh/homebutler/internal/proxmox"
 	"github.com/Higangssh/homebutler/internal/style"
 	"github.com/charmbracelet/lipgloss"
 )
@@ -62,18 +64,34 @@ type Options struct {
 
 // CollectFuncs allows tests to inject data sources.
 type CollectFuncs struct {
-	InventoryFns inventory.CollectFuncs
-	BackupListFn func(string) ([]backup.ListEntry, error)
-	SnapshotDir  string
+	InventoryFns  inventory.CollectFuncs
+	BackupListFn  func(string) ([]backup.ListEntry, error)
+	SnapshotDir   string
+	ProxmoxOpenFn func(config.ProxmoxConfig) (*proxmox.Client, error)
 }
 
 // DefaultCollectFuncs returns real doctor data sources.
 func DefaultCollectFuncs() CollectFuncs {
 	return CollectFuncs{
-		InventoryFns: inventory.DefaultCollectFuncs(),
-		BackupListFn: backup.List,
-		SnapshotDir:  defaultSnapshotDir(),
+		InventoryFns:  inventory.DefaultCollectFuncs(),
+		BackupListFn:  backup.List,
+		SnapshotDir:   defaultSnapshotDir(),
+		ProxmoxOpenFn: openProxmoxEndpoint,
 	}
+}
+
+// openProxmoxEndpoint resolves the token and builds a client the same way the
+// proxmox commands do, so doctor and proxmox status never disagree about what
+// a configured endpoint accepts.
+func openProxmoxEndpoint(endpoint config.ProxmoxConfig) (*proxmox.Client, error) {
+	token, err := endpoint.TokenValue()
+	if err != nil {
+		return nil, err
+	}
+	return proxmox.New(proxmox.Options{
+		Host: endpoint.Host, Port: endpoint.APIPort(), TokenID: endpoint.TokenID, Token: token,
+		Fingerprint: endpoint.Fingerprint, CAFile: endpoint.CAFile, Insecure: endpoint.Insecure, Timeout: endpoint.TimeoutDuration(),
+	})
 }
 
 // Run performs a read-only health and readiness diagnosis.
@@ -89,6 +107,9 @@ func Run(cfg *config.Config, fns CollectFuncs, opts Options) (*Result, error) {
 	}
 	if fns.SnapshotDir == "" {
 		fns.SnapshotDir = defaultSnapshotDir()
+	}
+	if fns.ProxmoxOpenFn == nil {
+		fns.ProxmoxOpenFn = openProxmoxEndpoint
 	}
 
 	inv, err := inventory.Collect(cfg, fns.InventoryFns)
@@ -109,6 +130,7 @@ func Run(cfg *config.Config, fns CollectFuncs, opts Options) (*Result, error) {
 	checkBackups(r, cfg, fns.BackupListFn, opts)
 	checkNotifications(r, cfg)
 	checkReportBaseline(r, fns.SnapshotDir)
+	checkProxmox(r, cfg, fns.ProxmoxOpenFn)
 
 	if len(r.Findings) == 0 {
 		r.Findings = append(r.Findings, Finding{
@@ -302,6 +324,87 @@ func checkReportBaseline(r *Result, snapshotDir string) {
 		}
 	}
 	r.add(SeverityWarn, "report", "No report baseline yet", "Snapshot directory exists, but no report snapshots were found.", "Run report once so homebutler can notice what changes later.", "homebutler report")
+}
+
+// checkProxmox diagnoses each configured Proxmox endpoint with read-only
+// requests. It reports one finding per endpoint and keeps TLS, authentication,
+// authorization, and transport failures distinguishable rather than
+// collapsing them into a single "unavailable" result, per #105 and #111.
+func checkProxmox(r *Result, cfg *config.Config, openFn func(config.ProxmoxConfig) (*proxmox.Client, error)) {
+	if cfg == nil || len(cfg.Proxmox) == 0 {
+		return
+	}
+	for _, endpoint := range cfg.Proxmox {
+		command := "homebutler proxmox status --endpoint " + endpoint.Name
+		client, err := openFn(endpoint)
+		if err != nil {
+			r.add(SeverityFail, "proxmox", fmt.Sprintf("Proxmox endpoint %q could not be configured", endpoint.Name), err.Error(), proxmoxFailureAction(err), command)
+			continue
+		}
+		checkProxmoxEndpoint(r, endpoint.Name, client, command)
+	}
+}
+
+type proxmoxCollector struct {
+	name  string
+	err   error
+	empty bool
+}
+
+func checkProxmoxEndpoint(r *Result, name string, client *proxmox.Client, command string) {
+	ctx := context.Background()
+
+	var collectors []proxmoxCollector
+	_, err := client.Version(ctx)
+	collectors = append(collectors, proxmoxCollector{name: "version", err: err})
+	_, err = client.ClusterStatus(ctx)
+	collectors = append(collectors, proxmoxCollector{name: "cluster status", err: err})
+	resources, err := client.Resources(ctx)
+	empty := err == nil && len(resources.Nodes) == 0 && len(resources.Guests) == 0 && len(resources.Storage) == 0
+	collectors = append(collectors, proxmoxCollector{name: "resources", err: err, empty: empty})
+
+	var failed, empties []string
+	var firstErr error
+	for _, c := range collectors {
+		switch {
+		case c.err != nil:
+			failed = append(failed, fmt.Sprintf("%s: %s", c.name, c.err.Error()))
+			if firstErr == nil {
+				firstErr = c.err
+			}
+		case c.empty:
+			empties = append(empties, c.name)
+		}
+	}
+
+	switch {
+	case len(failed) == len(collectors):
+		r.add(SeverityFail, "proxmox", fmt.Sprintf("Proxmox endpoint %q has no readable collectors", name), strings.Join(failed, "; "), proxmoxFailureAction(firstErr), command)
+	case len(failed) > 0:
+		r.add(SeverityWarn, "proxmox", fmt.Sprintf("Proxmox endpoint %q is only partially readable", name), strings.Join(failed, "; "), proxmoxFailureAction(firstErr), command)
+	case len(empties) > 0:
+		r.add(SeverityPass, "proxmox", fmt.Sprintf("Proxmox endpoint %q is reachable", name), fmt.Sprintf("%s returned no data; that may be correct, or the token's ACL may only grant access to specific resources.", strings.Join(empties, ", ")), "", "")
+	default:
+		r.add(SeverityPass, "proxmox", fmt.Sprintf("Proxmox endpoint %q is fully readable", name), "Version, cluster status, and resources all responded.", "", "")
+	}
+}
+
+// proxmoxFailureAction turns a classified Proxmox error into what the
+// operator can safely inspect or correct. It must never suggest widening a
+// token to Administrator just to make a check pass (#105).
+func proxmoxFailureAction(err error) string {
+	switch proxmox.Classify(err) {
+	case proxmox.FailureTLS:
+		return "Check the configured certificate trust: the fingerprint or CA file against the endpoint's actual certificate."
+	case proxmox.FailureAuthentication:
+		return "Check the token ID, the token value, and the token file's ownership and permissions; the token may be missing, unreadable, or revoked."
+	case proxmox.FailureAuthorization:
+		return "Check that the read-only PVEAuditor role is applied to both the API user and the privilege-separated token. Do not grant Administrator to make this pass."
+	case proxmox.FailureTransport:
+		return "Check network reachability to the configured host and port, and any firewall rules in between."
+	default:
+		return "Run homebutler proxmox status for the full error."
+	}
 }
 
 func (r *Result) add(severity, category, title, detail, action, command string) {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -335,7 +335,7 @@ func checkProxmox(r *Result, cfg *config.Config, openFn func(config.ProxmoxConfi
 		return
 	}
 	for _, endpoint := range cfg.Proxmox {
-		command := "homebutler proxmox status --endpoint " + endpoint.Name
+		command := fmt.Sprintf("homebutler proxmox status --endpoint %q", endpoint.Name)
 		client, err := openFn(endpoint)
 		if err != nil {
 			r.add(SeverityFail, "proxmox", fmt.Sprintf("Proxmox endpoint %q could not be configured", endpoint.Name), err.Error(), proxmoxFailureAction(err), command)
@@ -345,45 +345,22 @@ func checkProxmox(r *Result, cfg *config.Config, openFn func(config.ProxmoxConfi
 	}
 }
 
-type proxmoxCollector struct {
-	name  string
-	err   error
-	empty bool
-}
-
+// checkProxmoxEndpoint calls the same DefaultView the proxmox status command
+// renders, so the two never disagree about what a token can reach: an empty
+// resources collector is a failed collector here exactly as it is there,
+// not a doctor-only pass.
 func checkProxmoxEndpoint(r *Result, name string, client *proxmox.Client, command string) {
-	ctx := context.Background()
+	view, _ := client.DefaultView(context.Background())
 
-	var collectors []proxmoxCollector
-	_, err := client.Version(ctx)
-	collectors = append(collectors, proxmoxCollector{name: "version", err: err})
-	_, err = client.ClusterStatus(ctx)
-	collectors = append(collectors, proxmoxCollector{name: "cluster status", err: err})
-	resources, err := client.Resources(ctx)
-	empty := err == nil && len(resources.Nodes) == 0 && len(resources.Guests) == 0 && len(resources.Storage) == 0
-	collectors = append(collectors, proxmoxCollector{name: "resources", err: err, empty: empty})
-
-	var failed, empties []string
-	var firstErr error
-	for _, c := range collectors {
-		switch {
-		case c.err != nil:
-			failed = append(failed, fmt.Sprintf("%s: %s", c.name, c.err.Error()))
-			if firstErr == nil {
-				firstErr = c.err
-			}
-		case c.empty:
-			empties = append(empties, c.name)
-		}
-	}
+	allFailed := view.CollectorFailed(proxmox.CollectorVersion) &&
+		view.CollectorFailed(proxmox.CollectorCluster) &&
+		view.CollectorFailed(proxmox.CollectorResources)
 
 	switch {
-	case len(failed) == len(collectors):
-		r.add(SeverityFail, "proxmox", fmt.Sprintf("Proxmox endpoint %q has no readable collectors", name), strings.Join(failed, "; "), proxmoxFailureAction(firstErr), command)
-	case len(failed) > 0:
-		r.add(SeverityWarn, "proxmox", fmt.Sprintf("Proxmox endpoint %q is only partially readable", name), strings.Join(failed, "; "), proxmoxFailureAction(firstErr), command)
-	case len(empties) > 0:
-		r.add(SeverityPass, "proxmox", fmt.Sprintf("Proxmox endpoint %q is reachable", name), fmt.Sprintf("%s returned no data; that may be correct, or the token's ACL may only grant access to specific resources.", strings.Join(empties, ", ")), "", "")
+	case allFailed:
+		r.add(SeverityFail, "proxmox", fmt.Sprintf("Proxmox endpoint %q has no readable collectors", name), strings.Join(view.Warnings, "; "), proxmoxFailureAction(view.FirstErr), command)
+	case len(view.Failed) > 0:
+		r.add(SeverityWarn, "proxmox", fmt.Sprintf("Proxmox endpoint %q is only partially readable", name), strings.Join(view.Warnings, "; "), proxmoxFailureAction(view.FirstErr), command)
 	default:
 		r.add(SeverityPass, "proxmox", fmt.Sprintf("Proxmox endpoint %q is fully readable", name), "Version, cluster status, and resources all responded.", "", "")
 	}

--- a/internal/doctor/doctor_proxmox_test.go
+++ b/internal/doctor/doctor_proxmox_test.go
@@ -1,0 +1,170 @@
+package doctor
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/Higangssh/homebutler/internal/config"
+	"github.com/Higangssh/homebutler/internal/proxmox"
+)
+
+// startProxmoxServer starts a TLS test server and returns the host/port a
+// proxmox.Client can dial with Insecure: true, matching how the real client
+// talks to a self-signed Proxmox endpoint.
+func startProxmoxServer(t *testing.T, handler http.HandlerFunc) (string, int) {
+	t.Helper()
+	server := httptest.NewTLSServer(handler)
+	t.Cleanup(server.Close)
+
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	host, portStr, err := net.SplitHostPort(u.Host)
+	if err != nil {
+		t.Fatalf("split host/port: %v", err)
+	}
+	port, err := strconv.Atoi(portStr)
+	if err != nil {
+		t.Fatalf("parse port: %v", err)
+	}
+	return host, port
+}
+
+func openFnFor(host string, port int) func(config.ProxmoxConfig) (*proxmox.Client, error) {
+	return func(config.ProxmoxConfig) (*proxmox.Client, error) {
+		return proxmox.New(proxmox.Options{Host: host, Port: port, TokenID: "monitoring@pve!readonly", Token: "fixture-token", Insecure: true})
+	}
+}
+
+func envelope(data string) string {
+	return fmt.Sprintf(`{"data": %s}`, data)
+}
+
+func TestCheckProxmox_FullyReadable(t *testing.T) {
+	host, port := startProxmoxServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api2/json/version":
+			fmt.Fprint(w, envelope(`{"version":"9.0","release":"9.0"}`))
+		case "/api2/json/cluster/status":
+			fmt.Fprint(w, envelope(`[]`))
+		case "/api2/json/cluster/resources":
+			fmt.Fprint(w, envelope(`[{"type":"node","name":"pve1","status":"online"}]`))
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	cfg := &config.Config{Proxmox: []config.ProxmoxConfig{{Name: "home"}}}
+	r := &Result{}
+	checkProxmox(r, cfg, openFnFor(host, port))
+
+	f := findTitle(r.Findings, `Proxmox endpoint "home" is fully readable`)
+	if f == nil || f.Severity != SeverityPass {
+		t.Fatalf("expected pass finding, got: %#v", r.Findings)
+	}
+}
+
+func TestCheckProxmox_EmptyResourcesIsNotAFailure(t *testing.T) {
+	host, port := startProxmoxServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api2/json/version":
+			fmt.Fprint(w, envelope(`{"version":"9.0","release":"9.0"}`))
+		case "/api2/json/cluster/status":
+			fmt.Fprint(w, envelope(`[]`))
+		case "/api2/json/cluster/resources":
+			fmt.Fprint(w, envelope(`[]`))
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	cfg := &config.Config{Proxmox: []config.ProxmoxConfig{{Name: "home"}}}
+	r := &Result{}
+	checkProxmox(r, cfg, openFnFor(host, port))
+
+	f := findTitle(r.Findings, `Proxmox endpoint "home" is reachable`)
+	if f == nil || f.Severity != SeverityPass {
+		t.Fatalf("expected pass finding for valid empty result, got: %#v", r.Findings)
+	}
+	if !strings.Contains(f.Detail, "resources") {
+		t.Fatalf("expected detail to name the empty collector, got: %q", f.Detail)
+	}
+}
+
+func TestCheckProxmox_PartialCollectorFailureIsWarn(t *testing.T) {
+	host, port := startProxmoxServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/api2/json/version":
+			fmt.Fprint(w, envelope(`{"version":"9.0","release":"9.0"}`))
+		case "/api2/json/cluster/status":
+			http.Error(w, "Permission check failed (/, Sys.Audit)", http.StatusForbidden)
+		case "/api2/json/cluster/resources":
+			fmt.Fprint(w, envelope(`[{"type":"node","name":"pve1","status":"online"}]`))
+		default:
+			http.NotFound(w, r)
+		}
+	})
+
+	cfg := &config.Config{Proxmox: []config.ProxmoxConfig{{Name: "home"}}}
+	r := &Result{}
+	checkProxmox(r, cfg, openFnFor(host, port))
+
+	f := findTitle(r.Findings, `Proxmox endpoint "home" is only partially readable`)
+	if f == nil || f.Severity != SeverityWarn {
+		t.Fatalf("expected warn finding, got: %#v", r.Findings)
+	}
+	if !strings.Contains(f.Action, "PVEAuditor") || !strings.Contains(f.Action, "Do not grant Administrator") {
+		t.Fatalf("expected authorization action naming PVEAuditor and warning against Administrator, got: %q", f.Action)
+	}
+}
+
+func TestCheckProxmox_NoReadableCollectorsIsFail(t *testing.T) {
+	host, port := startProxmoxServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "authentication failure", http.StatusUnauthorized)
+	})
+
+	cfg := &config.Config{Proxmox: []config.ProxmoxConfig{{Name: "home"}}}
+	r := &Result{}
+	checkProxmox(r, cfg, openFnFor(host, port))
+
+	f := findTitle(r.Findings, `Proxmox endpoint "home" has no readable collectors`)
+	if f == nil || f.Severity != SeverityFail {
+		t.Fatalf("expected fail finding, got: %#v", r.Findings)
+	}
+	if !strings.Contains(f.Action, "token") {
+		t.Fatalf("expected authentication action naming the token, got: %q", f.Action)
+	}
+}
+
+func TestCheckProxmox_TokenFileUnreadableIsFail(t *testing.T) {
+	cfg := &config.Config{Proxmox: []config.ProxmoxConfig{{Name: "home", TokenFile: "/does/not/exist"}}}
+	r := &Result{}
+	checkProxmox(r, cfg, openProxmoxEndpoint)
+
+	f := findTitle(r.Findings, `Proxmox endpoint "home" could not be configured`)
+	if f == nil || f.Severity != SeverityFail {
+		t.Fatalf("expected fail finding for unreadable token file, got: %#v", r.Findings)
+	}
+	if strings.Contains(f.Detail, "fixture-token") {
+		t.Fatalf("finding must not contain a token value: %q", f.Detail)
+	}
+}
+
+func TestCheckProxmox_NoEndpointsIsSilent(t *testing.T) {
+	r := &Result{}
+	checkProxmox(r, &config.Config{}, openProxmoxEndpoint)
+	if len(r.Findings) != 0 {
+		t.Fatalf("expected no findings without configured endpoints, got: %#v", r.Findings)
+	}
+	checkProxmox(r, nil, openProxmoxEndpoint)
+	if len(r.Findings) != 0 {
+		t.Fatalf("expected no findings for nil config, got: %#v", r.Findings)
+	}
+}

--- a/internal/doctor/doctor_proxmox_test.go
+++ b/internal/doctor/doctor_proxmox_test.go
@@ -6,6 +6,9 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -71,7 +74,12 @@ func TestCheckProxmox_FullyReadable(t *testing.T) {
 	}
 }
 
-func TestCheckProxmox_EmptyResourcesIsNotAFailure(t *testing.T) {
+// An empty resources response is a warning, not a pass: proxmox status and
+// the resources collector it shares with doctor both treat "no nodes, no
+// guests, no storage" as a collector that failed to prove anything, usually
+// an ACL-limited token rather than a genuinely empty cluster. doctor must
+// agree, or the two commands disagree about the same endpoint.
+func TestCheckProxmox_EmptyResourcesIsWarn(t *testing.T) {
 	host, port := startProxmoxServer(t, func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/api2/json/version":
@@ -89,12 +97,12 @@ func TestCheckProxmox_EmptyResourcesIsNotAFailure(t *testing.T) {
 	r := &Result{}
 	checkProxmox(r, cfg, openFnFor(host, port))
 
-	f := findTitle(r.Findings, `Proxmox endpoint "home" is reachable`)
-	if f == nil || f.Severity != SeverityPass {
-		t.Fatalf("expected pass finding for valid empty result, got: %#v", r.Findings)
+	f := findTitle(r.Findings, `Proxmox endpoint "home" is only partially readable`)
+	if f == nil || f.Severity != SeverityWarn {
+		t.Fatalf("expected warn finding for a token that sees no resources, got: %#v", r.Findings)
 	}
-	if !strings.Contains(f.Detail, "resources") {
-		t.Fatalf("expected detail to name the empty collector, got: %q", f.Detail)
+	if !strings.Contains(f.Detail, "resources") || !strings.Contains(f.Detail, "token permissions") {
+		t.Fatalf("expected detail to name the empty collector and point at token permissions, got: %q", f.Detail)
 	}
 }
 
@@ -144,7 +152,22 @@ func TestCheckProxmox_NoReadableCollectorsIsFail(t *testing.T) {
 }
 
 func TestCheckProxmox_TokenFileUnreadableIsFail(t *testing.T) {
-	cfg := &config.Config{Proxmox: []config.ProxmoxConfig{{Name: "home", TokenFile: "/does/not/exist"}}}
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are not enforced the same way on Windows")
+	}
+
+	dir := t.TempDir()
+	tokenFile := filepath.Join(dir, "token")
+	const secret = "should-never-appear-in-a-finding"
+	if err := os.WriteFile(tokenFile, []byte(secret), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(tokenFile, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(tokenFile, 0o600) })
+
+	cfg := &config.Config{Proxmox: []config.ProxmoxConfig{{Name: "home", TokenFile: tokenFile}}}
 	r := &Result{}
 	checkProxmox(r, cfg, openProxmoxEndpoint)
 
@@ -152,7 +175,7 @@ func TestCheckProxmox_TokenFileUnreadableIsFail(t *testing.T) {
 	if f == nil || f.Severity != SeverityFail {
 		t.Fatalf("expected fail finding for unreadable token file, got: %#v", r.Findings)
 	}
-	if strings.Contains(f.Detail, "fixture-token") {
+	if strings.Contains(f.Detail, secret) {
 		t.Fatalf("finding must not contain a token value: %q", f.Detail)
 	}
 }

--- a/internal/proxmox/client.go
+++ b/internal/proxmox/client.go
@@ -170,11 +170,11 @@ func tlsConfig(options Options) (*tls.Config, error) {
 	if options.CAFile != "" {
 		pem, err := os.ReadFile(options.CAFile)
 		if err != nil {
-			return nil, WithFailureClass(FailureAuthentication, fmt.Errorf("read Proxmox CA file: %w", err))
+			return nil, WithFailureClass(FailureTLS, fmt.Errorf("read Proxmox CA file: %w", err))
 		}
 		pool := x509.NewCertPool()
 		if !pool.AppendCertsFromPEM(pem) {
-			return nil, WithFailureClass(FailureAuthentication, fmt.Errorf("proxmox CA file contains no certificates"))
+			return nil, WithFailureClass(FailureTLS, fmt.Errorf("proxmox CA file contains no certificates"))
 		}
 		config.RootCAs = pool
 		return config, nil
@@ -190,7 +190,7 @@ func parseFingerprint(value string) ([]byte, error) {
 	value = strings.ReplaceAll(strings.TrimSpace(value), ":", "")
 	fingerprint, err := hex.DecodeString(value)
 	if err != nil || len(fingerprint) != sha256.Size {
-		return nil, WithFailureClass(FailureAuthentication, fmt.Errorf("proxmox fingerprint must be a SHA-256 certificate fingerprint"))
+		return nil, WithFailureClass(FailureTLS, fmt.Errorf("proxmox fingerprint must be a SHA-256 certificate fingerprint"))
 	}
 	return fingerprint, nil
 }
@@ -342,31 +342,65 @@ func TaskResult(status, exitStatus string) string {
 	return "unknown"
 }
 
-// DefaultView performs the three requests used by the default status view.
+// DefaultView performs the three requests used by the default status view. A
+// FailureTransport on one collector means the host is not answering at all,
+// so the remaining collectors are skipped rather than each re-paying the same
+// dial timeout for no new information.
 func (c *Client) DefaultView(ctx context.Context) (DefaultView, error) {
 	view := DefaultView{}
-	if version, err := c.Version(ctx); err != nil {
-		view.Warnings = append(view.Warnings, "version: "+err.Error())
-		view.Failed = append(view.Failed, CollectorVersion)
+
+	version, err := c.Version(ctx)
+	if err != nil {
+		view.fail(CollectorVersion, err)
+		if Classify(err) == FailureTransport {
+			view.skip(CollectorCluster, CollectorResources)
+			return view, nil
+		}
 	} else {
 		view.Version = version
 	}
-	if cluster, err := c.ClusterStatus(ctx); err != nil {
-		view.Warnings = append(view.Warnings, "cluster: "+err.Error())
-		view.Failed = append(view.Failed, CollectorCluster)
+
+	cluster, err := c.ClusterStatus(ctx)
+	if err != nil {
+		view.fail(CollectorCluster, err)
+		if Classify(err) == FailureTransport {
+			view.skip(CollectorResources)
+			return view, nil
+		}
 	} else {
 		view.Cluster = cluster
 	}
+
 	if resources, err := c.Resources(ctx); err != nil {
-		view.Warnings = append(view.Warnings, "resources: "+err.Error())
-		view.Failed = append(view.Failed, CollectorResources)
+		view.fail(CollectorResources, err)
 	} else if len(resources.Nodes) == 0 && len(resources.Guests) == 0 && len(resources.Storage) == 0 {
 		view.Warnings = append(view.Warnings, "resources: no resources visible; check Proxmox token permissions")
 		view.Failed = append(view.Failed, CollectorResources)
 	} else {
 		view.Resources = resources
 	}
+
 	return view, nil
+}
+
+// fail records a collector's failure and keeps the first error whose class
+// can actually guide the operator: a later classified error (say, resources
+// coming back 403 after version failed to decode for an unrelated reason)
+// outranks an earlier unclassified one, since only the classified error
+// produces an action worth acting on.
+func (v *DefaultView) fail(collector string, err error) {
+	v.Warnings = append(v.Warnings, collector+": "+err.Error())
+	v.Failed = append(v.Failed, collector)
+	if v.FirstErr == nil || (Classify(v.FirstErr) == "" && Classify(err) != "") {
+		v.FirstErr = err
+	}
+}
+
+// skip marks collectors that were never attempted as failed, so callers
+// rendering per-collector status (writeProxmoxStatus, doctor) show them as
+// unavailable instead of a misleadingly empty success.
+func (v *DefaultView) skip(collectors ...string) {
+	v.Failed = append(v.Failed, collectors...)
 }
 
 func (c *Client) get(ctx context.Context, path string, query url.Values, out any) error {

--- a/internal/proxmox/client_test.go
+++ b/internal/proxmox/client_test.go
@@ -7,6 +7,8 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"errors"
+	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -136,6 +138,38 @@ func TestDefaultViewFlagsNoVisibleResources(t *testing.T) {
 	}
 	if !view.CollectorFailed(CollectorResources) || len(view.Warnings) != 1 || !strings.Contains(view.Warnings[0], "token permissions") {
 		t.Fatalf("DefaultView() = %#v", view)
+	}
+}
+
+// countingRoundTripper always fails, so it stands in for a host that never
+// answers: every request pays the same dial timeout.
+type countingRoundTripper struct {
+	calls int
+	err   error
+}
+
+func (t *countingRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	t.calls++
+	return nil, t.err
+}
+
+func TestDefaultViewStopsAfterTransportFailure(t *testing.T) {
+	client := testClient(t, "https://pve.example")
+	transport := &countingRoundTripper{err: &net.OpError{Op: "dial", Net: "tcp", Err: fmt.Errorf("connection refused")}}
+	client.http.Transport = transport
+
+	view, err := client.DefaultView(context.Background())
+	if err != nil {
+		t.Fatalf("DefaultView() error: %v", err)
+	}
+	if transport.calls != 1 {
+		t.Fatalf("expected one request before DefaultView gave up, got %d", transport.calls)
+	}
+	if !view.CollectorFailed(CollectorVersion) || !view.CollectorFailed(CollectorCluster) || !view.CollectorFailed(CollectorResources) {
+		t.Fatalf("expected every collector marked failed once the host is unreachable, got: %#v", view.Failed)
+	}
+	if Classify(view.FirstErr) != FailureTransport {
+		t.Fatalf("FirstErr class = %q, want %q", Classify(view.FirstErr), FailureTransport)
 	}
 }
 
@@ -487,16 +521,21 @@ func TestTLSModes(t *testing.T) {
 
 func TestFailureClassification(t *testing.T) {
 	t.Run("CA file unreadable", func(t *testing.T) {
+		// A missing or unreadable CA file is a certificate trust problem, not
+		// a credential problem: the token is never even read. Classifying it
+		// FailureAuthentication sent an operator staring at a fine token
+		// while pointing at "the token may be missing, unreadable, or
+		// revoked" instead of the ca_file setting that is actually wrong.
 		_, err := New(Options{Host: "pve.example", TokenID: "id", Token: "secret", CAFile: "missing.pem"})
-		if Classify(err) != FailureAuthentication {
-			t.Fatalf("Classify(%v) = %q, want %q", err, Classify(err), FailureAuthentication)
+		if Classify(err) != FailureTLS {
+			t.Fatalf("Classify(%v) = %q, want %q", err, Classify(err), FailureTLS)
 		}
 	})
 
 	t.Run("fingerprint format", func(t *testing.T) {
 		_, err := New(Options{Host: "pve.example", TokenID: "id", Token: "secret", Fingerprint: "not-hex"})
-		if Classify(err) != FailureAuthentication {
-			t.Fatalf("Classify(%v) = %q, want %q", err, Classify(err), FailureAuthentication)
+		if Classify(err) != FailureTLS {
+			t.Fatalf("Classify(%v) = %q, want %q", err, Classify(err), FailureTLS)
 		}
 	})
 

--- a/internal/proxmox/types.go
+++ b/internal/proxmox/types.go
@@ -286,6 +286,9 @@ type DefaultView struct {
 	// which points to an ACL-limited token rather than a genuinely empty
 	// cluster.
 	Failed []string `json:"failed_collectors,omitempty"`
+	// FirstErr is the first classified collector error, for callers that
+	// branch on FailureClass rather than display text. Not serialized.
+	FirstErr error `json:"-"`
 }
 
 // Collector names recorded in DefaultView.Failed.


### PR DESCRIPTION
## Summary

doctor now checks each configured Proxmox endpoint using read only requests (version, cluster status, resources) and reports one finding per endpoint. TLS, authentication, authorization, and transport failures stay distinguishable instead of collapsing into a single unavailable result, and a valid but empty response is never treated as a failure.

Authorization findings point at the read only PVEAuditor role and never suggest widening a token to Administrator to make a check pass.

Builds on the failure classification merged in #120 (#111).

## Test plan

- [x] gofmt -w .
- [x] go vet ./...
- [x] golangci-lint run
- [x] go test ./...
- [x] go build ./...

Closes #105