### PR TITLE
watch: add read-only Proxmox endpoint and guest-state incidents

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,13 @@ thresholds, and runs any remediation rules you have configured — one process,
 one set of notification providers. `alerts --watch` still exists and does the
 threshold half on its own.
 
+Every endpoint under `proxmox:` in your config is polled too: unreachable or
+ACL-filtered endpoints and any guest listed under that endpoint's `guests:`
+report one incident when the problem starts and one recovery incident when it
+clears. A guest not listed there is observational only — `watch start` never
+alerts on it, deliberately stopped or not. See
+[Proxmox setup →](docs/proxmox.md#watch-integration) for the `guests:` field.
+
 When a crash is detected, you'll see:
 
 ```

--- a/cmd/proxmox.go
+++ b/cmd/proxmox.go
@@ -25,26 +25,32 @@ func buildProxmoxTargets() []watch.ProxmoxTarget {
 	}
 	targets := make([]watch.ProxmoxTarget, 0, len(cfg.Proxmox))
 	for _, endpoint := range cfg.Proxmox {
+		guests := make([]proxmox.ExpectedGuest, 0, len(endpoint.Guests))
 		for _, guest := range endpoint.Guests {
 			if err := guest.Validate(); err != nil {
 				fmt.Fprintf(os.Stderr, "warning: proxmox endpoint %q: %v\n", endpoint.Name, err)
+				continue
 			}
+			guests = append(guests, guest)
 		}
 
-		token, err := endpoint.TokenValue()
+		newClient := func() (*proxmox.Client, error) {
+			token, err := endpoint.TokenValue()
+			if err != nil {
+				return nil, err
+			}
+			return proxmox.New(proxmox.Options{
+				Host: endpoint.Host, Port: endpoint.APIPort(), TokenID: endpoint.TokenID, Token: token,
+				Fingerprint: endpoint.Fingerprint, CAFile: endpoint.CAFile, Insecure: endpoint.Insecure, Timeout: endpoint.TimeoutDuration(),
+			})
+		}
+		client, err := newClient()
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "warning: proxmox endpoint %q: %v\n", endpoint.Name, err)
+			targets = append(targets, watch.ProxmoxTarget{Endpoint: endpoint.Name, Err: err, NewClient: newClient, Guests: guests})
 			continue
 		}
-		client, err := proxmox.New(proxmox.Options{
-			Host: endpoint.Host, Port: endpoint.APIPort(), TokenID: endpoint.TokenID, Token: token,
-			Fingerprint: endpoint.Fingerprint, CAFile: endpoint.CAFile, Insecure: endpoint.Insecure, Timeout: endpoint.TimeoutDuration(),
-		})
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "warning: proxmox endpoint %q: %v\n", endpoint.Name, err)
-			continue
-		}
-		targets = append(targets, watch.ProxmoxTarget{Endpoint: endpoint.Name, Client: client, Guests: endpoint.Guests})
+		targets = append(targets, watch.ProxmoxTarget{Endpoint: endpoint.Name, Client: client, NewClient: newClient, Guests: guests})
 	}
 	return targets
 }

--- a/cmd/proxmox.go
+++ b/cmd/proxmox.go
@@ -4,12 +4,50 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/Higangssh/homebutler/internal/config"
 	"github.com/Higangssh/homebutler/internal/proxmox"
+	"github.com/Higangssh/homebutler/internal/watch"
 	"github.com/spf13/cobra"
 )
+
+// buildProxmoxTargets turns the global config's Proxmox endpoints into
+// ProxmoxMonitor targets for `watch start`. An endpoint whose client cannot
+// be built (bad token file, invalid TLS setting) is skipped with a warning
+// rather than aborting the whole monitoring run over one misconfigured
+// endpoint — the same tolerance `watch start` already gives an empty target
+// list.
+func buildProxmoxTargets() []watch.ProxmoxTarget {
+	if cfg == nil {
+		return nil
+	}
+	targets := make([]watch.ProxmoxTarget, 0, len(cfg.Proxmox))
+	for _, endpoint := range cfg.Proxmox {
+		for _, guest := range endpoint.Guests {
+			if err := guest.Validate(); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: proxmox endpoint %q: %v\n", endpoint.Name, err)
+			}
+		}
+
+		token, err := endpoint.TokenValue()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: proxmox endpoint %q: %v\n", endpoint.Name, err)
+			continue
+		}
+		client, err := proxmox.New(proxmox.Options{
+			Host: endpoint.Host, Port: endpoint.APIPort(), TokenID: endpoint.TokenID, Token: token,
+			Fingerprint: endpoint.Fingerprint, CAFile: endpoint.CAFile, Insecure: endpoint.Insecure, Timeout: endpoint.TimeoutDuration(),
+		})
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "warning: proxmox endpoint %q: %v\n", endpoint.Name, err)
+			continue
+		}
+		targets = append(targets, watch.ProxmoxTarget{Endpoint: endpoint.Name, Client: client, Guests: endpoint.Guests})
+	}
+	return targets
+}
 
 func newProxmoxCmd() *cobra.Command {
 	cmd := &cobra.Command{

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -522,6 +522,20 @@ Docker targets use docker events (real-time). Systemd and PM2 targets use pollin
 				}()
 			}
 
+			proxmoxTargets := buildProxmoxTargets()
+			if len(proxmoxTargets) > 0 {
+				monitorCount++
+				wg.Add(1)
+				proxmoxMon := &watch.ProxmoxMonitor{Targets: proxmoxTargets, Dir: dir, Interval: dur, Keep: watchCfg.Retention.MaxIncidents}
+				go func() {
+					defer wg.Done()
+					if err := proxmoxMon.Watch(ctx, incCh); err != nil && ctx.Err() == nil {
+						fmt.Fprintf(os.Stderr, "[proxmox-monitor] error: %v\n", err)
+					}
+				}()
+				fmt.Printf("  Proxmox endpoints: %d\n", len(proxmoxTargets))
+			}
+
 			// With no restart monitors there is nothing to close incCh, and a
 			// nil channel is never selected — so the loop below waits on the
 			// thresholds and the signal instead of seeing a closed channel and
@@ -546,6 +560,24 @@ Docker targets use docker events (real-time). Systemd and PM2 targets use pollin
 					if !ok {
 						fmt.Println("\nAll monitors stopped.")
 						return nil
+					}
+
+					// Proxmox incidents are state transitions on an endpoint or a
+					// configured guest, not a process restart: they carry no exit
+					// code or logs to analyze, and "flapping" would only measure
+					// how often a poll caught a different answer. The monitor has
+					// already saved the incident itself.
+					if inc.Source == "proxmox" {
+						if notifier != nil {
+							_ = notifier.NotifyIncident(inc, watch.FlappingResult{}, nil, time.Now())
+						}
+						ts := time.Now().Format("15:04:05")
+						verb := "INCIDENT"
+						if inc.Recovered {
+							verb = "RECOVERED"
+						}
+						fmt.Printf("[%s] PROXMOX %s: %s\n", ts, verb, inc.PostLogs)
+						continue
 					}
 
 					// The exit code is the analyser's highest-confidence signal —

--- a/cmd/watch.go
+++ b/cmd/watch.go
@@ -526,7 +526,7 @@ Docker targets use docker events (real-time). Systemd and PM2 targets use pollin
 			if len(proxmoxTargets) > 0 {
 				monitorCount++
 				wg.Add(1)
-				proxmoxMon := &watch.ProxmoxMonitor{Targets: proxmoxTargets, Dir: dir, Interval: dur, Keep: watchCfg.Retention.MaxIncidents}
+				proxmoxMon := &watch.ProxmoxMonitor{Targets: proxmoxTargets, Dir: dir, Interval: dur, Keep: watchCfg.Retention.MaxIncidents, Flapping: watchCfg.Flapping}
 				go func() {
 					defer wg.Done()
 					if err := proxmoxMon.Watch(ctx, incCh); err != nil && ctx.Err() == nil {
@@ -569,7 +569,11 @@ Docker targets use docker events (real-time). Systemd and PM2 targets use pollin
 					// already saved the incident itself.
 					if inc.Source == "proxmox" {
 						if notifier != nil {
-							_ = notifier.NotifyIncident(inc, watch.FlappingResult{}, nil, time.Now())
+							flap := watch.FlappingResult{}
+							if inc.Flapping != nil {
+								flap = *inc.Flapping
+							}
+							_ = notifier.NotifyIncident(inc, flap, nil, time.Now())
 						}
 						ts := time.Now().Format("15:04:05")
 						verb := "INCIDENT"
@@ -713,6 +717,12 @@ func newWatchHistoryCmd() *cobra.Command {
 				if inc.CrashAnalysis != nil {
 					info += inc.CrashAnalysis.Category
 				}
+				if inc.Source == "proxmox" {
+					if inc.Recovered {
+						info += "[RECOVERED] "
+					}
+					info += inc.ProxmoxState + " " + inc.PostLogs
+				}
 				fmt.Printf("%-20s  %-36s  %-20s  %s\n",
 					inc.Container, id,
 					inc.DetectedAt.Format("2006-01-02 15:04:05"),
@@ -753,6 +763,13 @@ func newWatchShowCmd() *cobra.Command {
 			fmt.Printf("Detected:  %s\n", inc.DetectedAt.Format("2006-01-02 15:04:05"))
 			if inc.RestartCount > 0 {
 				fmt.Printf("Restarts:  %d\n", inc.RestartCount)
+			}
+			if inc.Source == "proxmox" {
+				fmt.Printf("State:     %s\n", inc.ProxmoxState)
+				if inc.ProxmoxClass != "" {
+					fmt.Printf("Class:     %s\n", inc.ProxmoxClass)
+				}
+				fmt.Printf("Recovered: %t\n", inc.Recovered)
 			}
 			fmt.Printf("Previous Start: %s\n", inc.PrevStarted)
 			fmt.Printf("Current Start:  %s\n", inc.CurrStarted)

--- a/docs/proxmox.md
+++ b/docs/proxmox.md
@@ -105,6 +105,44 @@ follow the same rules as their read-token counterparts: configure exactly one
 credential source (`action_token_file` or the inline `action_token`) alongside
 `action_token_id`. They enable guest start, reboot, and shutdown actions on
 this endpoint; without them, guest actions are unavailable.
+## Watch integration
+
+`homebutler watch start` polls every configured endpoint alongside its
+docker/systemd/pm2 targets — no separate scheduler or long-running command.
+It reports three kinds of state transition, each with a recovery incident
+when the problem clears:
+
+- the endpoint became unreachable (TLS, authentication/token expiry, or
+  transport/timeout failures)
+- the endpoint authenticated but returned nothing at all, or a 403 — recorded
+  as ACL-filtered, because `proxmox status` treats an empty resource list as a
+  permissions problem rather than a genuinely empty cluster
+- a guest named under `guests:` stopped running
+
+```yaml
+proxmox:
+  - name: pve
+    host: 192.168.1.10
+    token_id: monitoring@pve!readonly
+    token_file: ~/.config/homebutler/pve.token
+    guests:
+      - node: pve1
+        type: qemu   # or lxc
+        vmid: 100
+      - node: pve1
+        type: lxc
+        vmid: 101
+```
+
+A guest not listed under `guests:` is observational only: `watch start` never
+alerts on it, whether it was deliberately stopped or never running. Each entry
+names a guest by the exact triple Proxmox needs to address it — `node`,
+`type`, and `vmid` — matching `proxmox guest start/shutdown/reboot`.
+
+These checks are read-only, same as every other Proxmox command: `watch
+start` performs `GET`s only and never starts, stops, or otherwise acts on a
+guest. Alerts go through the same notifier and incident store as every other
+`watch start` incident (`homebutler watch history`, `watch show`).
 
 ## TLS
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -180,6 +180,11 @@ type ProxmoxConfig struct {
 	ActionTokenID   string `yaml:"action_token_id,omitempty"`
 	ActionToken     string `yaml:"action_token,omitempty" json:"-" secret:"true"`
 	ActionTokenFile string `yaml:"action_token_file,omitempty"`
+
+	// Guests names guests `watch start` expects to stay running on this
+	// endpoint. A guest not listed here is observational only: watch never
+	// alerts on it, deliberately stopped or not.
+	Guests []proxmox.ExpectedGuest `yaml:"guests,omitempty"`
 }
 
 // APIPort returns the configured API port or Proxmox's default HTTPS port.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -380,6 +380,42 @@ func TestLoadProxmoxConfig(t *testing.T) {
 	}
 }
 
+func TestLoadProxmoxConfigGuests(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	content := `proxmox:
+  - name: pve
+    host: pve.example
+    token_id: monitoring@pve!readonly
+    token: inline
+    guests:
+      - node: pve1
+        type: qemu
+        vmid: 100
+      - node: pve1
+        type: lxc
+        vmid: 101
+`
+	if err := os.WriteFile(path, []byte(content), 0600); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	guests := cfg.Proxmox[0].Guests
+	if len(guests) != 2 {
+		t.Fatalf("Guests = %d, want 2", len(guests))
+	}
+	if guests[0].Node != "pve1" || guests[0].Type != "qemu" || guests[0].VMID != 100 {
+		t.Errorf("guests[0] = %+v", guests[0])
+	}
+	if guests[1].Type != "lxc" || guests[1].VMID != 101 {
+		t.Errorf("guests[1] = %+v", guests[1])
+	}
+}
+
 func TestResolveBackupDir(t *testing.T) {
 	tests := []struct {
 		name      string

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -553,6 +553,12 @@ func (r *ValidationResult) checkProxmox(cfg *Config) {
 				r.add(SeverityError, field+".timeout", fmt.Sprintf("Invalid duration %q.", p.Timeout), `Use a positive Go duration such as "10s".`)
 			}
 		}
+		for j, guest := range p.Guests {
+			if err := guest.Validate(); err != nil {
+				r.add(SeverityError, fmt.Sprintf("%s.guests[%d]", field, j), err.Error(),
+					"Set node, type (qemu or lxc), and a positive vmid.")
+			}
+		}
 
 		if p.ActionTokenID != "" || p.ActionToken != "" || p.ActionTokenFile != "" {
 			if p.ActionTokenID == "" {

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -217,6 +217,29 @@ proxmox:
 	}
 }
 
+func TestValidateProxmoxGuestErrors(t *testing.T) {
+	path := writeConfig(t, `proxmox:
+  - name: pve
+    host: pve.example
+    token: token
+    token_id: monitor@pve!readonly
+    guests:
+      - node: pve1
+        type: docker
+        vmid: 0
+`)
+	r := Validate(path)
+	if r.Valid {
+		t.Fatal("invalid guest was accepted")
+	}
+	for _, finding := range r.Findings {
+		if finding.Field == "proxmox[0].guests[0]" {
+			return
+		}
+	}
+	t.Fatalf("findings = %+v, want invalid guest finding", r.Findings)
+}
+
 func TestValidateProxmoxActionCredentialErrors(t *testing.T) {
 	path := writeConfig(t, `
 proxmox:

--- a/internal/proxmox/types.go
+++ b/internal/proxmox/types.go
@@ -322,6 +322,28 @@ func (b *flexibleBool) UnmarshalJSON(data []byte) error {
 	return fmt.Errorf("expected boolean or 0/1, got %s", data)
 }
 
+// ExpectedGuest names one guest `watch start` expects to be running, by the
+// exact triple Proxmox needs to address it.
+type ExpectedGuest struct {
+	Node string `yaml:"node"`
+	Type string `yaml:"type"` // "qemu" or "lxc"
+	VMID int    `yaml:"vmid"`
+}
+
+// Validate reports a malformed expected-guest entry without contacting Proxmox.
+func (g ExpectedGuest) Validate() error {
+	if strings.TrimSpace(g.Node) == "" {
+		return fmt.Errorf("proxmox guest entry is missing node")
+	}
+	if g.Type != "qemu" && g.Type != "lxc" {
+		return fmt.Errorf("proxmox guest entry for node %q has invalid type %q: must be qemu or lxc", g.Node, g.Type)
+	}
+	if g.VMID < 1 {
+		return fmt.Errorf("proxmox guest entry for node %q has invalid vmid %d", g.Node, g.VMID)
+	}
+	return nil
+}
+
 func splitTags(tags string) []string {
 	if tags == "" {
 		return nil

--- a/internal/proxmox/types_test.go
+++ b/internal/proxmox/types_test.go
@@ -1,0 +1,26 @@
+package proxmox
+
+import "testing"
+
+func TestExpectedGuestValidate(t *testing.T) {
+	tests := []struct {
+		name    string
+		guest   ExpectedGuest
+		wantErr bool
+	}{
+		{"valid qemu", ExpectedGuest{Node: "pve1", Type: "qemu", VMID: 100}, false},
+		{"valid lxc", ExpectedGuest{Node: "pve1", Type: "lxc", VMID: 101}, false},
+		{"missing node", ExpectedGuest{Type: "qemu", VMID: 100}, true},
+		{"bad type", ExpectedGuest{Node: "pve1", Type: "docker", VMID: 100}, true},
+		{"zero vmid", ExpectedGuest{Node: "pve1", Type: "qemu", VMID: 0}, true},
+		{"negative vmid", ExpectedGuest{Node: "pve1", Type: "qemu", VMID: -1}, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.guest.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/watch/notify.go
+++ b/internal/watch/notify.go
@@ -30,7 +30,7 @@ func (wn *WatchNotifier) NotifyIncident(inc Incident, flap FlappingResult, crash
 		return nil
 	}
 
-	shouldNotify := (flap.IsFlapping && wn.Settings.OnFlapping) ||
+	shouldNotify := inc.Source == "proxmox" || (flap.IsFlapping && wn.Settings.OnFlapping) ||
 		(!flap.IsFlapping && wn.Settings.OnIncident)
 	if !shouldNotify {
 		return nil
@@ -42,10 +42,17 @@ func (wn *WatchNotifier) NotifyIncident(inc Incident, flap FlappingResult, crash
 		status = "flapping"
 		kind = "watch.flapping"
 	}
+	if inc.Recovered {
+		status = "recovered"
+		kind = "watch.recovery"
+	}
 
 	var details []string
 	if crash != nil {
 		details = append(details, fmt.Sprintf("category=%s reason=%s", crash.Category, crash.Reason))
+	}
+	if inc.Source == "proxmox" && inc.PostLogs != "" {
+		details = append(details, inc.PostLogs)
 	}
 
 	event := notify.Event{

--- a/internal/watch/notify.go
+++ b/internal/watch/notify.go
@@ -30,7 +30,8 @@ func (wn *WatchNotifier) NotifyIncident(inc Incident, flap FlappingResult, crash
 		return nil
 	}
 
-	shouldNotify := inc.Source == "proxmox" || (flap.IsFlapping && wn.Settings.OnFlapping) ||
+	shouldNotify := (inc.Source == "proxmox" && (wn.Settings.OnIncident || wn.Settings.OnFlapping)) ||
+		(flap.IsFlapping && wn.Settings.OnFlapping) ||
 		(!flap.IsFlapping && wn.Settings.OnIncident)
 	if !shouldNotify {
 		return nil

--- a/internal/watch/notify_test.go
+++ b/internal/watch/notify_test.go
@@ -202,3 +202,19 @@ func TestNotifyIncident_ProxmoxRecoveryBypassesDefaultGateAndCooldown(t *testing
 		t.Fatalf("notifications = %d, want failure and recovery", called)
 	}
 }
+
+func TestNotifyIncident_ProxmoxRespectsNotifyOff(t *testing.T) {
+	called := 0
+	settings := NotifySettings{Enabled: true, NotifyOn: "off", Cooldown: "5m"}
+	settings.Normalize()
+	wn := makeTestNotifier(settings, &called)
+	inc := baseIncident("proxmox-pve", time.Now())
+	inc.Source = "proxmox"
+
+	if err := wn.NotifyIncident(inc, FlappingResult{}, nil, time.Now()); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if called != 0 {
+		t.Errorf("notifications = %d, want 0 when notify_on is off", called)
+	}
+}

--- a/internal/watch/notify_test.go
+++ b/internal/watch/notify_test.go
@@ -184,3 +184,21 @@ func TestNotifyIncident_IndependentCooldown(t *testing.T) {
 		t.Errorf("expected 2 calls for different containers, got %d", called)
 	}
 }
+
+func TestNotifyIncident_ProxmoxRecoveryBypassesDefaultGateAndCooldown(t *testing.T) {
+	called := 0
+	wn := makeTestNotifier(NotifySettings{Enabled: true, OnFlapping: true, Cooldown: "5m"}, &called)
+	now := time.Date(2026, 1, 1, 12, 0, 0, 0, time.UTC)
+	inc := baseIncident("proxmox-pve", now)
+	inc.Source = "proxmox"
+	inc.ProxmoxState = ProxmoxStateUnavailable
+	inc.PostLogs = "proxmox pve is unavailable"
+
+	_ = wn.NotifyIncident(inc, FlappingResult{}, nil, now)
+	inc.Recovered = true
+	inc.PostLogs = "proxmox pve recovered from unavailable"
+	_ = wn.NotifyIncident(inc, FlappingResult{}, nil, now.Add(time.Minute))
+	if called != 2 {
+		t.Fatalf("notifications = %d, want failure and recovery", called)
+	}
+}

--- a/internal/watch/proxmox_monitor.go
+++ b/internal/watch/proxmox_monitor.go
@@ -121,7 +121,7 @@ func (pm *ProxmoxMonitor) poll(ctx context.Context, endpointPrev map[string]prox
 		if target.Client == nil {
 			err = target.Err
 			if err == nil {
-				err = fmt.Errorf("Proxmox client is not configured")
+				err = fmt.Errorf("proxmox client is not configured")
 			}
 		} else {
 			resources, err = target.Client.Resources(ctx)

--- a/internal/watch/proxmox_monitor.go
+++ b/internal/watch/proxmox_monitor.go
@@ -1,0 +1,227 @@
+package watch
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/Higangssh/homebutler/internal/proxmox"
+)
+
+// Proxmox incident states. Kept distinct from restart-monitor Container
+// values by the "proxmox-" prefix built in guestKey/endpointKey, so an
+// endpoint and a docker container can never collide in incidents/ or in
+// flapping/notification fingerprints.
+const (
+	ProxmoxStateUnavailable = "unavailable"
+	ProxmoxStateACLFiltered = "acl_filtered"
+	ProxmoxStateGuestDown   = "guest_down"
+)
+
+// ProxmoxClassEmptyResult marks a response that authenticated but returned no
+// nodes, guests, or storage at all — the same heuristic client.DefaultView
+// uses, and the fifth failure class #104 asks to keep distinguishable from a
+// genuine 403.
+const ProxmoxClassEmptyResult = "empty_result"
+
+// ProxmoxTarget is one configured Proxmox endpoint to poll, together with the
+// guests on it that are expected to stay running.
+type ProxmoxTarget struct {
+	Endpoint string
+	Client   *proxmox.Client
+	Guests   []proxmox.ExpectedGuest
+}
+
+// ProxmoxMonitor polls Proxmox endpoints for reachability and for the
+// running state of explicitly configured guests. It performs GETs only.
+type ProxmoxMonitor struct {
+	Targets  []ProxmoxTarget
+	Dir      string
+	Interval time.Duration
+	Keep     int
+}
+
+type proxmoxEndpointState struct {
+	state string // "" (healthy), ProxmoxStateUnavailable, or ProxmoxStateACLFiltered
+	class string
+}
+
+func endpointKey(name string) string {
+	return "proxmox-" + name
+}
+
+func guestKey(endpoint string, g proxmox.ExpectedGuest) string {
+	return fmt.Sprintf("proxmox-%s-%s-%s-%d", endpoint, g.Node, g.Type, g.VMID)
+}
+
+// Watch polls each endpoint's resources and reports endpoint and configured
+// guest state transitions. A collector failure on one endpoint never blocks
+// the others, and a guest state read failure on one endpoint never discards
+// resources it already fetched for the rest of that poll.
+func (pm *ProxmoxMonitor) Watch(ctx context.Context, incidents chan<- Incident) error {
+	if len(pm.Targets) == 0 {
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	interval := pm.Interval
+	if interval == 0 {
+		interval = 30 * time.Second
+	}
+
+	endpointPrev := make(map[string]proxmoxEndpointState, len(pm.Targets))
+	guestPrev := make(map[string]bool)
+
+	// Seed without emitting, so a guest that is already stopped or an
+	// endpoint that is already unreachable when watch starts does not fire an
+	// incident for a state that was never observed to change.
+	if err := pm.poll(ctx, endpointPrev, guestPrev, nil); err != nil {
+		return err
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-ticker.C:
+			if err := pm.poll(ctx, endpointPrev, guestPrev, incidents); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (pm *ProxmoxMonitor) poll(ctx context.Context, endpointPrev map[string]proxmoxEndpointState, guestPrev map[string]bool, incidents chan<- Incident) error {
+	for _, target := range pm.Targets {
+		resources, err := target.Client.Resources(ctx)
+
+		var curr proxmoxEndpointState
+		switch {
+		case err != nil:
+			switch proxmox.Classify(err) {
+			case proxmox.FailureAuthorization:
+				curr = proxmoxEndpointState{state: ProxmoxStateACLFiltered, class: string(proxmox.FailureAuthorization)}
+			case proxmox.FailureTLS:
+				curr = proxmoxEndpointState{state: ProxmoxStateUnavailable, class: string(proxmox.FailureTLS)}
+			case proxmox.FailureAuthentication:
+				curr = proxmoxEndpointState{state: ProxmoxStateUnavailable, class: string(proxmox.FailureAuthentication)}
+			default:
+				curr = proxmoxEndpointState{state: ProxmoxStateUnavailable, class: string(proxmox.FailureTransport)}
+			}
+		case len(resources.Nodes) == 0 && len(resources.Guests) == 0 && len(resources.Storage) == 0:
+			curr = proxmoxEndpointState{state: ProxmoxStateACLFiltered, class: ProxmoxClassEmptyResult}
+		default:
+			curr = proxmoxEndpointState{} // healthy
+		}
+
+		key := endpointKey(target.Endpoint)
+		if prev, ok := endpointPrev[key]; ok && incidents != nil && prev.state != curr.state {
+			if err := pm.emitEndpointIncident(ctx, target.Endpoint, prev, curr, incidents); err != nil {
+				return err
+			}
+		}
+		endpointPrev[key] = curr
+
+		// A failed collector carries no resources to check guests against.
+		// Guest state before the failure is left exactly as it was rather
+		// than guessed at, matching #104's "preserve partial results".
+		if err != nil {
+			continue
+		}
+
+		running := make(map[string]bool, len(resources.Guests))
+		for _, guest := range resources.Guests {
+			running[fmt.Sprintf("%s-%s-%d", guest.Node, guest.Type, guest.VMID)] = guest.Status == "running"
+		}
+
+		for _, expected := range target.Guests {
+			key := guestKey(target.Endpoint, expected)
+			isRunning := running[fmt.Sprintf("%s-%s-%d", expected.Node, expected.Type, expected.VMID)]
+
+			if prev, ok := guestPrev[key]; ok && incidents != nil && prev != isRunning {
+				if err := pm.emitGuestIncident(ctx, target.Endpoint, expected, isRunning, incidents); err != nil {
+					return err
+				}
+			}
+			guestPrev[key] = isRunning
+		}
+	}
+	return nil
+}
+
+func (pm *ProxmoxMonitor) emitEndpointIncident(ctx context.Context, endpoint string, prev, curr proxmoxEndpointState, incidents chan<- Incident) error {
+	recovered := curr.state == ""
+	state, class := curr.state, curr.class
+	if recovered {
+		state, class = prev.state, prev.class
+	}
+
+	now := time.Now()
+	inc := Incident{
+		ID:           GenerateIncidentID(endpointKey(endpoint), now),
+		Container:    endpointKey(endpoint),
+		DetectedAt:   now,
+		Source:       "proxmox",
+		ProxmoxState: state,
+		ProxmoxClass: class,
+		Recovered:    recovered,
+		PostLogs:     proxmoxStateMessage(endpoint, "", state, class, recovered),
+	}
+	pm.save(&inc)
+	return send(ctx, incidents, inc)
+}
+
+func (pm *ProxmoxMonitor) emitGuestIncident(ctx context.Context, endpoint string, guest proxmox.ExpectedGuest, isRunning bool, incidents chan<- Incident) error {
+	label := fmt.Sprintf("%s/%s/%d", guest.Node, guest.Type, guest.VMID)
+	now := time.Now()
+	inc := Incident{
+		ID:           GenerateIncidentID(guestKey(endpoint, guest), now),
+		Container:    guestKey(endpoint, guest),
+		DetectedAt:   now,
+		Source:       "proxmox",
+		ProxmoxState: ProxmoxStateGuestDown,
+		Recovered:    isRunning,
+		PostLogs:     proxmoxStateMessage(endpoint, label, ProxmoxStateGuestDown, "", isRunning),
+	}
+	pm.save(&inc)
+	return send(ctx, incidents, inc)
+}
+
+func proxmoxStateMessage(endpoint, guest, state, class string, recovered bool) string {
+	target := endpoint
+	if guest != "" {
+		target = endpoint + " " + guest
+	}
+	if recovered {
+		return fmt.Sprintf("proxmox %s recovered from %s", target, state)
+	}
+	if class != "" {
+		return fmt.Sprintf("proxmox %s is %s (%s)", target, state, class)
+	}
+	return fmt.Sprintf("proxmox %s is %s", target, state)
+}
+
+func (pm *ProxmoxMonitor) save(inc *Incident) {
+	if pm.Dir == "" {
+		return
+	}
+	if err := SaveIncident(pm.Dir, inc, pm.Keep); err != nil {
+		fmt.Fprintf(os.Stderr, "[proxmox-monitor] warning: save incident: %v\n", err)
+	}
+}
+
+func send(ctx context.Context, incidents chan<- Incident, inc Incident) error {
+	if incidents == nil {
+		return nil
+	}
+	select {
+	case incidents <- inc:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}

--- a/internal/watch/proxmox_monitor.go
+++ b/internal/watch/proxmox_monitor.go
@@ -28,9 +28,13 @@ const ProxmoxClassEmptyResult = "empty_result"
 // ProxmoxTarget is one configured Proxmox endpoint to poll, together with the
 // guests on it that are expected to stay running.
 type ProxmoxTarget struct {
-	Endpoint string
-	Client   *proxmox.Client
-	Guests   []proxmox.ExpectedGuest
+	Endpoint  string
+	Client    *proxmox.Client
+	NewClient func() (*proxmox.Client, error)
+	// Err keeps a configured endpoint visible to the monitor when its client
+	// cannot be built, so a bad credential is an incident instead of silence.
+	Err    error
+	Guests []proxmox.ExpectedGuest
 }
 
 // ProxmoxMonitor polls Proxmox endpoints for reachability and for the
@@ -40,6 +44,8 @@ type ProxmoxMonitor struct {
 	Dir      string
 	Interval time.Duration
 	Keep     int
+	Flapping FlappingConfig
+	flapping map[string]bool
 }
 
 type proxmoxEndpointState struct {
@@ -76,7 +82,16 @@ func (pm *ProxmoxMonitor) Watch(ctx context.Context, incidents chan<- Incident) 
 	// Seed without emitting, so a guest that is already stopped or an
 	// endpoint that is already unreachable when watch starts does not fire an
 	// incident for a state that was never observed to change.
-	if err := pm.poll(ctx, endpointPrev, guestPrev, nil); err != nil {
+	for _, target := range pm.Targets {
+		if target.Err != nil {
+			state := pm.endpointState(target.Err)
+			if err := pm.emitEndpointIncident(ctx, target.Endpoint, proxmoxEndpointState{}, state, incidents); err != nil {
+				return err
+			}
+			endpointPrev[endpointKey(target.Endpoint)] = state
+		}
+	}
+	if err := pm.poll(ctx, endpointPrev, guestPrev, incidents); err != nil {
 		return err
 	}
 
@@ -96,22 +111,29 @@ func (pm *ProxmoxMonitor) Watch(ctx context.Context, incidents chan<- Incident) 
 }
 
 func (pm *ProxmoxMonitor) poll(ctx context.Context, endpointPrev map[string]proxmoxEndpointState, guestPrev map[string]bool, incidents chan<- Incident) error {
-	for _, target := range pm.Targets {
-		resources, err := target.Client.Resources(ctx)
+	for i := range pm.Targets {
+		target := &pm.Targets[i]
+		var resources proxmox.Resources
+		var err error
+		if target.Client == nil && target.NewClient != nil {
+			target.Client, target.Err = target.NewClient()
+		}
+		if target.Client == nil {
+			err = target.Err
+			if err == nil {
+				err = fmt.Errorf("Proxmox client is not configured")
+			}
+		} else {
+			resources, err = target.Client.Resources(ctx)
+			if proxmox.Classify(err) == proxmox.FailureAuthentication {
+				target.Client = nil // retry token-file resolution on the next poll
+			}
+		}
 
 		var curr proxmoxEndpointState
 		switch {
 		case err != nil:
-			switch proxmox.Classify(err) {
-			case proxmox.FailureAuthorization:
-				curr = proxmoxEndpointState{state: ProxmoxStateACLFiltered, class: string(proxmox.FailureAuthorization)}
-			case proxmox.FailureTLS:
-				curr = proxmoxEndpointState{state: ProxmoxStateUnavailable, class: string(proxmox.FailureTLS)}
-			case proxmox.FailureAuthentication:
-				curr = proxmoxEndpointState{state: ProxmoxStateUnavailable, class: string(proxmox.FailureAuthentication)}
-			default:
-				curr = proxmoxEndpointState{state: ProxmoxStateUnavailable, class: string(proxmox.FailureTransport)}
-			}
+			curr = pm.endpointState(err)
 		case len(resources.Nodes) == 0 && len(resources.Guests) == 0 && len(resources.Storage) == 0:
 			curr = proxmoxEndpointState{state: ProxmoxStateACLFiltered, class: ProxmoxClassEmptyResult}
 		default:
@@ -129,7 +151,7 @@ func (pm *ProxmoxMonitor) poll(ctx context.Context, endpointPrev map[string]prox
 		// A failed collector carries no resources to check guests against.
 		// Guest state before the failure is left exactly as it was rather
 		// than guessed at, matching #104's "preserve partial results".
-		if err != nil {
+		if err != nil || curr.state == ProxmoxStateACLFiltered {
 			continue
 		}
 
@@ -140,7 +162,10 @@ func (pm *ProxmoxMonitor) poll(ctx context.Context, endpointPrev map[string]prox
 
 		for _, expected := range target.Guests {
 			key := guestKey(target.Endpoint, expected)
-			isRunning := running[fmt.Sprintf("%s-%s-%d", expected.Node, expected.Type, expected.VMID)]
+			isRunning, found := running[fmt.Sprintf("%s-%s-%d", expected.Node, expected.Type, expected.VMID)]
+			if !found {
+				continue
+			}
 
 			if prev, ok := guestPrev[key]; ok && incidents != nil && prev != isRunning {
 				if err := pm.emitGuestIncident(ctx, target.Endpoint, expected, isRunning, incidents); err != nil {
@@ -151,6 +176,19 @@ func (pm *ProxmoxMonitor) poll(ctx context.Context, endpointPrev map[string]prox
 		}
 	}
 	return nil
+}
+
+func (pm *ProxmoxMonitor) endpointState(err error) proxmoxEndpointState {
+	switch proxmox.Classify(err) {
+	case proxmox.FailureAuthorization:
+		return proxmoxEndpointState{state: ProxmoxStateACLFiltered, class: string(proxmox.FailureAuthorization)}
+	case proxmox.FailureTLS:
+		return proxmoxEndpointState{state: ProxmoxStateUnavailable, class: string(proxmox.FailureTLS)}
+	case proxmox.FailureAuthentication:
+		return proxmoxEndpointState{state: ProxmoxStateUnavailable, class: string(proxmox.FailureAuthentication)}
+	default:
+		return proxmoxEndpointState{state: ProxmoxStateUnavailable, class: string(proxmox.FailureTransport)}
+	}
 }
 
 func (pm *ProxmoxMonitor) emitEndpointIncident(ctx context.Context, endpoint string, prev, curr proxmoxEndpointState, incidents chan<- Incident) error {
@@ -171,8 +209,42 @@ func (pm *ProxmoxMonitor) emitEndpointIncident(ctx context.Context, endpoint str
 		Recovered:    recovered,
 		PostLogs:     proxmoxStateMessage(endpoint, "", state, class, recovered),
 	}
+	if pm.isFlapping(&inc) {
+		if pm.flapping[inc.Container] {
+			return nil
+		}
+		pm.flapping[inc.Container] = true
+	} else {
+		delete(pm.flapping, inc.Container)
+	}
 	pm.save(&inc)
 	return send(ctx, incidents, inc)
+}
+
+// isFlapping marks the first incident that crosses the configured threshold;
+// later transitions are coalesced until the endpoint is stable again.
+func (pm *ProxmoxMonitor) isFlapping(inc *Incident) bool {
+	if pm.Dir == "" {
+		return false
+	}
+	refs, err := ListIncidentRefs(pm.Dir)
+	if err != nil {
+		return false
+	}
+	refs = append(refs, IncidentRef{ID: inc.ID, Container: inc.Container, DetectedAt: inc.DetectedAt})
+	flapping := pm.Flapping
+	if flapping.ShortThreshold == 0 && flapping.LongThreshold == 0 {
+		flapping = DefaultFlappingConfig()
+	}
+	result := flapping.CheckRefs(inc.Container, refs, inc.DetectedAt)
+	if !result.IsFlapping {
+		return false
+	}
+	inc.Flapping = &result
+	if pm.flapping == nil {
+		pm.flapping = make(map[string]bool)
+	}
+	return true
 }
 
 func (pm *ProxmoxMonitor) emitGuestIncident(ctx context.Context, endpoint string, guest proxmox.ExpectedGuest, isRunning bool, incidents chan<- Incident) error {

--- a/internal/watch/proxmox_monitor_test.go
+++ b/internal/watch/proxmox_monitor_test.go
@@ -1,0 +1,324 @@
+package watch
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Higangssh/homebutler/internal/proxmox"
+)
+
+// proxmoxFixtureClient builds a Client that talks to a local TLS test server
+// using an insecure connection, mirroring internal/server/proxmox_test.go.
+func proxmoxFixtureClient(t *testing.T, server *httptest.Server) *proxmox.Client {
+	t.Helper()
+	apiURL, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, portText, err := net.SplitHostPort(apiURL.Host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	client, err := proxmox.New(proxmox.Options{
+		Host: host, Port: port, TokenID: "monitoring@pve!readonly", Token: "test-token", Insecure: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func resourcesResponse(nodes, guests string) string {
+	items := []string{}
+	if nodes != "" {
+		items = append(items, nodes)
+	}
+	if guests != "" {
+		items = append(items, guests)
+	}
+	return fmt.Sprintf(`{"data":[%s]}`, strings.Join(items, ","))
+}
+
+const oneNode = `{"type":"node","node":"pve1","status":"online"}`
+
+func guestJSON(node, guestType string, vmid int, status string) string {
+	return fmt.Sprintf(`{"type":%q,"vmid":%d,"node":%q,"status":%q}`, guestType, vmid, node, status)
+}
+
+// scriptedServer replays one response body per call to /cluster/resources, in
+// order, then repeats the last one. status lets a call simulate an HTTP
+// failure instead of a body.
+type scriptedServer struct {
+	mu        sync.Mutex
+	responses []scriptedResponse
+	calls     int32
+}
+
+type scriptedResponse struct {
+	status int
+	body   string
+}
+
+func (s *scriptedServer) handler(t *testing.T) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/api2/json/cluster/resources" {
+			http.NotFound(w, r)
+			return
+		}
+		s.mu.Lock()
+		i := int(atomic.AddInt32(&s.calls, 1)) - 1
+		if i >= len(s.responses) {
+			i = len(s.responses) - 1
+		}
+		resp := s.responses[i]
+		s.mu.Unlock()
+		if resp.status != 0 && resp.status != http.StatusOK {
+			http.Error(w, "scripted failure", resp.status)
+			return
+		}
+		_, _ = w.Write([]byte(resp.body))
+	}
+}
+
+// runPolls drives n synchronous polls of a ProxmoxMonitor without going
+// through the timer-driven Watch loop, so a test controls exactly which
+// poll the incident channel should be checked after.
+func runPolls(t *testing.T, pm *ProxmoxMonitor, n int) []Incident {
+	t.Helper()
+	ctx := context.Background()
+	endpointPrev := make(map[string]proxmoxEndpointState)
+	guestPrev := make(map[string]bool)
+	incCh := make(chan Incident, 64)
+
+	// Seed pass, matching Watch's own behavior.
+	if err := pm.poll(ctx, endpointPrev, guestPrev, nil); err != nil {
+		t.Fatalf("seed poll: %v", err)
+	}
+
+	var got []Incident
+	for i := 0; i < n; i++ {
+		if err := pm.poll(ctx, endpointPrev, guestPrev, incCh); err != nil {
+			t.Fatalf("poll %d: %v", i, err)
+		}
+	}
+	close(incCh)
+	for inc := range incCh {
+		got = append(got, inc)
+	}
+	return got
+}
+
+func TestProxmoxMonitorGuestDownAndRecovered(t *testing.T) {
+	script := &scriptedServer{responses: []scriptedResponse{
+		{body: resourcesResponse(oneNode, guestJSON("pve1", "qemu", 100, "running"))},
+		{body: resourcesResponse(oneNode, guestJSON("pve1", "qemu", 100, "stopped"))},
+		{body: resourcesResponse(oneNode, guestJSON("pve1", "qemu", 100, "running"))},
+	}}
+	server := httptest.NewTLSServer(script.handler(t))
+	defer server.Close()
+
+	pm := &ProxmoxMonitor{Targets: []ProxmoxTarget{{
+		Endpoint: "pve",
+		Client:   proxmoxFixtureClient(t, server),
+		Guests:   []proxmox.ExpectedGuest{{Node: "pve1", Type: "qemu", VMID: 100}},
+	}}}
+
+	got := runPolls(t, pm, 2)
+	if len(got) != 2 {
+		t.Fatalf("incidents = %d, want 2: %+v", len(got), got)
+	}
+	if got[0].Source != "proxmox" || got[0].ProxmoxState != ProxmoxStateGuestDown || got[0].Recovered {
+		t.Errorf("first incident = %+v, want unrecovered guest_down", got[0])
+	}
+	if !got[1].Recovered || got[1].ProxmoxState != ProxmoxStateGuestDown {
+		t.Errorf("second incident = %+v, want recovered guest_down", got[1])
+	}
+}
+
+func TestProxmoxMonitorUnconfiguredGuestNeverAlerts(t *testing.T) {
+	script := &scriptedServer{responses: []scriptedResponse{
+		{body: resourcesResponse(oneNode, guestJSON("pve1", "lxc", 200, "running"))},
+		{body: resourcesResponse(oneNode, guestJSON("pve1", "lxc", 200, "stopped"))},
+	}}
+	server := httptest.NewTLSServer(script.handler(t))
+	defer server.Close()
+
+	// Guest 200 is never declared in Targets[0].Guests, so it is
+	// observational only.
+	pm := &ProxmoxMonitor{Targets: []ProxmoxTarget{{
+		Endpoint: "pve",
+		Client:   proxmoxFixtureClient(t, server),
+	}}}
+
+	got := runPolls(t, pm, 1)
+	if len(got) != 0 {
+		t.Fatalf("incidents = %+v, want none for an unconfigured guest", got)
+	}
+}
+
+func TestProxmoxMonitorEndpointUnavailableAndRecovered(t *testing.T) {
+	script := &scriptedServer{responses: []scriptedResponse{
+		{body: resourcesResponse(oneNode, "")},
+		{status: http.StatusServiceUnavailable},
+		{body: resourcesResponse(oneNode, "")},
+	}}
+	server := httptest.NewTLSServer(script.handler(t))
+	defer server.Close()
+
+	pm := &ProxmoxMonitor{Targets: []ProxmoxTarget{{Endpoint: "pve", Client: proxmoxFixtureClient(t, server)}}}
+
+	got := runPolls(t, pm, 2)
+	if len(got) != 2 {
+		t.Fatalf("incidents = %d, want 2: %+v", len(got), got)
+	}
+	if got[0].ProxmoxState != ProxmoxStateUnavailable || got[0].ProxmoxClass != string(proxmox.FailureTransport) || got[0].Recovered {
+		t.Errorf("first incident = %+v, want unrecovered unavailable/transport", got[0])
+	}
+	if !got[1].Recovered || got[1].ProxmoxState != ProxmoxStateUnavailable {
+		t.Errorf("second incident = %+v, want recovered unavailable", got[1])
+	}
+}
+
+func TestProxmoxMonitorACLFilteredEmptyResult(t *testing.T) {
+	script := &scriptedServer{responses: []scriptedResponse{
+		{body: resourcesResponse(oneNode, "")},
+		{body: `{"data":[]}`}, // authenticated but nothing visible at all
+		{body: resourcesResponse(oneNode, "")},
+	}}
+	server := httptest.NewTLSServer(script.handler(t))
+	defer server.Close()
+
+	pm := &ProxmoxMonitor{Targets: []ProxmoxTarget{{Endpoint: "pve", Client: proxmoxFixtureClient(t, server)}}}
+
+	got := runPolls(t, pm, 2)
+	if len(got) != 2 {
+		t.Fatalf("incidents = %d, want 2: %+v", len(got), got)
+	}
+	if got[0].ProxmoxState != ProxmoxStateACLFiltered || got[0].ProxmoxClass != ProxmoxClassEmptyResult {
+		t.Errorf("first incident = %+v, want acl_filtered/empty_result", got[0])
+	}
+	if !got[1].Recovered || got[1].ProxmoxState != ProxmoxStateACLFiltered {
+		t.Errorf("second incident = %+v, want recovered acl_filtered", got[1])
+	}
+}
+
+func TestProxmoxMonitorAuthorizationFailureIsACLFiltered(t *testing.T) {
+	script := &scriptedServer{responses: []scriptedResponse{
+		{body: resourcesResponse(oneNode, "")},
+		{status: http.StatusForbidden},
+	}}
+	server := httptest.NewTLSServer(script.handler(t))
+	defer server.Close()
+
+	pm := &ProxmoxMonitor{Targets: []ProxmoxTarget{{Endpoint: "pve", Client: proxmoxFixtureClient(t, server)}}}
+
+	got := runPolls(t, pm, 1)
+	if len(got) != 1 {
+		t.Fatalf("incidents = %d, want 1: %+v", len(got), got)
+	}
+	if got[0].ProxmoxState != ProxmoxStateACLFiltered || got[0].ProxmoxClass != string(proxmox.FailureAuthorization) {
+		t.Errorf("incident = %+v, want acl_filtered/authorization", got[0])
+	}
+}
+
+func TestProxmoxMonitorSeedDoesNotAlertOnAlreadyStoppedGuest(t *testing.T) {
+	script := &scriptedServer{responses: []scriptedResponse{
+		{body: resourcesResponse(oneNode, guestJSON("pve1", "qemu", 100, "stopped"))},
+		{body: resourcesResponse(oneNode, guestJSON("pve1", "qemu", 100, "stopped"))},
+	}}
+	server := httptest.NewTLSServer(script.handler(t))
+	defer server.Close()
+
+	pm := &ProxmoxMonitor{Targets: []ProxmoxTarget{{
+		Endpoint: "pve",
+		Client:   proxmoxFixtureClient(t, server),
+		Guests:   []proxmox.ExpectedGuest{{Node: "pve1", Type: "qemu", VMID: 100}},
+	}}}
+
+	got := runPolls(t, pm, 1)
+	if len(got) != 0 {
+		t.Fatalf("incidents = %+v, want none: a guest already stopped when watch starts is not a transition", got)
+	}
+}
+
+// A failed endpoint collector must not erase guest state from a prior
+// successful poll (#104 "preserve partial results").
+func TestProxmoxMonitorPartialFailurePreservesGuestState(t *testing.T) {
+	script := &scriptedServer{responses: []scriptedResponse{
+		{body: resourcesResponse(oneNode, guestJSON("pve1", "qemu", 100, "running"))},
+		{status: http.StatusServiceUnavailable},
+		{body: resourcesResponse(oneNode, guestJSON("pve1", "qemu", 100, "stopped"))},
+	}}
+	server := httptest.NewTLSServer(script.handler(t))
+	defer server.Close()
+
+	pm := &ProxmoxMonitor{Targets: []ProxmoxTarget{{
+		Endpoint: "pve",
+		Client:   proxmoxFixtureClient(t, server),
+		Guests:   []proxmox.ExpectedGuest{{Node: "pve1", Type: "qemu", VMID: 100}},
+	}}}
+
+	got := runPolls(t, pm, 2)
+
+	var guestIncidents int
+	for _, inc := range got {
+		if inc.ProxmoxState == ProxmoxStateGuestDown {
+			guestIncidents++
+		}
+	}
+	if guestIncidents != 1 {
+		t.Fatalf("guest_down incidents = %d, want exactly 1 (from running to stopped, not lost by the intervening failure): %+v", guestIncidents, got)
+	}
+}
+
+func TestProxmoxMonitorNoTargetsBlocksUntilCancelled(t *testing.T) {
+	pm := &ProxmoxMonitor{}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+	if err := pm.Watch(ctx, make(chan Incident)); err != context.DeadlineExceeded {
+		t.Fatalf("Watch() = %v, want context.DeadlineExceeded", err)
+	}
+}
+
+func TestProxmoxMonitorSavesIncidentsToDisk(t *testing.T) {
+	dir := t.TempDir()
+	script := &scriptedServer{responses: []scriptedResponse{
+		{body: resourcesResponse(oneNode, "")},
+		{status: http.StatusServiceUnavailable},
+	}}
+	server := httptest.NewTLSServer(script.handler(t))
+	defer server.Close()
+
+	pm := &ProxmoxMonitor{
+		Targets: []ProxmoxTarget{{Endpoint: "pve", Client: proxmoxFixtureClient(t, server)}},
+		Dir:     dir,
+	}
+	got := runPolls(t, pm, 1)
+	if len(got) != 1 {
+		t.Fatalf("incidents = %+v, want 1", got)
+	}
+
+	loaded, err := LoadIncident(dir, got[0].ID)
+	if err != nil {
+		t.Fatalf("LoadIncident: %v", err)
+	}
+	data, _ := json.Marshal(loaded)
+	if loaded.ProxmoxState != ProxmoxStateUnavailable {
+		t.Errorf("saved incident = %s, want proxmox_state unavailable", data)
+	}
+}

--- a/internal/watch/proxmox_monitor_test.go
+++ b/internal/watch/proxmox_monitor_test.go
@@ -286,6 +286,43 @@ func TestProxmoxMonitorPartialFailurePreservesGuestState(t *testing.T) {
 	}
 }
 
+func TestProxmoxMonitorACLFilteredEmptyResultPreservesGuestState(t *testing.T) {
+	script := &scriptedServer{responses: []scriptedResponse{
+		{body: resourcesResponse(oneNode, guestJSON("pve1", "qemu", 100, "running"))},
+		{body: `{"data":[]}`},
+		{body: resourcesResponse(oneNode, guestJSON("pve1", "qemu", 100, "running"))},
+	}}
+	server := httptest.NewTLSServer(script.handler(t))
+	defer server.Close()
+
+	pm := &ProxmoxMonitor{Targets: []ProxmoxTarget{{
+		Endpoint: "pve", Client: proxmoxFixtureClient(t, server),
+		Guests: []proxmox.ExpectedGuest{{Node: "pve1", Type: "qemu", VMID: 100}},
+	}}}
+	got := runPolls(t, pm, 2)
+	if len(got) != 2 || got[0].ProxmoxState != ProxmoxStateACLFiltered || got[1].ProxmoxState != ProxmoxStateACLFiltered || !got[1].Recovered {
+		t.Fatalf("incidents = %+v, want only ACL-filtered transition and recovery", got)
+	}
+}
+
+func TestProxmoxMonitorMissingGuestPreservesState(t *testing.T) {
+	script := &scriptedServer{responses: []scriptedResponse{
+		{body: resourcesResponse(oneNode, guestJSON("pve1", "qemu", 100, "running"))},
+		{body: resourcesResponse(oneNode, "")},
+		{body: resourcesResponse(oneNode, guestJSON("pve1", "qemu", 100, "running"))},
+	}}
+	server := httptest.NewTLSServer(script.handler(t))
+	defer server.Close()
+
+	pm := &ProxmoxMonitor{Targets: []ProxmoxTarget{{
+		Endpoint: "pve", Client: proxmoxFixtureClient(t, server),
+		Guests: []proxmox.ExpectedGuest{{Node: "pve1", Type: "qemu", VMID: 100}},
+	}}}
+	if got := runPolls(t, pm, 2); len(got) != 0 {
+		t.Fatalf("incidents = %+v, want none when a configured guest is absent", got)
+	}
+}
+
 func TestProxmoxMonitorNoTargetsBlocksUntilCancelled(t *testing.T) {
 	pm := &ProxmoxMonitor{}
 	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)

--- a/internal/watch/query.go
+++ b/internal/watch/query.go
@@ -88,7 +88,9 @@ func History(dir string, opts HistoryOptions) ([]Incident, error) {
 		copy(stripped, incidents)
 		for i := range stripped {
 			stripped[i].PreLogs = ""
-			stripped[i].PostLogs = ""
+			if stripped[i].Source != "proxmox" {
+				stripped[i].PostLogs = ""
+			}
 		}
 		incidents = stripped
 	}

--- a/internal/watch/store.go
+++ b/internal/watch/store.go
@@ -79,6 +79,21 @@ type Incident struct {
 	OOMKilled     bool            `json:"oom_killed,omitempty"`
 	Flapping      *FlappingResult `json:"flapping,omitempty"`
 	CrashAnalysis *CrashSummary   `json:"crash_analysis,omitempty"`
+
+	// Source distinguishes an incident that did not come from a restart
+	// monitor. Empty means docker/systemd/pm2, as it always has; a non-empty
+	// value opts the incident out of restart-shaped handling (crash analysis,
+	// flapping) in cmd/watch.go's print loop.
+	Source string `json:"source,omitempty"`
+	// ProxmoxState is the state the incident transitioned into: "unavailable",
+	// "acl_filtered", or "guest_down". Empty outside Source == "proxmox".
+	ProxmoxState string `json:"proxmox_state,omitempty"`
+	// ProxmoxClass is the specific failure behind ProxmoxState — tls,
+	// authentication, authorization, transport, or empty_result — kept
+	// alongside the coarser state per #104.
+	ProxmoxClass string `json:"proxmox_class,omitempty"`
+	// Recovered marks a transition back to healthy rather than into failure.
+	Recovered bool `json:"recovered,omitempty"`
 }
 
 func WatchDir() (string, error) {


### PR DESCRIPTION
## Summary

`watch start` now polls every configured Proxmox endpoint alongside its docker/systemd/pm2 targets, using the same unified monitoring loop from #97 rather than a second scheduler. It reports endpoint reachability and, for guests explicitly named under a new `guests:` key on each `proxmox:` entry, whether an expected-running guest stopped — one incident on the transition, one recovery incident when it clears.

TLS, authentication, authorization, and transport failures keep the classes #111 already introduced on `proxmox.Client`. A response that authenticates but returns no nodes, guests, or storage at all is folded into the same "ACL-filtered" incident state as an outright 403, with the specific failure kept on the incident as `proxmox_class` so the two stay distinguishable in output.

A guest not listed under `guests:` is observational only — never alerted on, deliberately stopped or not. A failed collector on one endpoint doesn't touch guest state already read from another poll or another endpoint.

## Implementation notes

- `internal/watch/proxmox_monitor.go` is a new `ProxmoxMonitor`, structured like `SystemdMonitor`/`PM2Monitor` (seed pass without emitting, then poll on the shared interval) but keyed by endpoint+guest rather than `Target`, since Proxmox targets come from `config.Proxmox`, not the watch target list.
- `ExpectedGuest` lives in `internal/proxmox`, not `internal/config`, because `internal/config` already imports `internal/watch` (for `WatchRuntimeConfig`) — putting it in `internal/config` would have made `internal/watch` importing `internal/config` a cycle.
- `Incident` gained `Source`, `ProxmoxState`, `ProxmoxClass`, and `Recovered` fields rather than a new incident type, so history/show/notify keep working unchanged. `cmd/watch.go`'s print loop branches on `Source == "proxmox"` to skip crash analysis and flapping, which don't mean anything for an API poll.
- All requests are GETs (`client.Resources`); no guest actions, retries, or task polling.

## Test plan

- [x] `gofmt -w .`
- [x] `go vet ./...`
- [x] `golangci-lint run` (no issues)
- [x] `go test ./...` (1217 passed)
- [x] `go build ./...`
- New fixtures in `internal/watch/proxmox_monitor_test.go` cover: guest down/recovered, unconfigured guest never alerting, endpoint unavailable/recovered, ACL-filtered via empty result and via 403, no false alert on an already-stopped guest at startup, and partial-failure preserving guest state across a failed poll.