### PR TITLE
feat: track processes across runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+**`report` observed processes on every run and remembered none of them.** The snapshot held containers, ports and disks; `processes` was collected, rendered, and thrown away, so "what started running since yesterday" had no path to an answer.
+
+### ✨ Features
+
+- track processes across runs (#59). A process is identified by its executable name and a hash of its full invocation, so a name that appears, disappears, or comes back running something else is reported — `python3 /opt/old.py` becoming `python3 /opt/new.py` is a `replaced` rather than silence. Identical invocations collapse to one identity, because eight workers sharing a command line are one thing running and a pool resizing is a resource signal rather than an arrival
+- ignore processes that have not been running for a minute. This threshold was measured rather than chosen: two runs thirty seconds apart on an idle machine reported `new head` and `new sed`, which was the shell pipeline reading the report. A process held back is reported on the next run, by which time it has earned the word
+
+### 🔐 Security
+
+- keep the executable name and a twelve-character hash of the invocation, never the command line itself. Command lines carry secrets in flags and `~/.homebutler/reports/snapshots/` has never had to be handled as a credential store. `ProcessInfo.Command` is excluded from JSON, so neither the `processes` command nor its MCP tool gains the field
+
+### ⚠️ Behavior changes
+
+- **Snapshots are larger.** On a desktop macOS with 639 distinct process identities a snapshot is about 50 KB, against 2 KB before; a Linux server running a few services is well under that. At the default `--keep 30` that is roughly 1.5 MB of history in the worst case measured. No cap is imposed — the measurement did not call for one — but it is worth knowing before turning `--keep` up
+
+## [Unreleased]
+
 **`report` compared counts, so a container replaced by a different container read as no change.** The snapshot on disk held the full container and port lists all along; the diff read four integers off it and threw the lists away. Six running before and six running after was reported as "No significant changes since last report", whether or not the six were the same six.
 
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,24 +4,7 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-**`report` observed processes on every run and remembered none of them.** The snapshot held containers, ports and disks; `processes` was collected, rendered, and thrown away, so "what started running since yesterday" had no path to an answer.
-
-### ✨ Features
-
-- track processes across runs (#59). A process is identified by its executable name and a hash of its full invocation, so a name that appears, disappears, or comes back running something else is reported — `python3 /opt/old.py` becoming `python3 /opt/new.py` is a `replaced` rather than silence. Identical invocations collapse to one identity, because eight workers sharing a command line are one thing running and a pool resizing is a resource signal rather than an arrival
-- ignore processes that have not been running for a minute. This threshold was measured rather than chosen: two runs thirty seconds apart on an idle machine reported `new head` and `new sed`, which was the shell pipeline reading the report. A process held back is reported on the next run, by which time it has earned the word
-
-### 🔐 Security
-
-- keep the executable name and a twelve-character hash of the invocation, never the command line itself. Command lines carry secrets in flags and `~/.homebutler/reports/snapshots/` has never had to be handled as a credential store. `ProcessInfo.Command` is excluded from JSON, so neither the `processes` command nor its MCP tool gains the field
-
-### ⚠️ Behavior changes
-
-- **Snapshots are larger.** On a desktop macOS with 639 distinct process identities a snapshot is about 50 KB, against 2 KB before; a Linux server running a few services is well under that. At the default `--keep 30` that is roughly 1.5 MB of history in the worst case measured. No cap is imposed — the measurement did not call for one — but it is worth knowing before turning `--keep` up
-
-## [Unreleased]
-
-**`report` compared counts, so a container replaced by a different container read as no change.** The snapshot on disk held the full container and port lists all along; the diff read four integers off it and threw the lists away. Six running before and six running after was reported as "No significant changes since last report", whether or not the six were the same six.
+**`report` compared counts and remembered no processes, so a container replaced by a different container read as no change and "what started running since yesterday" had no path to an answer.** The snapshot on disk held the full container and port lists all along; the diff read four integers off it and threw the lists away. `processes` was collected, rendered, and discarded entirely.
 
 ```
 ── Notable Changes ───────────────────────────────────────────
@@ -39,11 +22,18 @@ All notable changes to this project will be documented in this file.
 - compare containers and listeners by identity rather than by cardinality (#58). Containers are matched by name and then by container ID, image and state; listeners by bind address, port number and protocol, then by the process answering on them. The address is part of a listener's identity: without it a service moving from `127.0.0.1` to `0.0.0.0` — the change in this section with the largest consequence — reads as no change at all. The case this exists for is `replaced` — a container recreated under the same name, which leaves every count identical and was therefore invisible. `docs/report.md` is new and states what earns a line and what is deliberately suppressed: uptime strings, CPU and memory, and restart counters that moved without a state change, because a report nobody reads is worse than no report
 - collapse more than five changes of one kind into a line that names three and counts the rest. Grouping and truncation happen only in the human renderer — `--json` carries every change, ungrouped, because a person needs the section readable and anything parsing the output needs all of it
 - skip the comparison, and say so *in the section*, when a collector did not answer for either snapshot. Diffing against a snapshot taken while Docker was down would otherwise report every container as gone — and putting the caveat only in a trailing warning would hand anything reading `notable_changes` an all-clear the report cannot stand behind
+- track processes across runs (#59). A process is identified by its executable name and a hash of its full invocation, so a name that appears, disappears, or comes back running something else is reported — `python3 /opt/old.py` becoming `python3 /opt/new.py` is a `replaced` rather than silence. Identical invocations collapse to one identity, because eight workers sharing a command line are one thing running and a pool resizing is a resource signal rather than an arrival
+- ignore processes that have not been running for a minute. This threshold was measured rather than chosen: two runs thirty seconds apart on an idle machine reported `new head` and `new sed`, which was the shell pipeline reading the report. A process held back is reported on the next run, by which time it has earned the word "new"
+
+### 🔐 Security
+
+- keep the executable name and a twelve-character hash of the invocation, never the command line itself. Command lines carry secrets in flags and `~/.homebutler/reports/snapshots/` has never had to be handled as a credential store. `ProcessInfo.Command` is excluded from JSON, so neither the `processes` command nor its MCP tool gains the field
 
 ### ⚠️ Behavior changes
 
 - **`notable_changes` no longer contains the count lines** `Running containers: N → M`, `Stopped containers: N → M` or `Public ports: N → M`. They are replaced by one entry per change, shaped `kind: subject — detail`. Anything matching on the old strings needs updating; the field is still `[]string` and the JSON schema is unchanged
 - **The human report leads with `Notable Changes` rather than `Current Status`.** Current status is context for what moved above it, not the headline. `--json` is unaffected — field order in the document has not changed
+- **Snapshots are larger.** On a desktop macOS with 639 distinct process identities a snapshot is about 50 KB, against 2 KB before; a Linux server running a few services is well under that. At the default `--keep 30` that is roughly 1.5 MB of history in the worst case measured. No cap is imposed — the measurement did not call for one — but it is worth knowing before turning `--keep` up
 
 ## [0.25.0](https://github.com/Higangssh/homebutler/compare/v0.24.0...v0.25.0) - 2026-09-02
 

--- a/docs/report.md
+++ b/docs/report.md
@@ -29,6 +29,11 @@ Processes are compared the same way. A process is identified by its executable
 name and a hash of its full invocation, so `python3 /opt/old.py` becoming
 `python3 /opt/new.py` is a `replaced`, not silence.
 
+`replaced` is reserved for the case where it is true: one invocation under a
+name before, one after, and they differ. Names like `python3`, `bash` and `ssh`
+routinely run several at once, and one of them exiting is reported as a
+departure under a name that is still running — nothing was replaced.
+
 `replaced` is the one worth knowing about. A container recreated under the same
 name leaves every count identical, so a report that compares counts says
 nothing at all — which is what this one did before 0.26.0.

--- a/docs/report.md
+++ b/docs/report.md
@@ -25,6 +25,10 @@ after is not "no change" when one of them is a different container.
 | `port` | the same port, a different process answering on it |
 | `disk` | a mount whose usage moved by more than half a gigabyte |
 
+Processes are compared the same way. A process is identified by its executable
+name and a hash of its full invocation, so `python3 /opt/old.py` becoming
+`python3 /opt/new.py` is a `replaced`, not silence.
+
 `replaced` is the one worth knowing about. A container recreated under the same
 name leaves every count identical, so a report that compares counts says
 nothing at all — which is what this one did before 0.26.0.
@@ -40,6 +44,15 @@ A report nobody reads is worse than no report. These are excluded on purpose:
   it, which is a separate feature rather than a diff.
 - **Restart counters that moved without a state change.** A container that
   restarted and came back is in the same state it was in.
+- **Processes that have not been running for a minute.** Measured rather than
+  guessed: two runs thirty seconds apart on an idle machine reported `new head`
+  and `new sed` — the shell pipeline that was reading the report. Cron jobs and
+  package managers arrive the same way. A process held back is not lost; it is
+  reported on the next run, by which time it has earned the word "new".
+- **The command line itself.** A snapshot keeps the executable name and a
+  twelve-character hash of the invocation, never the arguments. Command lines
+  carry secrets in flags, and `~/.homebutler/reports/snapshots/` has never had
+  to be handled as a credential store.
 - **Anything from a collector that did not answer.** If Docker was down when
   either snapshot was taken, container changes are not compared at all and the
   report says so. Reporting every container as gone because the daemon was
@@ -57,6 +70,14 @@ state     7 containers  postgres, redis, grafana, +4
 `--json` never groups and never truncates. A person needs the section to stay
 readable; anything reading the output needs all of it, and quietly handing a
 shortened list to an agent is how an agent becomes confidently wrong.
+
+## Snapshot size
+
+Tracking processes made snapshots larger, and the number is worth knowing
+before turning `--keep` up: on a desktop macOS with 639 distinct process
+identities a snapshot is about 50 KB, against 2 KB before. A Linux server
+running a handful of services is well under that. At the default `--keep 30`
+that is roughly 1.5 MB of history in the worst case measured.
 
 ## Order
 

--- a/internal/inventory/inventory.go
+++ b/internal/inventory/inventory.go
@@ -52,7 +52,11 @@ type CollectFuncs struct {
 	StatusFn     func() (*system.StatusInfo, error)
 	DockerListFn func() ([]docker.Container, error)
 	PortsListFn  func() (*ports.Result, error)
-	ProcessesFn  func() ([]system.ProcessInfo, error)
+	// ProcessesFn is optional and left unset by DefaultCollectFuncs. Only
+	// report compares runs, and every other caller of Collect — inventory
+	// scan, the MCP tools, doctor — would otherwise pay for a full ps sweep
+	// whose result it never renders, and inherit a warning about it.
+	ProcessesFn func() ([]system.ProcessInfo, error)
 }
 
 // DefaultCollectFuncs returns the real system/docker/ports functions.
@@ -61,7 +65,6 @@ func DefaultCollectFuncs() CollectFuncs {
 		StatusFn:     system.Status,
 		DockerListFn: docker.List,
 		PortsListFn:  ports.List,
-		ProcessesFn:  system.AllProcesses,
 	}
 }
 

--- a/internal/inventory/inventory.go
+++ b/internal/inventory/inventory.go
@@ -16,7 +16,10 @@ type Inventory struct {
 	System     *system.StatusInfo `json:"system"`
 	Containers []docker.Container `json:"containers"`
 	Ports      []ports.PortInfo   `json:"ports"`
-	Warnings   []string           `json:"warnings,omitempty"`
+	// Processes is collected so report can compare runs. It is not rendered
+	// by inventory scan, which has its own process command.
+	Processes []system.ProcessInfo `json:"-"`
+	Warnings  []string             `json:"warnings,omitempty"`
 	// Failed names the collectors that did not answer, so a reader can ask
 	// which part of the snapshot is missing rather than matching on the
 	// prefix of a warning string. Warnings stays the human-readable list;
@@ -27,8 +30,9 @@ type Inventory struct {
 
 // Collector names recorded in Failed.
 const (
-	CollectorDocker = "docker"
-	CollectorPorts  = "ports"
+	CollectorDocker    = "docker"
+	CollectorPorts     = "ports"
+	CollectorProcesses = "processes"
 )
 
 // CollectorFailed reports whether the named collector failed during Collect.
@@ -48,6 +52,7 @@ type CollectFuncs struct {
 	StatusFn     func() (*system.StatusInfo, error)
 	DockerListFn func() ([]docker.Container, error)
 	PortsListFn  func() (*ports.Result, error)
+	ProcessesFn  func() ([]system.ProcessInfo, error)
 }
 
 // DefaultCollectFuncs returns the real system/docker/ports functions.
@@ -56,6 +61,7 @@ func DefaultCollectFuncs() CollectFuncs {
 		StatusFn:     system.Status,
 		DockerListFn: docker.List,
 		PortsListFn:  ports.List,
+		ProcessesFn:  system.AllProcesses,
 	}
 }
 
@@ -93,6 +99,18 @@ func Collect(cfg *config.Config, fns CollectFuncs) (*Inventory, error) {
 		inv.Failed = append(inv.Failed, CollectorPorts)
 	} else {
 		inv.Ports = result.Ports
+	}
+
+	// Processes: best-effort, and optional so existing callers that build
+	// CollectFuncs by hand keep working.
+	if fns.ProcessesFn != nil {
+		procs, err := fns.ProcessesFn()
+		if err != nil {
+			inv.Warnings = append(inv.Warnings, CollectorProcesses+": "+err.Error())
+			inv.Failed = append(inv.Failed, CollectorProcesses)
+		} else {
+			inv.Processes = procs
+		}
 	}
 
 	return inv, nil

--- a/internal/report/diff.go
+++ b/internal/report/diff.go
@@ -401,7 +401,10 @@ func processIdentities(procs []system.ProcessInfo) []ProcessIdentity {
 	seen := map[ProcessIdentity]bool{}
 	var out []ProcessIdentity
 	for _, p := range procs {
-		if p.Elapsed < minProcessAge {
+		// An unknown age is kept. Dropping it would make a running daemon
+		// vanish from this snapshot and return in the next one, a pair of
+		// changes for something that never stopped.
+		if p.Elapsed >= 0 && p.Elapsed < minProcessAge {
 			continue
 		}
 		id := ProcessIdentity{Name: p.Name}
@@ -426,10 +429,13 @@ func processIdentities(procs []system.ProcessInfo) []ProcessIdentity {
 
 // diffProcesses compares two runs by executable name, then by invocation.
 //
-// A name present in both runs with a different set of invocations is
-// "replaced" rather than a disappearance and an arrival, for the same reason
-// a container recreated under one name is: the interesting fact is that what
-// is running under that name changed, not that a line moved.
+// "replaced" is reserved for the case where it is true: one invocation under a
+// name before, one after, and they differ. The container analogy stops there —
+// a container name maps to one container, while python3, bash, node and ssh
+// routinely map to several, and calling it a replacement when one of four
+// python3 invocations exits would describe something that did not happen.
+// Those are reported as what they are, an arrival and a departure under a
+// name that is still running.
 func diffProcesses(prev, curr []ProcessIdentity) []Change {
 	prevByName := groupProcessesByName(prev)
 	currByName := groupProcessesByName(curr)
@@ -441,11 +447,31 @@ func diffProcesses(prev, curr []ProcessIdentity) []Change {
 			changes = append(changes, Change{Kind: kindGone, Subject: name, noun: nounProcesses})
 			continue
 		}
-		if !sameHashes(prevHashes, currHashes) {
+		if sameHashes(prevHashes, currHashes) {
+			continue
+		}
+		if len(prevHashes) == 1 && len(currHashes) == 1 {
 			changes = append(changes, Change{
 				Kind:    kindReplaced,
 				Subject: name,
 				Detail:  "same name, different invocation",
+				noun:    nounProcesses,
+			})
+			continue
+		}
+		if departed := countMissing(prevHashes, currHashes); departed > 0 {
+			changes = append(changes, Change{
+				Kind:    kindGone,
+				Subject: name,
+				Detail:  invocationCount(departed) + ", others still running",
+				noun:    nounProcesses,
+			})
+		}
+		if arrived := countMissing(currHashes, prevHashes); arrived > 0 {
+			changes = append(changes, Change{
+				Kind:    kindNew,
+				Subject: name,
+				Detail:  invocationCount(arrived) + " under a name already running",
 				noun:    nounProcesses,
 			})
 		}
@@ -456,6 +482,24 @@ func diffProcesses(prev, curr []ProcessIdentity) []Change {
 		}
 	}
 	return changes
+}
+
+// countMissing counts entries of a that b does not have.
+func countMissing(a, b map[string]bool) int {
+	var n int
+	for k := range a {
+		if !b[k] {
+			n++
+		}
+	}
+	return n
+}
+
+func invocationCount(n int) string {
+	if n == 1 {
+		return "1 invocation"
+	}
+	return strconv.Itoa(n) + " invocations"
 }
 
 func groupProcessesByName(list []ProcessIdentity) map[string]map[string]bool {

--- a/internal/report/diff.go
+++ b/internal/report/diff.go
@@ -1,10 +1,13 @@
 package report
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/charmbracelet/lipgloss"
 
@@ -50,6 +53,7 @@ const (
 	nounContainers = "containers"
 	nounPorts      = "ports"
 	nounMounts     = "mounts"
+	nounProcesses  = "processes"
 )
 
 var kindRank = map[string]int{
@@ -362,4 +366,117 @@ func collectorFailed(s *Snapshot, collector string) bool {
 		}
 	}
 	return false
+}
+
+// ProcessIdentity is what a snapshot keeps about a process: enough to tell
+// two runs apart, and nothing that moves on every sample.
+//
+// CPU, memory and PID are absent by construction rather than by a rule in the
+// differ. They change between any two runs, and a pid is recycled, so
+// persisting them would invite a diff that reports noise. Hash is the first
+// twelve hex characters of sha256 over the full command line: it separates
+// two processes sharing an executable name without writing their arguments,
+// which carry secrets in flags, into a file on disk.
+type ProcessIdentity struct {
+	Name string `json:"name"`
+	Hash string `json:"hash,omitempty"`
+}
+
+// minProcessAge is how long a process has to have been running before it is
+// worth recording. Measured rather than guessed: two runs thirty seconds
+// apart on an idle machine reported "new head" and "new sed" — the shell
+// pipeline that was reading the report. Cron jobs, package managers and
+// anything else that lives for a moment would arrive the same way.
+//
+// A process held back here is not lost. It is simply reported on the next
+// run, by which time it has earned the word "new".
+const minProcessAge = time.Minute
+
+// processIdentities reduces a process list to the set of distinct identities.
+//
+// Duplicates are collapsed on purpose: eight workers sharing one invocation
+// are one thing running, and a pool growing or shrinking is a resource
+// signal rather than something appearing or disappearing.
+func processIdentities(procs []system.ProcessInfo) []ProcessIdentity {
+	seen := map[ProcessIdentity]bool{}
+	var out []ProcessIdentity
+	for _, p := range procs {
+		if p.Elapsed < minProcessAge {
+			continue
+		}
+		id := ProcessIdentity{Name: p.Name}
+		if p.Command != "" {
+			sum := sha256.Sum256([]byte(p.Command))
+			id.Hash = hex.EncodeToString(sum[:])[:12]
+		}
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+		out = append(out, id)
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Name != out[j].Name {
+			return out[i].Name < out[j].Name
+		}
+		return out[i].Hash < out[j].Hash
+	})
+	return out
+}
+
+// diffProcesses compares two runs by executable name, then by invocation.
+//
+// A name present in both runs with a different set of invocations is
+// "replaced" rather than a disappearance and an arrival, for the same reason
+// a container recreated under one name is: the interesting fact is that what
+// is running under that name changed, not that a line moved.
+func diffProcesses(prev, curr []ProcessIdentity) []Change {
+	prevByName := groupProcessesByName(prev)
+	currByName := groupProcessesByName(curr)
+
+	var changes []Change
+	for name, prevHashes := range prevByName {
+		currHashes, ok := currByName[name]
+		if !ok {
+			changes = append(changes, Change{Kind: kindGone, Subject: name, noun: nounProcesses})
+			continue
+		}
+		if !sameHashes(prevHashes, currHashes) {
+			changes = append(changes, Change{
+				Kind:    kindReplaced,
+				Subject: name,
+				Detail:  "same name, different invocation",
+				noun:    nounProcesses,
+			})
+		}
+	}
+	for name := range currByName {
+		if _, ok := prevByName[name]; !ok {
+			changes = append(changes, Change{Kind: kindNew, Subject: name, noun: nounProcesses})
+		}
+	}
+	return changes
+}
+
+func groupProcessesByName(list []ProcessIdentity) map[string]map[string]bool {
+	out := map[string]map[string]bool{}
+	for _, p := range list {
+		if out[p.Name] == nil {
+			out[p.Name] = map[string]bool{}
+		}
+		out[p.Name][p.Hash] = true
+	}
+	return out
+}
+
+func sameHashes(a, b map[string]bool) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for k := range a {
+		if !b[k] {
+			return false
+		}
+	}
+	return true
 }

--- a/internal/report/diff_test.go
+++ b/internal/report/diff_test.go
@@ -13,7 +13,13 @@ import (
 )
 
 func snapshotWith(containers []docker.Container, listeners []ports.PortInfo) *Snapshot {
-	s := &Snapshot{Containers: containers, Ports: listeners}
+	s := &Snapshot{
+		Containers: containers,
+		Ports:      listeners,
+		// One stable process on both sides, so the process comparison is a
+		// no-op for the tests that are not about processes.
+		Processes: []ProcessIdentity{{Name: "init", Hash: "000000000000"}},
+	}
 	for _, c := range containers {
 		if c.State == "running" {
 			s.RunningCount++
@@ -318,6 +324,59 @@ func snapshotWithProcesses(list []system.ProcessInfo) *Snapshot {
 	return s
 }
 
+// A name running several invocations is not "replaced" when one of them
+// exits — nothing was replaced, and the departure has to be reported as one.
+func TestOneOfSeveralInvocationsLeaving(t *testing.T) {
+	prev := snapshotWithProcesses(procs(
+		system.ProcessInfo{PID: 1, Name: "python3", Command: "python3 /opt/a.py"},
+		system.ProcessInfo{PID: 2, Name: "python3", Command: "python3 /opt/b.py"},
+	))
+	curr := snapshotWithProcesses(procs(
+		system.ProcessInfo{PID: 1, Name: "python3", Command: "python3 /opt/a.py"},
+	))
+
+	r := buildReport(curr, prev)
+	got := strings.Join(r.NotableChanges, " | ")
+	if strings.Contains(got, "replaced: python3") {
+		t.Errorf("one of two invocations exiting was called a replacement: %s", got)
+	}
+	if !strings.Contains(got, "gone: python3 — 1 invocation, others still running") {
+		t.Errorf("the departed invocation was not reported: %s", got)
+	}
+}
+
+// A snapshot written before process tracking existed has no processes. The
+// first run after upgrading must not report the whole machine as new.
+func TestPreviousSnapshotWithoutProcessesIsNotAnEmptyMachine(t *testing.T) {
+	prev := snapshotWith(nil, nil)
+	prev.Processes = nil
+	curr := snapshotWithProcesses(procs(
+		system.ProcessInfo{PID: 1, Name: "nginx", Command: "nginx -g daemon off"},
+		system.ProcessInfo{PID: 2, Name: "postgres", Command: "postgres -D /data"},
+	))
+
+	r := buildReport(curr, prev)
+	got := strings.Join(r.NotableChanges, " | ")
+	if strings.Contains(got, "new: nginx") || strings.Contains(got, "new: postgres") {
+		t.Errorf("the first run after upgrading reported every process as new: %s", got)
+	}
+	if !strings.Contains(got, "not compared — the previous snapshot has none") {
+		t.Errorf("the skipped comparison was not explained: %s", got)
+	}
+}
+
+// A process the invocation lookup missed has an unknown age, not a young one.
+// Dropping it would make a running daemon disappear and come back.
+func TestUnknownAgeIsKept(t *testing.T) {
+	ids := processIdentities([]system.ProcessInfo{
+		{PID: 1, Name: "sshd", Command: "", Elapsed: system.ElapsedUnknown},
+		{PID: 2, Name: "sed", Command: "sed -n", Elapsed: 2 * time.Second},
+	})
+	if len(ids) != 1 || ids[0].Name != "sshd" {
+		t.Errorf("expected the unknown-age process kept and the young one dropped, got %+v", ids)
+	}
+}
+
 func TestProcessAppearedAndDisappeared(t *testing.T) {
 	prev := snapshotWithProcesses(procs(
 		system.ProcessInfo{PID: 1, Name: "nginx", Command: "nginx -g daemon off"},
@@ -396,5 +455,27 @@ func TestIdenticalProcessesCollapse(t *testing.T) {
 	}
 	if got := len(processIdentities(list)); got != 1 {
 		t.Errorf("eight identical workers became %d identities", got)
+	}
+}
+
+// If ps fails, AllProcesses returns an error and inventory records the
+// collector as failed. Without that, every process on the machine reads as
+// having disappeared — the same shape as the Docker case, reachable through
+// a different door.
+func TestFailedProcessCollectorDoesNotEmptyTheMachine(t *testing.T) {
+	prev := snapshotWithProcesses(procs(
+		system.ProcessInfo{PID: 1, Name: "nginx", Command: "nginx -g daemon off"},
+		system.ProcessInfo{PID: 2, Name: "postgres", Command: "postgres -D /data"},
+	))
+	curr := snapshotWithProcesses(nil)
+	curr.Failed = []string{inventory.CollectorProcesses}
+
+	r := buildReport(curr, prev)
+	got := strings.Join(r.NotableChanges, " | ")
+	if strings.Contains(got, "gone: nginx") || strings.Contains(got, "gone: postgres") {
+		t.Errorf("a failed collector reported every process as gone: %s", got)
+	}
+	if !strings.Contains(got, "skipped: processes — not compared") {
+		t.Errorf("the skipped comparison is not in notable_changes: %s", got)
 	}
 }

--- a/internal/report/diff_test.go
+++ b/internal/report/diff_test.go
@@ -1,8 +1,10 @@
 package report
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/Higangssh/homebutler/internal/docker"
 	"github.com/Higangssh/homebutler/internal/inventory"
@@ -296,5 +298,103 @@ func TestDuplicateMountDoesNotCrossProduct(t *testing.T) {
 	}
 	if diskLines != 2 {
 		t.Errorf("two df rows for one mount should report twice, not %d times: %v", diskLines, r.NotableChanges)
+	}
+}
+
+func procs(entries ...system.ProcessInfo) []system.ProcessInfo {
+	out := make([]system.ProcessInfo, 0, len(entries))
+	for _, e := range entries {
+		if e.Elapsed == 0 {
+			e.Elapsed = time.Hour
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
+func snapshotWithProcesses(list []system.ProcessInfo) *Snapshot {
+	s := snapshotWith(nil, nil)
+	s.Processes = processIdentities(list)
+	return s
+}
+
+func TestProcessAppearedAndDisappeared(t *testing.T) {
+	prev := snapshotWithProcesses(procs(
+		system.ProcessInfo{PID: 1, Name: "nginx", Command: "nginx -g daemon off"},
+	))
+	curr := snapshotWithProcesses(procs(
+		system.ProcessInfo{PID: 2, Name: "borgbackup", Command: "borg create ::daily /data"},
+	))
+
+	r := buildReport(curr, prev)
+	got := strings.Join(r.NotableChanges, " | ")
+	if !strings.Contains(got, "gone: nginx") {
+		t.Errorf("a process that exited was not named: %s", got)
+	}
+	if !strings.Contains(got, "new: borgbackup") {
+		t.Errorf("a process that started was not named: %s", got)
+	}
+}
+
+// Same executable, different invocation. The interesting fact is that what is
+// running under that name changed, not that a line moved.
+func TestProcessInvocationChangeIsReplaced(t *testing.T) {
+	prev := snapshotWithProcesses(procs(
+		system.ProcessInfo{PID: 1, Name: "python3", Command: "python3 /opt/old.py"},
+	))
+	curr := snapshotWithProcesses(procs(
+		system.ProcessInfo{PID: 2, Name: "python3", Command: "python3 /opt/new.py"},
+	))
+
+	r := buildReport(curr, prev)
+	got := strings.Join(r.NotableChanges, " | ")
+	if !strings.Contains(got, "replaced: python3 — same name, different invocation") {
+		t.Errorf("an invocation change was not reported: %s", got)
+	}
+}
+
+// Measured, not guessed: two runs thirty seconds apart on an idle machine
+// reported the shell pipeline that was reading the report.
+func TestShortLivedProcessesAreNotReported(t *testing.T) {
+	prev := snapshotWithProcesses(nil)
+	curr := snapshotWithProcesses([]system.ProcessInfo{
+		{PID: 9, Name: "sed", Command: "sed -n 1,10p", Elapsed: 2 * time.Second},
+		{PID: 10, Name: "head", Command: "head -20", Elapsed: time.Second},
+	})
+
+	r := buildReport(curr, prev)
+	got := strings.Join(r.NotableChanges, " | ")
+	if strings.Contains(got, "sed") || strings.Contains(got, "head") {
+		t.Errorf("a process that lived for a moment earned a line: %s", got)
+	}
+}
+
+// The command line carries secrets in flags and a snapshot is a file on disk.
+func TestSnapshotNeverHoldsACommandLine(t *testing.T) {
+	secret := "--api-token=hunter2-should-never-be-persisted"
+	snap := snapshotWithProcesses(procs(
+		system.ProcessInfo{PID: 1, Name: "agent", Command: "agent " + secret},
+	))
+
+	data, err := json.Marshal(snap)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(data), "hunter2") {
+		t.Fatalf("the snapshot persisted a command line: %s", data)
+	}
+	if len(snap.Processes) != 1 || snap.Processes[0].Hash == "" {
+		t.Errorf("the invocation was not reduced to a hash: %+v", snap.Processes)
+	}
+}
+
+// Eight workers sharing one invocation are one thing running.
+func TestIdenticalProcessesCollapse(t *testing.T) {
+	var list []system.ProcessInfo
+	for i := 0; i < 8; i++ {
+		list = append(list, system.ProcessInfo{PID: i + 1, Name: "worker", Command: "worker --pool", Elapsed: time.Hour})
+	}
+	if got := len(processIdentities(list)); got != 1 {
+		t.Errorf("eight identical workers became %d identities", got)
 	}
 }

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -24,6 +24,7 @@ type Snapshot struct {
 	System     *system.StatusInfo `json:"system"`
 	Containers []docker.Container `json:"containers"`
 	Ports      []ports.PortInfo   `json:"ports"`
+	Processes  []ProcessIdentity  `json:"processes,omitempty"`
 	Warnings   []string           `json:"warnings,omitempty"`
 	// Failed records which collectors did not answer when this snapshot was
 	// taken. A diff that does not know this would report every container as
@@ -122,6 +123,7 @@ func buildSnapshot(inv *inventory.Inventory) *Snapshot {
 		System:     inv.System,
 		Containers: inv.Containers,
 		Ports:      inv.Ports,
+		Processes:  processIdentities(inv.Processes),
 		Warnings:   inv.Warnings,
 		Failed:     inv.Failed,
 	}
@@ -222,6 +224,16 @@ func buildReport(snap *Snapshot, prev *Snapshot) *Report {
 			Subject: nounContainers,
 			Detail:  "not compared — Docker did not answer",
 			noun:    nounContainers,
+		})
+	}
+	if collectorAnswered(prev, snap, inventory.CollectorProcesses) {
+		changes = append(changes, diffProcesses(prev.Processes, snap.Processes)...)
+	} else {
+		changes = append(changes, Change{
+			Kind:    kindSkipped,
+			Subject: nounProcesses,
+			Detail:  "not compared — the process collector did not answer",
+			noun:    nounProcesses,
 		})
 	}
 	if collectorAnswered(prev, snap, inventory.CollectorPorts) {

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -63,9 +63,13 @@ type Options struct {
 // CollectFuncs allows injecting data sources for testing.
 type CollectFuncs = inventory.CollectFuncs
 
-// DefaultCollectFuncs returns real system/docker/ports functions.
+// DefaultCollectFuncs returns real system/docker/ports functions, plus the
+// process collector: report is the only caller that compares runs, so it is
+// the only one that asks for it.
 func DefaultCollectFuncs() CollectFuncs {
-	return inventory.DefaultCollectFuncs()
+	fns := inventory.DefaultCollectFuncs()
+	fns.ProcessesFn = system.AllProcesses
+	return fns
 }
 
 // Run collects current state, compares against previous snapshot, and produces a report.
@@ -226,15 +230,26 @@ func buildReport(snap *Snapshot, prev *Snapshot) *Report {
 			noun:    nounContainers,
 		})
 	}
-	if collectorAnswered(prev, snap, inventory.CollectorProcesses) {
-		changes = append(changes, diffProcesses(prev.Processes, snap.Processes)...)
-	} else {
+	switch {
+	case !collectorAnswered(prev, snap, inventory.CollectorProcesses):
 		changes = append(changes, Change{
 			Kind:    kindSkipped,
 			Subject: nounProcesses,
 			Detail:  "not compared — the process collector did not answer",
 			noun:    nounProcesses,
 		})
+	case len(prev.Processes) == 0:
+		// A snapshot written before process tracking existed has no
+		// processes at all. Diffing against it would report every process on
+		// the machine as new on the first run after upgrading.
+		changes = append(changes, Change{
+			Kind:    kindSkipped,
+			Subject: nounProcesses,
+			Detail:  "not compared — the previous snapshot has none",
+			noun:    nounProcesses,
+		})
+	default:
+		changes = append(changes, diffProcesses(prev.Processes, snap.Processes)...)
 	}
 	if collectorAnswered(prev, snap, inventory.CollectorPorts) {
 		changes = append(changes, diffPorts(prev.Ports, snap.Ports)...)

--- a/internal/system/processes.go
+++ b/internal/system/processes.go
@@ -22,9 +22,10 @@ type ProcessInfo struct {
 	State  string  `json:"state,omitempty"`
 	Zombie bool    `json:"zombie,omitempty"`
 
-	// Elapsed is how long the process has been running. Excluded from JSON
-	// for the same reason as Command: this is here for callers comparing
-	// runs, not for the processes command's output.
+	// Elapsed is how long the process has been running, or ElapsedUnknown
+	// when the invocation lookup did not find it. Excluded from JSON for the
+	// same reason as Command: this is here for callers comparing runs, not
+	// for the processes command's output.
 	Elapsed time.Duration `json:"-"`
 
 	// Command is the full invocation, used to tell two processes sharing an
@@ -131,7 +132,6 @@ func allProcesses() ([]ProcessInfo, error) {
 	}
 
 	all := parseProcesses(out, 0)
-	fillCommands(all)
 
 	// Filter out kernel threads (PID <= 2 or bracketed names like [kthreadd])
 	var filtered []ProcessInfo
@@ -148,12 +148,32 @@ func allProcesses() ([]ProcessInfo, error) {
 	return filtered, nil
 }
 
+// ElapsedUnknown marks a process the invocation lookup did not match — it
+// exited between the two ps calls, or ps printed it in a shape this does not
+// parse. It is distinct from a young process: dropping an unknown-age daemon
+// from a snapshot makes it disappear and come back, a pair of changes for
+// something that never stopped.
+const ElapsedUnknown = time.Duration(-1)
+
 // AllProcesses returns every running process except kernel threads, with the
-// command line filled in. Unlike ListProcesses it does not sort or truncate:
-// a caller comparing two runs needs the whole set, since a process dropping
-// out of a top-N sample is not the same event as a process exiting.
+// command line and elapsed time filled in. Unlike ListProcesses it does not
+// sort or truncate: a caller comparing two runs needs the whole set, since a
+// process dropping out of a top-N sample is not the same event as a process
+// exiting.
+//
+// It fails when the invocation join fails, where ListProcesses tolerates it.
+// A caller comparing runs cannot use a list with no elapsed times — it would
+// read as every process on the machine having disappeared — so this has to be
+// a collector failure rather than an empty answer.
 func AllProcesses() ([]ProcessInfo, error) {
-	return allProcesses()
+	procs, err := allProcesses()
+	if err != nil {
+		return nil, err
+	}
+	if err := fillCommands(procs); err != nil {
+		return nil, err
+	}
+	return procs, nil
 }
 
 // fillCommands joins invocations onto processes by PID.
@@ -163,12 +183,12 @@ func AllProcesses() ([]ProcessInfo, error) {
 // line to recover it — so appending args to the same output leaves no
 // unambiguous split. A process that exits between the two calls simply has
 // no command, and identity falls back to its name.
-func fillCommands(procs []ProcessInfo) {
+func fillCommands(procs []ProcessInfo) error {
 	// etime rather than etimes: etimes is Linux-only, and this has to parse
 	// on macOS too.
 	out, err := util.RunCmd("ps", "-eo", "pid=,etime=,args=")
 	if err != nil {
-		return
+		return fmt.Errorf("reading process invocations: %w", err)
 	}
 	type detail struct {
 		command string
@@ -189,11 +209,25 @@ func fillCommands(procs []ProcessInfo) {
 			elapsed: parseElapsed(fields[1]),
 		}
 	}
+	var matched int
 	for i := range procs {
-		d := details[procs[i].PID]
+		d, ok := details[procs[i].PID]
+		if !ok {
+			procs[i].Elapsed = ElapsedUnknown
+			continue
+		}
+		matched++
 		procs[i].Command = d.command
 		procs[i].Elapsed = d.elapsed
 	}
+
+	// A join that matched nothing means the output was not in the shape this
+	// parses, not that the machine is idle. Reporting it as an empty result
+	// would tell a caller comparing runs that every process disappeared.
+	if len(procs) > 0 && matched == 0 {
+		return fmt.Errorf("no process invocations matched by pid")
+	}
+	return nil
 }
 
 // parseElapsed reads ps's etime format: [[dd-]hh:]mm:ss. An unparseable

--- a/internal/system/processes.go
+++ b/internal/system/processes.go
@@ -5,7 +5,9 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/Higangssh/homebutler/internal/util"
 )
@@ -19,6 +21,18 @@ type ProcessInfo struct {
 	RSS    int64   `json:"rss"`
 	State  string  `json:"state,omitempty"`
 	Zombie bool    `json:"zombie,omitempty"`
+
+	// Elapsed is how long the process has been running. Excluded from JSON
+	// for the same reason as Command: this is here for callers comparing
+	// runs, not for the processes command's output.
+	Elapsed time.Duration `json:"-"`
+
+	// Command is the full invocation, used to tell two processes sharing an
+	// executable name apart. It is excluded from JSON deliberately: command
+	// lines carry secrets in flags, and nothing that reads this struct over
+	// the wire has ever had to be handled as a credential. Callers that need
+	// to compare invocations across runs should hash it.
+	Command string `json:"-"`
 }
 
 // ProcessResult holds the process list and summary metadata.
@@ -117,6 +131,7 @@ func allProcesses() ([]ProcessInfo, error) {
 	}
 
 	all := parseProcesses(out, 0)
+	fillCommands(all)
 
 	// Filter out kernel threads (PID <= 2 or bracketed names like [kthreadd])
 	var filtered []ProcessInfo
@@ -131,6 +146,84 @@ func allProcesses() ([]ProcessInfo, error) {
 	}
 
 	return filtered, nil
+}
+
+// AllProcesses returns every running process except kernel threads, with the
+// command line filled in. Unlike ListProcesses it does not sort or truncate:
+// a caller comparing two runs needs the whole set, since a process dropping
+// out of a top-N sample is not the same event as a process exiting.
+func AllProcesses() ([]ProcessInfo, error) {
+	return allProcesses()
+}
+
+// fillCommands joins invocations onto processes by PID.
+//
+// It is a second ps call rather than an extra column on the first, because
+// comm can itself contain spaces — the existing parser joins the tail of the
+// line to recover it — so appending args to the same output leaves no
+// unambiguous split. A process that exits between the two calls simply has
+// no command, and identity falls back to its name.
+func fillCommands(procs []ProcessInfo) {
+	// etime rather than etimes: etimes is Linux-only, and this has to parse
+	// on macOS too.
+	out, err := util.RunCmd("ps", "-eo", "pid=,etime=,args=")
+	if err != nil {
+		return
+	}
+	type detail struct {
+		command string
+		elapsed time.Duration
+	}
+	details := make(map[int]detail, len(procs))
+	for _, line := range strings.Split(out, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 3 {
+			continue
+		}
+		pid, err := strconv.Atoi(fields[0])
+		if err != nil {
+			continue
+		}
+		details[pid] = detail{
+			command: strings.Join(fields[2:], " "),
+			elapsed: parseElapsed(fields[1]),
+		}
+	}
+	for i := range procs {
+		d := details[procs[i].PID]
+		procs[i].Command = d.command
+		procs[i].Elapsed = d.elapsed
+	}
+}
+
+// parseElapsed reads ps's etime format: [[dd-]hh:]mm:ss. An unparseable
+// value returns zero, which callers treat as "too young to report" — the
+// safer direction, since a process wrongly held back appears on the next run
+// and one wrongly reported is noise forever.
+func parseElapsed(value string) time.Duration {
+	days := 0
+	if before, after, found := strings.Cut(value, "-"); found {
+		d, err := strconv.Atoi(before)
+		if err != nil {
+			return 0
+		}
+		days, value = d, after
+	}
+
+	parts := strings.Split(value, ":")
+	if len(parts) < 2 || len(parts) > 3 {
+		return 0
+	}
+	units := []time.Duration{time.Second, time.Minute, time.Hour}
+	total := time.Duration(days) * 24 * time.Hour
+	for i := range parts {
+		n, err := strconv.Atoi(parts[len(parts)-1-i])
+		if err != nil {
+			return 0
+		}
+		total += time.Duration(n) * units[i]
+	}
+	return total
 }
 
 // isKernelThread detects common Linux kernel thread names.

--- a/internal/system/processes_test.go
+++ b/internal/system/processes_test.go
@@ -1,6 +1,9 @@
 package system
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
 func TestParseProcesses(t *testing.T) {
 	output := `  PID  %CPU %MEM   RSS STAT COMMAND
@@ -189,6 +192,23 @@ func TestTopProcesses(t *testing.T) {
 		}
 		if p.Name == "" {
 			t.Error("expected non-empty process name")
+		}
+	}
+}
+
+func TestParseElapsed(t *testing.T) {
+	cases := map[string]time.Duration{
+		"00:07":       7 * time.Second,
+		"01:30":       90 * time.Second,
+		"02:01:30":    2*time.Hour + time.Minute + 30*time.Second,
+		"01-01:53:03": 25*time.Hour + 53*time.Minute + 3*time.Second,
+		"garbage":     0,
+		"":            0,
+		"1:2:3:4":     0,
+	}
+	for in, want := range cases {
+		if got := parseElapsed(in); got != want {
+			t.Errorf("parseElapsed(%q) = %v, want %v", in, got, want)
 		}
 	}
 }


