### PR TITLE
feat: require a separate credential for proxmox guest actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+**Guest power actions now need their own Proxmox credential, separate from the one that reads status.** The same token drove both, so anything with read access to the config also held `VM.PowerMgmt` on every guest, even though status polling never needed it.
+
+### ✨ Features
+
+- require a separate credential for Proxmox guest actions (#107). `action_token_id` plus `action_token` or `action_token_file` configures a second, optional token used only for start, reboot, and shutdown; reads, the dashboard, and the read-only MCP tools keep using the existing token. `config validate` warns when the action credential is the same token as the read one, since that defeats the separation. See [Proxmox setup →](docs/proxmox.md) for creating the second token with a least-privilege ACL
+
+### ⚠️ Behavior changes
+
+- **Guest start, reboot, and shutdown fail with `no action credential configured for Proxmox endpoint "..."` until `action_token_id` and `action_token` (or `action_token_file`) are added to the endpoint.** There is no fallback to the read token and no compatibility flag — reusing it defeated the reason this credential is separate in the first place
+
 ## [0.25.0](https://github.com/Higangssh/homebutler/compare/v0.24.0...v0.25.0) - 2026-09-02
 
 **Every permission failure homebutler can hit printed the operator's next command last.** `backup`, `restore`, `install` and `upgrade` all led with the raw syscall error and put the one line that mattered underneath it — and the detail could not simply be dropped, because there was no way to ask for it back. This release inverts the order and adds the flag that makes dropping it safe.

--- a/README.md
+++ b/README.md
@@ -459,10 +459,14 @@ CA file, and only then an explicit `insecure` fallback.
 
 Reads are plain. Power actions are not: every one of them takes an explicit
 endpoint, node, guest type and VMID, and refuses to run without `--confirm`,
-which is checked before the token is even read. `shutdown` asks the guest to shut
-down cleanly — it is not Proxmox's hard `stop`, which cuts power and can leave a
-filesystem behind it. A successful action reports the task it submitted, not that
-the guest finished; `proxmox task` answers that separately.
+which is checked before any credential is read. They also need their own
+`action_token_id` (plus `action_token` or `action_token_file`) configured on
+the endpoint — the read token alone will not start, reboot, or shut down a
+guest; see [Proxmox setup →](docs/proxmox.md) for creating that second token.
+`shutdown` asks the guest to shut down cleanly — it is not Proxmox's hard
+`stop`, which cuts power and can leave a filesystem behind it. A successful
+action reports the task it submitted, not that the guest finished; `proxmox
+task` answers that separately.
 
 `proxmox script` prints the install command for a Community Script pinned to one
 commit, along with a warning that the script is not reviewed by homebutler and

--- a/cmd/proxmox.go
+++ b/cmd/proxmox.go
@@ -45,6 +45,18 @@ func newProxmoxStatusCmd() *cobra.Command {
 }
 
 func openProxmoxClient(endpointName string) (*config.ProxmoxConfig, *proxmox.Client, error) {
+	return openProxmoxClientCredential(endpointName, false)
+}
+
+// openProxmoxActionClient is like openProxmoxClient but authenticates with the
+// endpoint's action credential instead of its read credential. Guest power
+// actions must never fall back to the read token: if no action credential is
+// configured, this fails before any network call.
+func openProxmoxActionClient(endpointName string) (*config.ProxmoxConfig, *proxmox.Client, error) {
+	return openProxmoxClientCredential(endpointName, true)
+}
+
+func openProxmoxClientCredential(endpointName string, action bool) (*config.ProxmoxConfig, *proxmox.Client, error) {
 	if serverName != "" || allServers {
 		return nil, nil, fmt.Errorf("proxmox commands do not support --server or --all; use --endpoint")
 	}
@@ -55,12 +67,12 @@ func openProxmoxClient(endpointName string) (*config.ProxmoxConfig, *proxmox.Cli
 	if err != nil {
 		return nil, nil, err
 	}
-	token, err := endpoint.TokenValue()
+	tokenID, token, err := endpoint.ResolveCredential(action)
 	if err != nil {
-		return nil, nil, fmt.Errorf("read token for Proxmox endpoint %q: %w", endpoint.Name, err)
+		return nil, nil, err
 	}
 	client, err := proxmox.New(proxmox.Options{
-		Host: endpoint.Host, Port: endpoint.APIPort(), TokenID: endpoint.TokenID, Token: token,
+		Host: endpoint.Host, Port: endpoint.APIPort(), TokenID: tokenID, Token: token,
 		Fingerprint: endpoint.Fingerprint, CAFile: endpoint.CAFile, Insecure: endpoint.Insecure, Timeout: endpoint.TimeoutDuration(),
 	})
 	if err != nil {
@@ -217,7 +229,7 @@ func newProxmoxGuestActionCmd(action proxmox.GuestAction) *cobra.Command {
 				return fmt.Errorf("confirmation required for Proxmox guest action: endpoint=%q node=%q type=%q vmid=%d action=%q; rerun with --endpoint %q --node %q --type %q --vmid %d --confirm",
 					endpointName, node, guestType, vmid, action, endpointName, node, guestType, vmid)
 			}
-			endpoint, client, err := openProxmoxClient(endpointName)
+			endpoint, client, err := openProxmoxActionClient(endpointName)
 			if err != nil {
 				return err
 			}

--- a/cmd/proxmox_test.go
+++ b/cmd/proxmox_test.go
@@ -382,7 +382,7 @@ func TestProxmoxGuestActions(t *testing.T) {
 				if r.Method != http.MethodPost {
 					t.Errorf("method = %q, want POST", r.Method)
 				}
-				if got, want := r.Header.Get("Authorization"), "PVEAPIToken=monitoring@pve!readonly=test-token"; got != want {
+				if got, want := r.Header.Get("Authorization"), "PVEAPIToken=action@pve!action=action-token"; got != want {
 					t.Errorf("Authorization = %q, want %q", got, want)
 				}
 				wantPath := "/api2/json/nodes/pve1/" + tt.guestType + "/100/status/" + string(tt.action)
@@ -395,7 +395,7 @@ func TestProxmoxGuestActions(t *testing.T) {
 
 			oldPath, oldJSON, oldCfg := cfgPath, jsonOutput, cfg
 			defer func() { cfgPath, jsonOutput, cfg = oldPath, oldJSON, oldCfg }()
-			cfgPath, jsonOutput, cfg = writeProxmoxTestConfig(t, server.URL), true, nil
+			cfgPath, jsonOutput, cfg = writeProxmoxActionTestConfig(t, server.URL), true, nil
 			cmd := newProxmoxGuestActionCmd(tt.action)
 			cmd.SetArgs([]string{"--endpoint", "pve", "--node", "pve1", "--type", tt.guestType, "--vmid", "100", "--confirm"})
 			var output bytes.Buffer
@@ -426,7 +426,7 @@ func TestProxmoxGuestActionHumanOutput(t *testing.T) {
 
 	oldPath, oldJSON, oldCfg := cfgPath, jsonOutput, cfg
 	defer func() { cfgPath, jsonOutput, cfg = oldPath, oldJSON, oldCfg }()
-	cfgPath, jsonOutput, cfg = writeProxmoxTestConfig(t, server.URL), false, nil
+	cfgPath, jsonOutput, cfg = writeProxmoxActionTestConfig(t, server.URL), false, nil
 	cmd := newProxmoxGuestActionCmd(proxmox.GuestActionStart)
 	cmd.SetArgs([]string{"--endpoint", "pve", "--node", "pve1", "--type", "qemu", "--vmid", "100", "--confirm"})
 	var output bytes.Buffer
@@ -450,6 +450,28 @@ func TestProxmoxGuestActionConfirmationPrecedesConfig(t *testing.T) {
 		if err == nil || !strings.Contains(err.Error(), want) {
 			t.Fatalf("confirmation error = %v, want %q", err, want)
 		}
+	}
+}
+
+func TestProxmoxGuestActionRequiresActionCredential(t *testing.T) {
+	requests := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		_, _ = w.Write([]byte(`{"data":"UPID:pve1:opaque"}`))
+	}))
+	defer server.Close()
+
+	oldPath, oldJSON, oldCfg := cfgPath, jsonOutput, cfg
+	defer func() { cfgPath, jsonOutput, cfg = oldPath, oldJSON, oldCfg }()
+	cfgPath, jsonOutput, cfg = writeProxmoxTestConfig(t, server.URL), true, nil
+	cmd := newProxmoxGuestActionCmd(proxmox.GuestActionStart)
+	cmd.SetArgs([]string{"--endpoint", "pve", "--node", "pve1", "--type", "qemu", "--vmid", "100", "--confirm"})
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "no action credential configured") {
+		t.Fatalf("action without action credential error = %v", err)
+	}
+	if requests != 0 {
+		t.Errorf("action without action credential made %d requests, want 0", requests)
 	}
 }
 
@@ -549,6 +571,28 @@ func writeProxmoxTestConfig(t *testing.T, serverURL string) string {
 	}
 	path := filepath.Join(t.TempDir(), "homebutler.yaml")
 	data := fmt.Sprintf("proxmox:\n  - name: pve\n    host: %s\n    port: %d\n    token_id: monitoring@pve!readonly\n    token: test-token\n    insecure: true\n", host, port)
+	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func writeProxmoxActionTestConfig(t *testing.T, serverURL string) string {
+	t.Helper()
+	parsed, err := url.Parse(serverURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	host, portText, err := net.SplitHostPort(parsed.Host)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "homebutler.yaml")
+	data := fmt.Sprintf("proxmox:\n  - name: pve\n    host: %s\n    port: %d\n    token_id: monitoring@pve!readonly\n    token: test-token\n    action_token_id: action@pve!action\n    action_token: action-token\n    insecure: true\n", host, port)
 	if err := os.WriteFile(path, []byte(data), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/docs/proxmox.md
+++ b/docs/proxmox.md
@@ -7,7 +7,7 @@ tasks, and the status of one asynchronous task.
 
 ## Setup
 
-### Create a least-privilege API token
+### Create least-privilege API tokens
 
 For read operations, the built-in `PVEAuditor` role is the recommended baseline.
 It includes the audit privileges needed for the cluster, node, guest, storage,
@@ -34,25 +34,48 @@ the user is not enough: the token can authenticate yet return empty resource
 lists. The `/` ACL is recommended because `/cluster/status` needs `Sys.Audit`
 on `/`.
 
-Guest actions need `VM.PowerMgmt` on each selected `/vms/<vmid>` path. Keep
-that permission separate from `PVEAuditor`; do not grant an administrator role
-to HomeButler. Create a narrow role and grant it to both the user and the
-privilege-separated token only for guests HomeButler may control:
+Guest actions use a second, separate token scoped only to `VM.PowerMgmt` on
+approved guests. Never grant `HomeButlerPower` to the read token or its user;
+keep the read credential audit-only, and never grant `PVEAuditor` to the
+action token or its user. The recommended setup is a dedicated second user,
+since a token's effective permissions are the intersection of its own ACLs
+and its owning user's ACLs — the action token could technically live on
+`monitoring@pve`, but only if that user is granted nothing beyond
+`HomeButlerPower` on the guest paths it controls.
 
 ```bash
+# Create a dedicated user for the action token (recommended).
+pveum user add power@pve --comment "least-privilege guest-action API user for homebutler"
+
+# Privilege separation is enabled by default. The token value is displayed once.
+pveum user token add power@pve action --privsep 1
+
+# Create the narrow role, then grant it to both the user and the token, only
+# for guests HomeButler may control.
 pveum role add HomeButlerPower -privs VM.PowerMgmt
-pveum acl modify /vms/100 --users 'monitoring@pve' --roles HomeButlerPower
-pveum acl modify /vms/100 --tokens 'monitoring@pve!readonly' --roles HomeButlerPower
+pveum acl modify /vms/100 --users 'power@pve' --roles HomeButlerPower
+pveum acl modify /vms/100 --tokens 'power@pve!action' --roles HomeButlerPower
 ```
 
-Repeat the two ACL commands only for other approved VMIDs. The task owner may
-inspect its own task. Inspecting a task started by another user requires
-`Sys.Audit` on the task's node; the read-only setup above already provides the
-audit privileges used by HomeButler's read views.
+> **Note:** A token's effective permissions are the intersection of the
+> token's own ACLs and its owning user's ACLs. Reusing the read token's user
+> (which already holds `PVEAuditor`) as the action token's owning user, or
+> disabling privilege separation (`--privsep 0`) on the action token, can
+> silently widen the action credential's effective access beyond
+> `VM.PowerMgmt` — anything else granted to that user elsewhere leaks through.
+> Restrict both the token and its owning user, and prefer a dedicated user for
+> the action credential if this boundary matters to the deployment.
 
-Save the token value when it is printed. Proxmox does not reveal it again; if
-it is lost, remove and create the token again. A newly granted token can briefly
-return `403 Permission check failed (/, Sys.Audit)` while ACL changes propagate.
+Repeat the two `HomeButlerPower` ACL commands only for other approved VMIDs.
+
+The task owner may inspect its own task. Inspecting a task started by another
+user requires `Sys.Audit` on the task's node; the read-only setup above
+already provides the audit privileges used by HomeButler's read views.
+
+Save each token value when it is printed. Proxmox does not reveal it again; if
+one is lost, remove and create that token again. A newly granted token can
+briefly return `403 Permission check failed (/, Sys.Audit)` while ACL changes
+propagate.
 
 ### Configure endpoints
 
@@ -67,6 +90,8 @@ proxmox:
     port: 8006                 # optional; 8006 is the default
     token_id: monitoring@pve!readonly
     token_file: ~/.config/homebutler/pve.token
+    action_token_id: power@pve!action        # optional; enables guest actions
+    action_token_file: ~/.config/homebutler/pve-action.token
     fingerprint: "AB:CD:EF:..." # recommended for self-signed node certificates
     timeout: 10s               # optional; 10s is the default
 ```
@@ -74,6 +99,12 @@ proxmox:
 `name`, `host`, and `token_id` are required. Configure exactly one credential
 source: `token_file` or the inline `token`. Inline tokens are supported, but
 HomeButler treats them as secrets and excludes them from JSON serialization.
+
+`action_token_id`, `action_token_file`, and `action_token` are optional and
+follow the same rules as their read-token counterparts: configure exactly one
+credential source (`action_token_file` or the inline `action_token`) alongside
+`action_token_id`. They enable guest start, reboot, and shutdown actions on
+this endpoint; without them, guest actions are unavailable.
 
 ## TLS
 
@@ -134,7 +165,10 @@ Guest actions always require explicit `--endpoint`, `--node`, `--type`,
 `--vmid`, and `--confirm` values, even when only one endpoint is configured.
 HomeButler does not discover or infer the node or guest type before an action.
 Without `--confirm`, the command reports the full target and exact rerun flags;
-it does not prompt interactively.
+it does not prompt interactively. If no `action_token_id`/`action_token`/
+`action_token_file` is configured for the endpoint, guest actions fail
+immediately with an explicit configuration error — this is intentional, and
+HomeButler never falls back to the read credential for an action.
 
 An action response means Proxmox accepted the asynchronous request. It does not
 mean the guest transition completed. HomeButler returns the UPID exactly as

--- a/homebutler.example.yaml
+++ b/homebutler.example.yaml
@@ -28,6 +28,8 @@ proxmox:
   #   port: 8006
   #   token_id: monitoring@pve!readonly
   #   token_file: ~/.config/homebutler/pve.token
+  #   action_token_id: power@pve!action        # optional, enables guest actions
+  #   action_token_file: ~/.config/homebutler/pve-action.token
   #   fingerprint: "AB:CD:EF:..."
   #   timeout: 10s
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -274,7 +274,8 @@ func (p ProxmoxConfig) ResolveCredential(action bool) (tokenID, token string, er
 		return p.TokenID, token, nil
 	}
 	if !p.HasActionCredential() {
-		return "", "", fmt.Errorf("no action credential configured for Proxmox endpoint %q; guest actions require action_token_id and action_token or action_token_file — see docs/proxmox.md", p.Name)
+		return "", "", proxmox.WithFailureClass(proxmox.FailureAuthentication,
+			fmt.Errorf("no action credential configured for Proxmox endpoint %q; guest actions require action_token_id and action_token or action_token_file — see docs/proxmox.md", p.Name))
 	}
 	token, err = p.ActionTokenValue()
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -171,6 +171,15 @@ type ProxmoxConfig struct {
 	CAFile      string `yaml:"ca_file,omitempty"`
 	Insecure    bool   `yaml:"insecure,omitempty"`
 	Timeout     string `yaml:"timeout,omitempty"`
+
+	// ActionTokenID/ActionToken/ActionTokenFile configure an optional second
+	// credential used only for guest power actions (start/reboot/shutdown).
+	// The credential above stays read-only; if no action credential is
+	// configured, guest actions are unavailable rather than falling back to
+	// the read credential.
+	ActionTokenID   string `yaml:"action_token_id,omitempty"`
+	ActionToken     string `yaml:"action_token,omitempty" json:"-" secret:"true"`
+	ActionTokenFile string `yaml:"action_token_file,omitempty"`
 }
 
 // APIPort returns the configured API port or Proxmox's default HTTPS port.
@@ -216,6 +225,62 @@ func (p ProxmoxConfig) TokenValue() (string, error) {
 		return token, nil
 	}
 	return "", proxmox.WithFailureClass(proxmox.FailureAuthentication, fmt.Errorf("proxmox token file %s is empty", p.TokenFile))
+}
+
+// HasActionCredential reports whether an action credential is configured for
+// guest power actions. Guest actions are unavailable when this is false;
+// there is no fallback to the read credential.
+func (p ProxmoxConfig) HasActionCredential() bool {
+	return p.ActionTokenID != "" && (p.ActionToken != "" || p.ActionTokenFile != "")
+}
+
+// ActionTokenFilePath expands a leading ~/ in the configured action token
+// file path.
+func (p ProxmoxConfig) ActionTokenFilePath() string {
+	return expandHome(p.ActionTokenFile)
+}
+
+// ActionTokenValue returns the action API token from the configured file or
+// inline value, mirroring TokenValue's file-wins precedence.
+func (p ProxmoxConfig) ActionTokenValue() (string, error) {
+	if p.ActionTokenFile == "" {
+		if p.ActionToken == "" {
+			return "", fmt.Errorf("proxmox action token is not configured")
+		}
+		return p.ActionToken, nil
+	}
+
+	data, err := os.ReadFile(p.ActionTokenFilePath())
+	if err != nil {
+		return "", proxmox.WithFailureClass(proxmox.FailureAuthentication, fmt.Errorf("read Proxmox action token file %s: %w", p.ActionTokenFile, err))
+	}
+	if token := strings.TrimSpace(string(data)); token != "" {
+		return token, nil
+	}
+	return "", proxmox.WithFailureClass(proxmox.FailureAuthentication, fmt.Errorf("proxmox action token file %s is empty", p.ActionTokenFile))
+}
+
+// ResolveCredential returns the token ID and token value for either the read
+// or action credential, wrapping resolution failures the same way across
+// every caller. Guest actions never fall back to the read credential: when
+// action is true and no action credential is configured, this fails before
+// any token is read.
+func (p ProxmoxConfig) ResolveCredential(action bool) (tokenID, token string, err error) {
+	if !action {
+		token, err = p.TokenValue()
+		if err != nil {
+			return "", "", fmt.Errorf("read token for Proxmox endpoint %q: %w", p.Name, err)
+		}
+		return p.TokenID, token, nil
+	}
+	if !p.HasActionCredential() {
+		return "", "", fmt.Errorf("no action credential configured for Proxmox endpoint %q; guest actions require action_token_id and action_token or action_token_file — see docs/proxmox.md", p.Name)
+	}
+	token, err = p.ActionTokenValue()
+	if err != nil {
+		return "", "", fmt.Errorf("read action token for Proxmox endpoint %q: %w", p.Name, err)
+	}
+	return p.ActionTokenID, token, nil
 }
 
 type WakeTarget struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -326,6 +326,8 @@ func TestProxmoxConfigResolveCredential(t *testing.T) {
 	}
 	if _, _, err := readOnly.ResolveCredential(true); err == nil || !strings.Contains(err.Error(), "no action credential configured") {
 		t.Errorf("ResolveCredential(true) without an action credential = %v, want a 'no action credential configured' error", err)
+	} else if class := proxmox.Classify(err); class != proxmox.FailureAuthentication {
+		t.Errorf("Classify(ResolveCredential(true) error) = %q, want %q", class, proxmox.FailureAuthentication)
 	}
 
 	withAction := readOnly

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -268,6 +268,78 @@ func TestProxmoxConfigTokenValue(t *testing.T) {
 	}
 }
 
+func TestProxmoxConfigActionTokenValue(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	path := filepath.Join(dir, "pve-action.token")
+	if err := os.WriteFile(path, []byte("  from-file\n"), 0600); err != nil {
+		t.Fatalf("write action token: %v", err)
+	}
+
+	fromFile := ProxmoxConfig{ActionTokenFile: "~/pve-action.token"}
+	if got := fromFile.ActionTokenFilePath(); got != path {
+		t.Errorf("ActionTokenFilePath() = %q, want %q", got, path)
+	}
+	if got, err := fromFile.ActionTokenValue(); err != nil || got != "from-file" {
+		t.Errorf("ActionTokenValue() = (%q, %v), want (from-file, nil)", got, err)
+	}
+
+	inline := ProxmoxConfig{ActionToken: "inline-action-token"}
+	if got, err := inline.ActionTokenValue(); err != nil || got != "inline-action-token" {
+		t.Errorf("ActionTokenValue() = (%q, %v), want (inline-action-token, nil)", got, err)
+	}
+	if _, err := (ProxmoxConfig{}).ActionTokenValue(); err == nil {
+		t.Error("ActionTokenValue() should fail without an action token source")
+	}
+
+	if _, err := (ProxmoxConfig{ActionTokenFile: filepath.Join(dir, "missing"), ActionToken: "inline-secret"}).ActionTokenValue(); err == nil {
+		t.Error("ActionTokenValue() should fail for a missing token file")
+	} else if proxmox.Classify(err) != proxmox.FailureAuthentication || strings.Contains(err.Error(), "inline-secret") {
+		t.Errorf("ActionTokenValue() error = %v, want authentication error without inline token", err)
+	}
+}
+
+func TestProxmoxConfigHasActionCredential(t *testing.T) {
+	cases := []struct {
+		name string
+		cfg  ProxmoxConfig
+		want bool
+	}{
+		{"none configured", ProxmoxConfig{}, false},
+		{"read token only", ProxmoxConfig{Token: "read"}, false},
+		{"action id without token", ProxmoxConfig{ActionTokenID: "monitoring@pve!action"}, false},
+		{"action id with inline token", ProxmoxConfig{ActionTokenID: "monitoring@pve!action", ActionToken: "secret"}, true},
+		{"action id with token file", ProxmoxConfig{ActionTokenID: "monitoring@pve!action", ActionTokenFile: "/etc/pve-action.token"}, true},
+	}
+	for _, tc := range cases {
+		if got := tc.cfg.HasActionCredential(); got != tc.want {
+			t.Errorf("%s: HasActionCredential() = %v, want %v", tc.name, got, tc.want)
+		}
+	}
+}
+
+func TestProxmoxConfigResolveCredential(t *testing.T) {
+	readOnly := ProxmoxConfig{Name: "pve", TokenID: "monitoring@pve!readonly", Token: "read-token"}
+	if tokenID, token, err := readOnly.ResolveCredential(false); err != nil || tokenID != "monitoring@pve!readonly" || token != "read-token" {
+		t.Errorf("ResolveCredential(false) = (%q, %q, %v), want (monitoring@pve!readonly, read-token, nil)", tokenID, token, err)
+	}
+	if _, _, err := readOnly.ResolveCredential(true); err == nil || !strings.Contains(err.Error(), "no action credential configured") {
+		t.Errorf("ResolveCredential(true) without an action credential = %v, want a 'no action credential configured' error", err)
+	}
+
+	withAction := readOnly
+	withAction.ActionTokenID = "monitoring@pve!action"
+	withAction.ActionToken = "action-token"
+	if tokenID, token, err := withAction.ResolveCredential(true); err != nil || tokenID != "monitoring@pve!action" || token != "action-token" {
+		t.Errorf("ResolveCredential(true) = (%q, %q, %v), want (monitoring@pve!action, action-token, nil)", tokenID, token, err)
+	}
+
+	if _, _, err := (ProxmoxConfig{Name: "pve"}).ResolveCredential(false); err == nil {
+		t.Error("ResolveCredential(false) should fail without a read token source")
+	}
+}
+
 func TestProxmoxConfigDefaults(t *testing.T) {
 	p := ProxmoxConfig{}
 	if got := p.APIPort(); got != 8006 {

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -493,6 +493,21 @@ func (r *ValidationResult) checkServers(cfg *Config) {
 	}
 }
 
+// sameProxmoxCredential reports whether the action credential's token source
+// is textually identical to the read credential's — either the same inline
+// value or the same file path. It does not read file contents: two different
+// paths could still hold the same secret, but that is outside what config
+// alone can tell.
+func sameProxmoxCredential(p ProxmoxConfig) bool {
+	if p.Token != "" && p.ActionToken != "" {
+		return p.Token == p.ActionToken
+	}
+	if p.TokenFile != "" && p.ActionTokenFile != "" {
+		return p.TokenFile == p.ActionTokenFile
+	}
+	return false
+}
+
 func (r *ValidationResult) checkProxmox(cfg *Config) {
 	seen := map[string]int{}
 	for i, p := range cfg.Proxmox {
@@ -542,7 +557,7 @@ func (r *ValidationResult) checkProxmox(cfg *Config) {
 		if p.ActionTokenID != "" || p.ActionToken != "" || p.ActionTokenFile != "" {
 			if p.ActionTokenID == "" {
 				r.add(SeverityError, field+".action_token_id", "Proxmox action_token_id is required when an action credential is configured.",
-					"Set the API token ID for the action credential, such as monitoring@pve!action.")
+					"Set the API token ID for a dedicated action user, such as power@pve!action — not the read-only user, which would widen its access.")
 			}
 			if p.ActionToken == "" && p.ActionTokenFile == "" {
 				r.add(SeverityError, field, "An action_token or action_token_file is required when action_token_id is set.",
@@ -553,9 +568,24 @@ func (r *ValidationResult) checkProxmox(cfg *Config) {
 					"Keep action_token_file (preferred) or action_token, but not both.")
 			}
 			if p.ActionTokenFile != "" {
-				if _, err := os.Stat(p.ActionTokenFilePath()); os.IsNotExist(err) {
+				if info, err := os.Stat(p.ActionTokenFilePath()); os.IsNotExist(err) {
 					r.add(SeverityError, field+".action_token_file", fmt.Sprintf("Action token file %s does not exist.", p.ActionTokenFile), "Create the file or set action_token instead.")
+				} else if err == nil && runtime.GOOS != "windows" {
+					if perm := info.Mode().Perm(); perm&0o077 != 0 {
+						r.add(SeverityWarning, field+".action_token_file",
+							fmt.Sprintf("Action token file %s is readable by group or others (%04o).", p.ActionTokenFile, perm),
+							fmt.Sprintf("This credential grants VM.PowerMgmt. Run: chmod 600 %s", p.ActionTokenFilePath()))
+					}
 				}
+			}
+			if p.HasActionCredential() && p.ActionTokenID == p.TokenID {
+				r.add(SeverityWarning, field+".action_token_id",
+					"action_token_id is the same as token_id, so the action credential is not separate from the read credential.",
+					"Use a dedicated user for the action token, such as power@pve!action; see docs/proxmox.md for the ACL split.")
+			} else if p.HasActionCredential() && sameProxmoxCredential(p) {
+				r.add(SeverityWarning, field+".action_token",
+					"The action token value is the same as the read token, so the two credentials carry identical access.",
+					"Issue a separate token for guest actions; see docs/proxmox.md for the ACL split.")
 			}
 		}
 	}

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -538,6 +538,26 @@ func (r *ValidationResult) checkProxmox(cfg *Config) {
 				r.add(SeverityError, field+".timeout", fmt.Sprintf("Invalid duration %q.", p.Timeout), `Use a positive Go duration such as "10s".`)
 			}
 		}
+
+		if p.ActionTokenID != "" || p.ActionToken != "" || p.ActionTokenFile != "" {
+			if p.ActionTokenID == "" {
+				r.add(SeverityError, field+".action_token_id", "Proxmox action_token_id is required when an action credential is configured.",
+					"Set the API token ID for the action credential, such as monitoring@pve!action.")
+			}
+			if p.ActionToken == "" && p.ActionTokenFile == "" {
+				r.add(SeverityError, field, "An action_token or action_token_file is required when action_token_id is set.",
+					"action_token_file is preferred so the token is not stored in the config file.")
+			}
+			if p.ActionToken != "" && p.ActionTokenFile != "" {
+				r.add(SeverityError, field, "Both Proxmox action_token and action_token_file are set.",
+					"Keep action_token_file (preferred) or action_token, but not both.")
+			}
+			if p.ActionTokenFile != "" {
+				if _, err := os.Stat(p.ActionTokenFilePath()); os.IsNotExist(err) {
+					r.add(SeverityError, field+".action_token_file", fmt.Sprintf("Action token file %s does not exist.", p.ActionTokenFile), "Create the file or set action_token instead.")
+				}
+			}
+		}
 	}
 }
 

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -216,6 +216,67 @@ proxmox:
 	}
 }
 
+func TestValidateProxmoxActionCredentialErrors(t *testing.T) {
+	path := writeConfig(t, `
+proxmox:
+  - name: pve
+    host: pve.example
+    token_id: monitoring@pve!readonly
+    token: read-token
+    action_token_id: monitoring@pve!action
+    action_token: inline-action
+    action_token_file: /does/not/exist
+  - name: pve2
+    host: pve2.example
+    token_id: monitoring@pve!readonly
+    token: read-token
+    action_token_id: monitoring@pve!action
+    action_token: inline-action
+`)
+
+	r := Validate(path)
+	if r.Valid {
+		t.Fatal("expected invalid config")
+	}
+	for _, field := range []string{
+		"proxmox[0]", "proxmox[0].action_token_file",
+	} {
+		requireFinding(t, r, field, SeverityError)
+	}
+	if _, found := findingFor(r, "proxmox[1]"); found {
+		t.Errorf("action_token_id with action_token alone should be valid: %+v", r.Findings)
+	}
+}
+
+func TestValidateProxmoxActionTokenIDRequired(t *testing.T) {
+	path := writeConfig(t, `
+proxmox:
+  - name: pve
+    host: pve.example
+    token_id: monitoring@pve!readonly
+    token: read-token
+    action_token: inline-action-without-id
+`)
+
+	r := Validate(path)
+	requireFinding(t, r, "proxmox[0].action_token_id", SeverityError)
+}
+
+func TestValidateProxmoxNoActionCredentialIsValid(t *testing.T) {
+	path := writeConfig(t, `
+proxmox:
+  - name: pve
+    host: pve.example
+    token_id: monitoring@pve!readonly
+    token: read-token
+`)
+
+	r := Validate(path)
+	if !r.Valid {
+		t.Errorf("expected valid config without an action credential, got findings: %+v", r.Findings)
+	}
+}
+
 func TestValidateProxmoxTokenFile(t *testing.T) {
 	dir := t.TempDir()
 	tokenPath := filepath.Join(dir, "pve.token")

--- a/internal/config/validate_test.go
+++ b/internal/config/validate_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -275,6 +276,85 @@ proxmox:
 	if !r.Valid {
 		t.Errorf("expected valid config without an action credential, got findings: %+v", r.Findings)
 	}
+}
+
+func TestValidateProxmoxActionCredentialSameIDWarns(t *testing.T) {
+	path := writeConfig(t, `
+proxmox:
+  - name: pve
+    host: pve.example
+    token_id: monitoring@pve!readonly
+    token: read-token
+    action_token_id: monitoring@pve!readonly
+    action_token: different-token
+`)
+
+	r := Validate(path)
+	if !r.Valid {
+		t.Fatalf("a warning should not invalidate the config: %+v", r.Findings)
+	}
+	requireFinding(t, r, "proxmox[0].action_token_id", SeverityWarning)
+}
+
+func TestValidateProxmoxActionCredentialSameTokenWarns(t *testing.T) {
+	path := writeConfig(t, `
+proxmox:
+  - name: pve
+    host: pve.example
+    token_id: monitoring@pve!readonly
+    token: shared-token
+    action_token_id: monitoring@pve!action
+    action_token: shared-token
+`)
+
+	r := Validate(path)
+	requireFinding(t, r, "proxmox[0].action_token", SeverityWarning)
+}
+
+func TestValidateProxmoxActionCredentialSameFileWarns(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "pve.token")
+	if err := os.WriteFile(tokenPath, []byte("token"), 0600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+
+	path := writeConfig(t, fmt.Sprintf(`
+proxmox:
+  - name: pve
+    host: pve.example
+    token_id: monitoring@pve!readonly
+    token_file: %s
+    action_token_id: monitoring@pve!action
+    action_token_file: %s
+`, tokenPath, tokenPath))
+
+	r := Validate(path)
+	requireFinding(t, r, "proxmox[0].action_token", SeverityWarning)
+}
+
+func TestValidateProxmoxActionTokenFilePermissionsWarns(t *testing.T) {
+	dir := t.TempDir()
+	tokenPath := filepath.Join(dir, "pve.token")
+	if err := os.WriteFile(tokenPath, []byte("token"), 0600); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+	actionTokenPath := filepath.Join(dir, "pve.action.token")
+	if err := os.WriteFile(actionTokenPath, []byte("token"), 0644); err != nil {
+		t.Fatalf("write action token: %v", err)
+	}
+
+	path := writeConfig(t, fmt.Sprintf(`
+proxmox:
+  - name: pve
+    host: pve.example
+    token_id: monitoring@pve!readonly
+    token_file: %s
+    action_token_id: monitoring@pve!action
+    action_token_file: %s
+`, tokenPath, actionTokenPath))
+
+	r := Validate(path)
+	requireFinding(t, r, "proxmox[0].action_token_file", SeverityWarning)
 }
 
 func TestValidateProxmoxTokenFile(t *testing.T) {

--- a/internal/mcp/proxmox.go
+++ b/internal/mcp/proxmox.go
@@ -76,12 +76,12 @@ func (s *Server) executeProxmox(name string, args map[string]any) (any, error) {
 	if err != nil {
 		return nil, err
 	}
-	token, err := endpoint.TokenValue()
+	tokenID, token, err := endpoint.ResolveCredential(isAction)
 	if err != nil {
-		return nil, fmt.Errorf("read token for Proxmox endpoint %q: %w", endpoint.Name, err)
+		return nil, err
 	}
 	client, err := proxmox.New(proxmox.Options{
-		Host: endpoint.Host, Port: endpoint.APIPort(), TokenID: endpoint.TokenID, Token: token,
+		Host: endpoint.Host, Port: endpoint.APIPort(), TokenID: tokenID, Token: token,
 		Fingerprint: endpoint.Fingerprint, CAFile: endpoint.CAFile, Insecure: endpoint.Insecure, Timeout: endpoint.TimeoutDuration(),
 	})
 	if err != nil {

--- a/internal/mcp/proxmox_test.go
+++ b/internal/mcp/proxmox_test.go
@@ -115,10 +115,15 @@ func TestProxmoxPhase2Dispatch(t *testing.T) {
 	var requests []string
 	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests = append(requests, r.URL.EscapedPath())
-		if got, want := r.Header.Get("Authorization"), "PVEAPIToken=monitoring@pve!readonly=fixture-token"; got != want {
+		isTaskStatus := strings.HasSuffix(r.URL.Path, "/status") && strings.Contains(r.URL.Path, "/tasks/")
+		want := "PVEAPIToken=power@pve!actions=fixture-action-token"
+		if isTaskStatus {
+			want = "PVEAPIToken=monitoring@pve!readonly=fixture-token"
+		}
+		if got := r.Header.Get("Authorization"); got != want {
 			t.Errorf("Authorization = %q, want %q", got, want)
 		}
-		if strings.HasSuffix(r.URL.Path, "/status") && strings.Contains(r.URL.Path, "/tasks/") {
+		if isTaskStatus {
 			if r.Method != http.MethodGet {
 				t.Errorf("task method = %q, want GET", r.Method)
 			}
@@ -131,7 +136,7 @@ func TestProxmoxPhase2Dispatch(t *testing.T) {
 		_, _ = w.Write([]byte(`{"data":"UPID:pve1:opaque"}`))
 	}))
 	defer server.Close()
-	s := testProxmoxMCPServer(t, server.URL)
+	s := testProxmoxMCPServerWithAction(t, server.URL)
 
 	tests := []struct {
 		name       string
@@ -168,6 +173,26 @@ func TestProxmoxPhase2Dispatch(t *testing.T) {
 	task := status.(proxmox.TaskStatus)
 	if task.Status != "stopped" || task.ExitStatus != "OK" || task.Result != "ok" {
 		t.Errorf("task status = %#v", task)
+	}
+}
+
+func TestProxmoxGuestActionRequiresActionCredential(t *testing.T) {
+	var requests int
+	server := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	s := testProxmoxMCPServer(t, server.URL)
+
+	_, err := s.executeTool("proxmox_guest_start", map[string]any{
+		"endpoint": "pve", "node": "pve1", "type": "qemu", "vmid": float64(100), "confirm": true,
+	})
+	if err == nil || !strings.Contains(err.Error(), "no action credential configured for Proxmox endpoint \"pve\"") {
+		t.Fatalf("error = %v, want no action credential message", err)
+	}
+	if requests != 0 {
+		t.Errorf("requests = %d, want 0 (no network call before the credential check)", requests)
 	}
 }
 
@@ -283,6 +308,23 @@ func testProxmoxMCPServer(t *testing.T, rawURL string) *Server {
 	}
 	return NewServer(&config.Config{Proxmox: []config.ProxmoxConfig{{
 		Name: "pve", Host: u.Hostname(), Port: port, TokenID: "monitoring@pve!readonly", Token: "fixture-token", Insecure: true,
+	}}}, "test")
+}
+
+func testProxmoxMCPServerWithAction(t *testing.T, rawURL string) *Server {
+	t.Helper()
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return NewServer(&config.Config{Proxmox: []config.ProxmoxConfig{{
+		Name: "pve", Host: u.Hostname(), Port: port, Insecure: true,
+		TokenID: "monitoring@pve!readonly", Token: "fixture-token",
+		ActionTokenID: "power@pve!actions", ActionToken: "fixture-action-token",
 	}}}, "test")
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -494,14 +494,14 @@ func (s *Server) handleProxmoxStatus(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, err.Error())
 		return
 	}
-	token, err := endpoint.TokenValue()
+	tokenID, token, err := endpoint.ResolveCredential(false)
 	if err != nil {
-		log.Printf("read token for Proxmox endpoint %q: %v", endpoint.Name, err)
+		log.Print(err)
 		writeError(w, http.StatusInternalServerError, fmt.Sprintf("Proxmox endpoint %q credentials are unavailable", endpoint.Name))
 		return
 	}
 	client, err := proxmox.New(proxmox.Options{
-		Host: endpoint.Host, Port: endpoint.APIPort(), TokenID: endpoint.TokenID, Token: token,
+		Host: endpoint.Host, Port: endpoint.APIPort(), TokenID: tokenID, Token: token,
 		Fingerprint: endpoint.Fingerprint, CAFile: endpoint.CAFile, Insecure: endpoint.Insecure, Timeout: endpoint.TimeoutDuration(),
 	})
 	if err != nil {


### PR DESCRIPTION
A single Proxmox token has done double duty. The same credential that drives read only status calls also carries the power to start, reboot, and shut down a guest, even though status polling never needed that permission in the first place. This closes issue #107, where that coupling was flagged as a design problem worth fixing before it caused an actual incident.

Guest start, reboot, and shutdown now resolve a second, optional credential (action_token_id plus action_token or action_token_file) instead of the endpoint's read token. The dashboard, watcher, and read only MCP tools are untouched, since they never needed anything more than the read credential.

There is no fallback and no compatibility flag. Anyone already running guest actions today needs to add the new fields to their config, or those commands start failing with a named error the moment this ships. That tradeoff was made deliberately: a warning that keeps the old behavior working would reintroduce the exact silent fallback the issue exists to remove. docs/proxmox.md walks through creating the second token with a least privilege ACL, including a note on the token and user permission intersection, since reusing the read user for the action token can quietly widen its access.

On the implementation side, config resolution for both credentials now goes through one method, ProxmoxConfig.ResolveCredential, so the CLI and MCP paths share the same logic and the same error text instead of each hand rolling the branch.

Verification:
- gofmt -w .
- go vet ./...
- golangci-lint run
- go test ./...
- go build ./...

Full design discussion, including the answers to the issue's six open questions, is in the comment thread on #107.