### PR TITLE
feat: support modern MCP requests without a handshake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,15 +4,38 @@ All notable changes to this project will be documented in this file.
 
 ## Unreleased
 
-**Modern MCP clients can now use homebutler without a lifecycle handshake while legacy clients keep working.**
+**Modern MCP clients can now use homebutler without a lifecycle handshake, while reports now identify what changed between snapshots.**
 
-### Features
+```
+── Notable Changes ───────────────────────────────────────────
+   gone      vaultwarden   was running
+   new       gitea         now running
+   replaced  nginx         7d4a91f0aa11 → 91be0322bb22
+   image     jellyfin      jellyfin:10.9.11 → jellyfin:10.10.0
+   state     7 containers  postgres, redis, grafana, +4
+   port      :8080/tcp     vaultwarden → gitea
+   disk      /             +2.4 GB since last report
+```
+
+### ✨ Features
 
 - add the MCP 2026-07-28 `server/discover` RPC, per-request metadata validation, version mismatch errors, result typing, cache hints, and deterministic tool ordering
+- compare containers and listeners by identity rather than by cardinality (#58). Containers are matched by name and then by container ID, image and state; listeners by bind address, port number and protocol, then by the process answering on them. The address is part of a listener's identity: without it a service moving from `127.0.0.1` to `0.0.0.0` — the change in this section with the largest consequence — reads as no change at all. The case this exists for is `replaced` — a container recreated under the same name, which leaves every count identical and was therefore invisible. `docs/report.md` is new and states what earns a line and what is deliberately suppressed: uptime strings, CPU and memory, and restart counters that moved without a state change, because a report nobody reads is worse than no report
+- collapse more than five changes of one kind into a line that names three and counts the rest. Grouping and truncation happen only in the human renderer — `--json` carries every change, ungrouped, because a person needs the section readable and anything parsing the output needs all of it
+- skip the comparison, and say so *in the section*, when a collector did not answer for either snapshot. Diffing against a snapshot taken while Docker was down would otherwise report every container as gone — and putting the caveat only in a trailing warning would hand anything reading `notable_changes` an all-clear the report cannot stand behind
+- track processes across runs (#59). A process is identified by its executable name and a hash of its full invocation, so a name that appears, disappears, or comes back running something else is reported — `python3 /opt/old.py` becoming `python3 /opt/new.py` is a `replaced` rather than silence. Identical invocations collapse to one identity, because eight workers sharing a command line are one thing running and a pool resizing is a resource signal rather than an arrival
+- ignore processes that have not been running for a minute. This threshold was measured rather than chosen: two runs thirty seconds apart on an idle machine reported `new head` and `new sed`, which was the shell pipeline reading the report. A process held back is reported on the next run, by which time it has earned the word "new"
 
-### Behavior changes
+### 🔐 Security
+
+- keep the executable name and a twelve-character hash of the invocation, never the command line itself. Command lines carry secrets in flags and `~/.homebutler/reports/snapshots/` has never had to be handled as a credential store. `ProcessInfo.Command` is excluded from JSON, so neither the `processes` command nor its MCP tool gains the field
+
+### ⚠️ Behavior changes
 
 - modern requests use stateless per-request metadata; legacy `initialize` requests continue to negotiate legacy protocol versions
+- **`notable_changes` no longer contains the count lines** `Running containers: N → M`, `Stopped containers: N → M` or `Public ports: N → M`. They are replaced by one entry per change, shaped `kind: subject — detail`. Anything matching on the old strings needs updating; the field is still `[]string` and the JSON schema is unchanged
+- **The human report leads with `Notable Changes` rather than `Current Status`.** Current status is context for what moved above it, not the headline. `--json` is unaffected — field order in the document has not changed
+- **Snapshots are larger.** On a desktop macOS with 639 distinct process identities a snapshot is about 50 KB, against 2 KB before; a Linux server running a few services is well under that. At the default `--keep 30` that is roughly 1.5 MB of history in the worst case measured. No cap is imposed — the measurement did not call for one — but it is worth knowing before turning `--keep` up
 
 ## [0.25.0](https://github.com/Higangssh/homebutler/compare/v0.24.0...v0.25.0) - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+**Modern MCP clients can now use homebutler without a lifecycle handshake while legacy clients keep working.**
+
+### Features
+
+- add the MCP 2026-07-28 `server/discover` RPC, per-request metadata validation, version mismatch errors, result typing, cache hints, and deterministic tool ordering
+
+### Behavior changes
+
+- modern requests use stateless per-request metadata; legacy `initialize` requests continue to negotiate legacy protocol versions
+
 ## [0.25.0](https://github.com/Higangssh/homebutler/compare/v0.24.0...v0.25.0) - 2026-09-02
 
 **Every permission failure homebutler can hit printed the operator's next command last.** `backup`, `restore`, `install` and `upgrade` all led with the raw syscall error and put the one line that mattered underneath it — and the detail could not simply be dropped, because there was no way to ask for it back. This release inverts the order and adds the flag that makes dropping it safe.

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -148,7 +148,8 @@ homebutler implements the MCP revisions `2026-07-28`, `2025-11-25`,
 `2025-06-18`, `2025-03-26` and `2024-11-05`. Modern clients send the protocol
 version and client capabilities in each request's `_meta`; they can start with
 `server/discover` without an `initialize` handshake. Legacy clients continue to
-use `initialize` unchanged.
+use `initialize` unchanged. An `initialize` request that carries modern `_meta`
+is rejected because the two opening modes contradict each other.
 
 For a tools-only stdio server these revisions describe the same tool surface.
 Modern `tools/list` responses include `resultType`, a five-minute `ttlMs` hint,

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -144,15 +144,18 @@ No network ports opened. MCP uses stdio (stdin/stdout) — only the parent AI pr
 
 ### Protocol versions
 
-homebutler implements the MCP revisions `2025-11-25`, `2025-06-18`, `2025-03-26`
-and `2024-11-05`. A client's `initialize` gets the version it asked for when
-that is one of them, and `2025-11-25` when it is not, so an older client keeps
-working and a current one is not held back.
+homebutler implements the MCP revisions `2026-07-28`, `2025-11-25`,
+`2025-06-18`, `2025-03-26` and `2024-11-05`. Modern clients send the protocol
+version and client capabilities in each request's `_meta`; they can start with
+`server/discover` without an `initialize` handshake. Legacy clients continue to
+use `initialize` unchanged.
 
-For a tools-only stdio server these four describe the same surface. What the
-later revisions added is either out of scope here — resources, prompts,
-sampling, roots, elicitation, tasks, and everything about Streamable HTTP — or
-already how homebutler behaves.
+For a tools-only stdio server these revisions describe the same tool surface.
+Modern `tools/list` responses include `resultType`, a five-minute `ttlMs` hint,
+`cacheScope: "public"`, and a deterministic tool order. What the later
+revisions added is either out of scope here — resources, prompts, sampling,
+roots, elicitation, tasks, and everything about Streamable HTTP — or already
+how homebutler behaves.
 
 ## Agent Skill
 

--- a/internal/mcp/capabilities.go
+++ b/internal/mcp/capabilities.go
@@ -1,5 +1,7 @@
 package mcp
 
+import "sort"
+
 type capabilityRisk string
 
 const (
@@ -52,6 +54,7 @@ func toolDefinitions() []toolDef {
 	for _, c := range capabilityRegistry {
 		defs = append(defs, c.tool)
 	}
+	sort.Slice(defs, func(i, j int) bool { return defs[i].Name < defs[j].Name })
 	return defs
 }
 

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -57,8 +57,8 @@ func TestInitialize(t *testing.T) {
 
 	// params carried no protocolVersion, so there is nothing to echo and the
 	// newest supported revision is the right answer.
-	if init.ProtocolVersion != supportedProtocolVersions[0] {
-		t.Errorf("protocolVersion = %q, want %q", init.ProtocolVersion, supportedProtocolVersions[0])
+	if init.ProtocolVersion != legacyProtocolVersions[0] {
+		t.Errorf("protocolVersion = %q, want %q", init.ProtocolVersion, legacyProtocolVersions[0])
 	}
 	if init.ServerInfo.Name != "homebutler" {
 		t.Errorf("serverInfo.name = %q, want %q", init.ServerInfo.Name, "homebutler")
@@ -505,11 +505,11 @@ func TestInitializeVersion(t *testing.T) {
 // was the oldest thing it could conformantly say, and clients cap their
 // behaviour to the version they are handed.
 func TestNegotiateProtocolVersion(t *testing.T) {
-	latest := supportedProtocolVersions[0]
+	latest := legacyProtocolVersions[0]
 
 	// "If the server supports the requested protocol version, it MUST respond
 	// with the same version."
-	for _, v := range supportedProtocolVersions {
+	for _, v := range legacyProtocolVersions {
 		if got := negotiateProtocolVersion(v); got != v {
 			t.Errorf("negotiateProtocolVersion(%q) = %q, want the same version back", v, got)
 		}
@@ -529,7 +529,7 @@ func TestNegotiateProtocolVersion(t *testing.T) {
 }
 
 func TestInitializeEchoesTheRequestedVersion(t *testing.T) {
-	for _, want := range supportedProtocolVersions {
+	for _, want := range legacyProtocolVersions {
 		s, out := newTestServer()
 		req := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"` + want + `"}}`
 		resp := sendAndReceive(t, s, out, req)
@@ -561,8 +561,8 @@ func TestInitializeAnswersLatestForAVersionItDoesNotSpeak(t *testing.T) {
 	if err := json.Unmarshal(result, &init); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if init.ProtocolVersion != supportedProtocolVersions[0] {
-		t.Errorf("protocolVersion = %q, want the latest supported %q", init.ProtocolVersion, supportedProtocolVersions[0])
+	if init.ProtocolVersion != legacyProtocolVersions[0] {
+		t.Errorf("protocolVersion = %q, want the latest legacy version %q", init.ProtocolVersion, legacyProtocolVersions[0])
 	}
 }
 
@@ -579,7 +579,7 @@ func TestInitializeWithoutParams(t *testing.T) {
 	if err := json.Unmarshal(result, &init); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	if init.ProtocolVersion != supportedProtocolVersions[0] {
+	if init.ProtocolVersion != legacyProtocolVersions[0] {
 		t.Errorf("protocolVersion = %q", init.ProtocolVersion)
 	}
 }
@@ -599,6 +599,91 @@ func TestPingIsAnswered(t *testing.T) {
 		t.Fatalf("marshal: %v", err)
 	}
 	if string(result) != "{}" {
-		t.Errorf("ping result = %s, want an empty object", result)
+		t.Errorf("legacy ping result = %s, want an empty object", result)
+	}
+}
+
+func modernMeta(version string) string {
+	return `"_meta":{"io.modelcontextprotocol/protocolVersion":"` + version + `","io.modelcontextprotocol/clientCapabilities":{}}`
+}
+
+func TestModernDiscover(t *testing.T) {
+	s, out := newTestServer()
+	req := `{"jsonrpc":"2.0","id":1,"method":"server/discover","params":{` + modernMeta(supportedProtocolVersions[0]) + `}}`
+	resp := sendAndReceive(t, s, out, req)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	result, _ := json.Marshal(resp.Result)
+	var discover discoverResult
+	if err := json.Unmarshal(result, &discover); err != nil {
+		t.Fatalf("unmarshal discover result: %v", err)
+	}
+	if discover.ResultType != "complete" {
+		t.Errorf("resultType = %q, want complete", discover.ResultType)
+	}
+	if len(discover.SupportedVersions) == 0 || discover.SupportedVersions[0] != "2026-07-28" {
+		t.Errorf("supportedVersions = %v", discover.SupportedVersions)
+	}
+	if discover.Meta.ServerInfo.Name != "homebutler" || discover.Meta.ServerInfo.Version != "test" {
+		t.Errorf("serverInfo = %+v", discover.Meta.ServerInfo)
+	}
+}
+
+func TestModernUnsupportedVersion(t *testing.T) {
+	s, out := newTestServer()
+	req := `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{` + modernMeta("1900-01-01") + `}}`
+	resp := sendAndReceive(t, s, out, req)
+	if resp.Error == nil || resp.Error.Code != -32022 {
+		t.Fatalf("error = %+v, want -32022", resp.Error)
+	}
+	data, ok := resp.Error.Data.(map[string]any)
+	if !ok {
+		t.Fatalf("error data = %#v, want object", resp.Error.Data)
+	}
+	if data["requested"] != "1900-01-01" {
+		t.Errorf("requested = %#v", data["requested"])
+	}
+}
+
+func TestRemovedPingIsRejectedByModernProtocol(t *testing.T) {
+	s, out := newTestServer()
+	req := `{"jsonrpc":"2.0","id":1,"method":"ping","params":{` + modernMeta(supportedProtocolVersions[0]) + `}}`
+	resp := sendAndReceive(t, s, out, req)
+	if resp.Error == nil || resp.Error.Code != -32601 {
+		t.Fatalf("error = %+v, want method not found", resp.Error)
+	}
+}
+
+func TestModernInitializeIsRejected(t *testing.T) {
+	s, out := newTestServer()
+	req := `{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-11-25",` + modernMeta(supportedProtocolVersions[0]) + `}}`
+	resp := sendAndReceive(t, s, out, req)
+	if resp.Error == nil || resp.Error.Code != -32601 {
+		t.Fatalf("error = %+v, want method not found", resp.Error)
+	}
+}
+
+func TestToolsListIsCacheableAndDeterministic(t *testing.T) {
+	s, out := newTestServer()
+	modern := `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{` + modernMeta(supportedProtocolVersions[0]) + `}}`
+	first := sendAndReceive(t, s, out, modern)
+	firstJSON, _ := json.Marshal(first.Result)
+	second := sendAndReceive(t, s, out, modern)
+	secondJSON, _ := json.Marshal(second.Result)
+	if string(firstJSON) != string(secondJSON) {
+		t.Fatal("tools/list order or result changed between identical requests")
+	}
+	var list toolsListResult
+	if err := json.Unmarshal(firstJSON, &list); err != nil {
+		t.Fatalf("unmarshal tools list: %v", err)
+	}
+	if list.ResultType != "complete" || list.TTLMS <= 0 || list.CacheScope != "public" {
+		t.Errorf("cacheable result = %+v", list)
+	}
+	for i := 1; i < len(list.Tools); i++ {
+		if list.Tools[i-1].Name >= list.Tools[i].Name {
+			t.Fatalf("tools are not sorted: %q before %q", list.Tools[i-1].Name, list.Tools[i].Name)
+		}
 	}
 }

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -630,6 +630,31 @@ func TestModernDiscover(t *testing.T) {
 	}
 }
 
+func TestDiscoverProbeWorksWithoutMetadata(t *testing.T) {
+	s, out := newTestServer()
+	resp := sendAndReceive(t, s, out, `{"jsonrpc":"2.0","id":1,"method":"server/discover"}`)
+	if resp.Error != nil {
+		t.Fatalf("unexpected error: %v", resp.Error)
+	}
+	result, _ := json.Marshal(resp.Result)
+	var discover discoverResult
+	if err := json.Unmarshal(result, &discover); err != nil {
+		t.Fatalf("unmarshal discover result: %v", err)
+	}
+	if discover.ResultType != "complete" || len(discover.SupportedVersions) == 0 {
+		t.Errorf("discover result = %+v", discover)
+	}
+}
+
+func TestLegacyVersionInModernMetadataIsRejected(t *testing.T) {
+	s, out := newTestServer()
+	req := `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{` + modernMeta(legacyProtocolVersions[0]) + `}}`
+	resp := sendAndReceive(t, s, out, req)
+	if resp.Error == nil || resp.Error.Code != -32022 {
+		t.Fatalf("error = %+v, want -32022", resp.Error)
+	}
+}
+
 func TestModernUnsupportedVersion(t *testing.T) {
 	s, out := newTestServer()
 	req := `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{` + modernMeta("1900-01-01") + `}}`

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -110,6 +110,11 @@ var supportedProtocolVersions = []string{
 
 var legacyProtocolVersions = supportedProtocolVersions[1:]
 
+// toolsListTTLMS is a freshness hint, not a promise that the tool registry is
+// immutable. Change it if the registry becomes dynamic or a shorter polling
+// interval is needed.
+const toolsListTTLMS = 5 * 60 * 1000
+
 // negotiateProtocolVersion answers with the version the client asked for when
 // this server implements it, and with the newest one it does implement when it
 // does not. That is what the lifecycle spec requires, and it is also the only
@@ -237,12 +242,6 @@ func (s *Server) handleRequest(req *jsonRPCRequest) {
 		}
 		return
 	}
-	if req.Method == "server/discover" && !modern {
-		if req.ID != nil {
-			s.writeError(req.ID, -32602, "server/discover requires modern request metadata")
-		}
-		return
-	}
 	if modern && req.Method == "initialize" {
 		if req.ID != nil {
 			s.writeError(req.ID, -32601, "method not found: initialize")
@@ -285,7 +284,7 @@ func (s *Server) handleRequest(req *jsonRPCRequest) {
 		s.writeResult(req.ID, toolsListResult{
 			ResultType: "complete",
 			Tools:      toolDefinitions(),
-			TTLMS:      300000,
+			TTLMS:      toolsListTTLMS,
 			CacheScope: "public",
 			Meta:       responseMeta{ServerInfo: serverInfo{Name: "homebutler", Version: s.version}},
 		})
@@ -851,7 +850,7 @@ func validateRequestMeta(req *jsonRPCRequest) (bool, error) {
 	if err := json.Unmarshal(meta.ClientCapabilities, &capabilities); err != nil || capabilities == nil {
 		return true, fmt.Errorf("invalid client capabilities")
 	}
-	if !isSupportedProtocolVersion(meta.ProtocolVersion) {
+	if !isModernProtocolVersion(meta.ProtocolVersion) {
 		return true, &unsupportedProtocolError{requested: meta.ProtocolVersion}
 	}
 	return true, nil
@@ -864,6 +863,19 @@ func (e *unsupportedProtocolError) Error() string { return "Unsupported protocol
 func isSupportedProtocolVersion(version string) bool {
 	for _, supported := range supportedProtocolVersions {
 		if version == supported {
+			return true
+		}
+	}
+	return false
+}
+
+func isModernProtocolVersion(version string) bool {
+	return isSupportedProtocolVersion(version) && !isLegacyProtocolVersion(version)
+}
+
+func isLegacyProtocolVersion(version string) bool {
+	for _, legacy := range legacyProtocolVersions {
+		if version == legacy {
 			return true
 		}
 	}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -45,6 +45,7 @@ type jsonRPCResponse struct {
 type rpcError struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
+	Data    any    `json:"data,omitempty"`
 }
 
 // MCP protocol types
@@ -58,6 +59,22 @@ type initializeResult struct {
 	ProtocolVersion string     `json:"protocolVersion"`
 	Capabilities    capInfo    `json:"capabilities"`
 	ServerInfo      serverInfo `json:"serverInfo"`
+}
+
+type discoverResult struct {
+	ResultType        string       `json:"resultType"`
+	SupportedVersions []string     `json:"supportedVersions"`
+	Capabilities      capInfo      `json:"capabilities"`
+	Meta              responseMeta `json:"_meta"`
+}
+
+type responseMeta struct {
+	ServerInfo serverInfo `json:"io.modelcontextprotocol/serverInfo"`
+}
+
+type requestMeta struct {
+	ProtocolVersion    string          `json:"io.modelcontextprotocol/protocolVersion"`
+	ClientCapabilities json.RawMessage `json:"io.modelcontextprotocol/clientCapabilities"`
 }
 
 // initializeParams is the part of the client's initialize request that this
@@ -76,7 +93,7 @@ type initializeParams struct {
 // was the oldest thing it could conformantly say, and clients cap their
 // behaviour to the version they are given.
 //
-// All four are listed because for a tools-only stdio server they describe the
+// All five are listed because for a tools-only stdio server they describe the
 // same surface. Everything the later revisions added is either out of scope
 // here (resources, prompts, sampling, roots, elicitation, tasks, Streamable
 // HTTP and its authorization) or already the behaviour: tool input validation
@@ -84,23 +101,26 @@ type initializeParams struct {
 // (SEP-1303), and the generated inputSchema uses no construct outside JSON
 // Schema 2020-12 (SEP-1613).
 var supportedProtocolVersions = []string{
+	"2026-07-28",
 	"2025-11-25",
 	"2025-06-18",
 	"2025-03-26",
 	"2024-11-05",
 }
 
+var legacyProtocolVersions = supportedProtocolVersions[1:]
+
 // negotiateProtocolVersion answers with the version the client asked for when
 // this server implements it, and with the newest one it does implement when it
 // does not. That is what the lifecycle spec requires, and it is also the only
 // shape that keeps working if a version is ever added or dropped here.
 func negotiateProtocolVersion(requested string) string {
-	for _, v := range supportedProtocolVersions {
+	for _, v := range legacyProtocolVersions {
 		if v == requested {
 			return requested
 		}
 	}
-	return supportedProtocolVersions[0]
+	return legacyProtocolVersions[0]
 }
 
 type capInfo struct {
@@ -127,7 +147,11 @@ type propDef struct {
 }
 
 type toolsListResult struct {
-	Tools []toolDef `json:"tools"`
+	ResultType string       `json:"resultType"`
+	Tools      []toolDef    `json:"tools"`
+	TTLMS      int          `json:"ttlMs"`
+	CacheScope string       `json:"cacheScope"`
+	Meta       responseMeta `json:"_meta"`
 }
 
 type toolsCallParams struct {
@@ -141,8 +165,10 @@ type contentItem struct {
 }
 
 type toolsCallResult struct {
-	Content []contentItem `json:"content"`
-	IsError bool          `json:"isError,omitempty"`
+	ResultType string        `json:"resultType"`
+	Content    []contentItem `json:"content"`
+	IsError    bool          `json:"isError,omitempty"`
+	Meta       responseMeta  `json:"_meta"`
 }
 
 // Server is the MCP server.
@@ -200,6 +226,30 @@ func (s *Server) Run() error {
 }
 
 func (s *Server) handleRequest(req *jsonRPCRequest) {
+	modern, err := validateRequestMeta(req)
+	if err != nil {
+		if req.ID != nil {
+			if unsupported, ok := err.(*unsupportedProtocolError); ok {
+				s.writeUnsupportedProtocolError(req.ID, unsupported.requested)
+			} else {
+				s.writeError(req.ID, -32602, err.Error())
+			}
+		}
+		return
+	}
+	if req.Method == "server/discover" && !modern {
+		if req.ID != nil {
+			s.writeError(req.ID, -32602, "server/discover requires modern request metadata")
+		}
+		return
+	}
+	if modern && req.Method == "initialize" {
+		if req.ID != nil {
+			s.writeError(req.ID, -32601, "method not found: initialize")
+		}
+		return
+	}
+
 	switch req.Method {
 	case "initialize":
 		var params initializeParams
@@ -215,12 +265,30 @@ func (s *Server) handleRequest(req *jsonRPCRequest) {
 	case "notifications/initialized":
 		// Notification — no response needed
 	case "ping":
-		// "The receiver MUST respond promptly with an empty response." Initiating
-		// a ping is optional; answering one is not, and this used to come back
-		// as -32601 method not found.
+		if modern {
+			// ping was removed in 2026-07-28.
+			if req.ID != nil {
+				s.writeError(req.ID, -32601, "method not found: ping")
+			}
+			break
+		}
+		// Legacy clients expect the empty ping result.
 		s.writeResult(req.ID, struct{}{})
+	case "server/discover":
+		s.writeResult(req.ID, discoverResult{
+			ResultType:        "complete",
+			SupportedVersions: supportedProtocolVersions,
+			Capabilities:      capInfo{Tools: &toolsCap{}},
+			Meta:              responseMeta{ServerInfo: serverInfo{Name: "homebutler", Version: s.version}},
+		})
 	case "tools/list":
-		s.writeResult(req.ID, toolsListResult{Tools: toolDefinitions()})
+		s.writeResult(req.ID, toolsListResult{
+			ResultType: "complete",
+			Tools:      toolDefinitions(),
+			TTLMS:      300000,
+			CacheScope: "public",
+			Meta:       responseMeta{ServerInfo: serverInfo{Name: "homebutler", Version: s.version}},
+		})
 	case "tools/call":
 		s.handleToolCall(req)
 	default:
@@ -240,8 +308,10 @@ func (s *Server) handleToolCall(req *jsonRPCRequest) {
 	result, toolErr := s.executeTool(params.Name, params.Arguments)
 	if toolErr != nil {
 		s.writeResult(req.ID, toolsCallResult{
-			Content: []contentItem{{Type: "text", Text: toolErr.Error()}},
-			IsError: true,
+			ResultType: "complete",
+			Content:    []contentItem{{Type: "text", Text: toolErr.Error()}},
+			IsError:    true,
+			Meta:       responseMeta{ServerInfo: serverInfo{Name: "homebutler", Version: s.version}},
 		})
 		return
 	}
@@ -249,14 +319,18 @@ func (s *Server) handleToolCall(req *jsonRPCRequest) {
 	data, err := json.Marshal(result)
 	if err != nil {
 		s.writeResult(req.ID, toolsCallResult{
-			Content: []contentItem{{Type: "text", Text: fmt.Sprintf("marshal error: %v", err)}},
-			IsError: true,
+			ResultType: "complete",
+			Content:    []contentItem{{Type: "text", Text: fmt.Sprintf("marshal error: %v", err)}},
+			IsError:    true,
+			Meta:       responseMeta{ServerInfo: serverInfo{Name: "homebutler", Version: s.version}},
 		})
 		return
 	}
 
 	s.writeResult(req.ID, toolsCallResult{
-		Content: []contentItem{{Type: "text", Text: string(data)}},
+		ResultType: "complete",
+		Content:    []contentItem{{Type: "text", Text: string(data)}},
+		Meta:       responseMeta{ServerInfo: serverInfo{Name: "homebutler", Version: s.version}},
 	})
 }
 
@@ -743,6 +817,57 @@ func (s *Server) writeError(id json.RawMessage, code int, message string) {
 	}
 	data, _ := json.Marshal(resp)
 	fmt.Fprintf(s.out, "%s\n", data)
+}
+
+func (s *Server) writeUnsupportedProtocolError(id json.RawMessage, requested string) {
+	resp := jsonRPCResponse{JSONRPC: "2.0", ID: id, Error: &rpcError{
+		Code:    -32022,
+		Message: "Unsupported protocol version",
+		Data:    map[string]any{"supported": supportedProtocolVersions, "requested": requested},
+	}}
+	data, _ := json.Marshal(resp)
+	fmt.Fprintf(s.out, "%s\n", data)
+}
+
+// validateRequestMeta identifies and validates the stateless modern request
+// envelope. An absent envelope is deliberately accepted for legacy clients.
+func validateRequestMeta(req *jsonRPCRequest) (bool, error) {
+	if len(req.Params) == 0 {
+		return false, nil
+	}
+	var params map[string]json.RawMessage
+	if err := json.Unmarshal(req.Params, &params); err != nil || params == nil {
+		return false, fmt.Errorf("invalid params")
+	}
+	rawMeta, present := params["_meta"]
+	if !present {
+		return false, nil
+	}
+	var meta requestMeta
+	if err := json.Unmarshal(rawMeta, &meta); err != nil || meta.ProtocolVersion == "" || len(meta.ClientCapabilities) == 0 {
+		return true, fmt.Errorf("invalid request metadata")
+	}
+	var capabilities map[string]any
+	if err := json.Unmarshal(meta.ClientCapabilities, &capabilities); err != nil || capabilities == nil {
+		return true, fmt.Errorf("invalid client capabilities")
+	}
+	if !isSupportedProtocolVersion(meta.ProtocolVersion) {
+		return true, &unsupportedProtocolError{requested: meta.ProtocolVersion}
+	}
+	return true, nil
+}
+
+type unsupportedProtocolError struct{ requested string }
+
+func (e *unsupportedProtocolError) Error() string { return "Unsupported protocol version" }
+
+func isSupportedProtocolVersion(version string) bool {
+	for _, supported := range supportedProtocolVersions {
+		if version == supported {
+			return true
+		}
+	}
+	return false
 }
 
 // Helper functions


### PR DESCRIPTION
homebutler now supports MCP 2026-07-28 modern requests while preserving legacy client compatibility.

The implementation adds:

- `server/discover`
- Per-request protocol metadata validation
- `UnsupportedProtocolVersionError` with supported versions
- Stateless modern request handling
- `resultType: "complete"` on modern results
- `ttlMs` and `cacheScope` on `tools/list`
- Deterministic tool ordering
- Legacy `initialize` and `ping` compatibility
- Updated MCP documentation and tests

Verified with:

- `go vet ./...`
- `golangci-lint run`
- `go test ./...`
- `go build ./...`

close #86 