### PR DESCRIPTION
Closes #59, and finishes the pair #58 opened.

`processes` ran on every report and was thrown away. The snapshot held containers, ports and disks, so the question in the issue — what started running since yesterday — had no path to an answer even though the observation already happened.

Two of the decisions I left on the issue were wrong about the collectors, and I corrected them there before starting:

**There was no command line to hash.** `ps -eo pid,pcpu,pmem,rss,state,comm` gives the executable name alone, so "name plus `argv[0]`" could not be built from what existed. The collector grows a `Command` field, filled from a second `ps` call joined on PID rather than an extra column — `comm` can itself contain spaces, which is why the existing parser joins the tail of the line, so appending `args` to the same output leaves no unambiguous split.

**`network` is a LAN ping sweep, not interfaces.** Tracking devices appearing on the network is a better feature than the one I described, and it does not belong in `report`: `Scan` sweeps every address in the subnet before reading ARP, which is seconds of work on a command people run in cron. That half is not in this PR and needs its own issue, where the question that decides its shape can be answered on its own.

**The threshold is measured, not chosen.** Two runs thirty seconds apart on an idle machine reported `new head` and `new sed` — the shell pipeline that was reading the report. Anything under a minute old is now ignored, and after that change forty idle seconds reported one line, for a process that had genuinely been running. A process held back is not lost; it appears on the next run, by which time it has earned the word "new".

**The invocation is hashed and never written down.** Command lines carry secrets in flags and `~/.homebutler/reports/snapshots/` has never had to be handled as a credential store. `Command` and `Elapsed` are both `json:"-"`, so neither the `processes` command nor its MCP tool gains a field. `TestSnapshotNeverHoldsACommandLine` plants a token in an invocation and asserts it is absent from the marshalled snapshot.

**Snapshot size, since the issue asked for a measurement rather than a guess.** About 50 KB on a desktop macOS with 639 distinct identities, against 2 KB before; a Linux server running a handful of services is well under that. At the default `--keep 30` that is roughly 1.5 MB of history in the worst case measured. No cap: the number did not call for one, and it is in `docs/report.md` next to `--keep` so the next person deciding does not have to re-derive it.

Verified by running it, not only by tests: baseline, forty seconds, report — and separately with a process started and stopped between runs. Snapshots written during that were removed afterwards. `gofmt`, `go vet`, `go build` and `go test ./...` are clean; `golangci-lint` is not installed here, so CI runs it first.

The report card in the README does not gain a process row here. It should, along with the README lede and the repository description, when the release that makes the whole claim true is cut — not one asset at a time.
