### PR TITLE
docs: the README promised a diff and now has to promise the judgement

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,9 @@
 <h1 align="center">HomeButler</h1>
 
 <p align="center">
-  <strong>Know what changed before you fix it.</strong><br>
-  A single Go binary for running a small home server without babysitting it.
+  <strong>Only the changes worth mentioning.</strong><br>
+  A single Go binary that remembers what your server looked like last time,
+  and tells you — or an agent — what moved.
 </p>
 
 <p align="center">
@@ -27,14 +28,16 @@
 </p>
 
 <p align="center">
-  <img src="assets/report-card.svg" alt="homebutler report output: what changed since the last report — a container gone, one new, one replaced behind the same name, an image bump, a port that changed owner — then current status" width="620">
+  <img src="assets/report-card.svg" alt="homebutler report output: what changed since the last report — a container gone, one new, one replaced behind the same name, a process running a different invocation, a port that changed owner — then current status" width="620">
 </p>
 
 Section rules, labels, and severities are colour-coded in a terminal. Colour is
 dropped automatically when output is piped, redirected, or run from cron.
 
-That is the whole idea. Most homelab tools show you a graph of right now. HomeButler
-remembers what your server looked like last time and tells you what moved.
+That is the whole idea. Most homelab tools show you a graph of right now, and leave
+"does this matter?" to you. HomeButler remembers what your server looked like last
+time, decides what is worth saying, and says it — six containers before and six after
+is not "no change" when one of them is a different container.
 
 HomeButler helps you answer the boring but painful questions every homelab eventually creates:
 

--- a/assets/report-card.svg
+++ b/assets/report-card.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="600" height="604" viewBox="0 0 600 604" role="img" aria-label="Terminal showing homebutler report output: notable changes since the last report — a container gone, one new, one replaced behind the same name, an image bump, seven state changes collapsed into a line, a port that changed owner, and disk growth — followed by current status and a suggested action">
+<svg xmlns="http://www.w3.org/2000/svg" width="600" height="604" viewBox="0 0 600 604" role="img" aria-label="Terminal showing homebutler report output: notable changes since the last report — a container gone, one new, one replaced behind the same name, a process running a different invocation, seven state changes collapsed into a line, a port that changed owner, and disk growth — followed by current status and a suggested action">
   <!--
     Terminal card used at the top of README.md. See assets/README.md.
 
@@ -42,9 +42,9 @@
     <text x="131" y="250" fill="#e6edf3">nginx</text>
     <text x="249" y="250" fill="#8b949e">7d4a91f0aa11 → 91be0322bb22</text>
 
-    <text x="47" y="273" fill="#e3b341">image</text>
-    <text x="131" y="273" fill="#e6edf3">jellyfin</text>
-    <text x="249" y="273" fill="#8b949e">jellyfin:10.9.11 → jellyfin:10.10.0</text>
+    <text x="47" y="273" fill="#e3b341">replaced</text>
+    <text x="131" y="273" fill="#e6edf3">python3</text>
+    <text x="249" y="273" fill="#8b949e">same name, different invocation</text>
 
     <text x="47" y="296" fill="#e3b341">state</text>
     <text x="131" y="296" fill="#e6edf3">7 containers</text>

--- a/internal/report/render_test.go
+++ b/internal/report/render_test.go
@@ -30,6 +30,13 @@ func TestRenderedChangeBlock(t *testing.T) {
 
 	prev := snapshotWith(prevC, []ports.PortInfo{{Protocol: "tcp", Address: "0.0.0.0", Port: "8080", Process: "vaultwarden"}})
 	curr := snapshotWith(currC, []ports.PortInfo{{Protocol: "tcp", Address: "0.0.0.0", Port: "8080", Process: "gitea"}})
+	prev.Processes = processIdentities(procs(
+		system.ProcessInfo{PID: 1, Name: "python3", Command: "python3 /opt/old.py"},
+	))
+	curr.Processes = processIdentities(procs(
+		system.ProcessInfo{PID: 1, Name: "python3", Command: "python3 /opt/new.py"},
+		system.ProcessInfo{PID: 2, Name: "borgbackup", Command: "borg create ::daily /data"},
+	))
 	prev.System = &system.StatusInfo{Disks: []system.DiskInfo{{Mount: "/", UsedGB: 45, TotalGB: 128}}}
 	curr.System = &system.StatusInfo{Disks: []system.DiskInfo{{Mount: "/", UsedGB: 47.4, TotalGB: 128}}}
 	curr.ServerName = "homelab"
@@ -47,6 +54,8 @@ func TestRenderedChangeBlock(t *testing.T) {
 		"state     7 containers  svc-0, svc-1, svc-2, +4",
 		"port      :8080/tcp     vaultwarden → gitea",
 		"disk      /             +2.4 GB since last report",
+		"new       borgbackup",
+		"replaced  python3       same name, different invocation",
 	}
 	for _, line := range want {
 		if !strings.Contains(human, line) {


### PR DESCRIPTION
`Know what changed before you fix it` was true of the ambition and not of the binary. #58 and #59 have landed, so the front page can now say what the tool does — and it has to say the half that was always missing.

The gap was never "changed". Every dashboard on the shelf is glanceable, and several are better looking. A graph makes no judgement: it plots the values and leaves "does this matter?" to whoever is reading. The line that separates this from Beszel and Portainer is that the butler decides what is worth saying and then says it.

So the lede is the decision, not the diff:

> **Only the changes worth mentioning.**
> A single Go binary that remembers what your server looked like last time, and tells you — or an agent — what moved.

The paragraph under the card now names the case that makes it concrete, because it is the one every homelabber recognises: six containers before and six after is not "no change" when one of them is a different container.

The report card swaps its `image` row for `replaced python3 — same name, different invocation`, so processes are visible in the picture now that they are tracked. `TestRenderedChangeBlock` gains both process rows, so the card and `FormatHuman` stay pinned to each other rather than drifting.

The repository description still sells the chat angle and is not changed here. It goes with the 0.26.0 tag, so the front page, the description and the release land in the same window rather than three weeks apart.
