### PR TITLE
chore: prepare the 0.26.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.26.0](https://github.com/Higangssh/homebutler/compare/v0.25.0...v0.26.0) - 2026-09-03
 
 **`report` compared counts and remembered no processes, so a container replaced by a different container read as no change and "what started running since yesterday" had no path to an answer.** The snapshot on disk held the full container and port lists all along; the diff read four integers off it and threw the lists away. `processes` was collected, rendered, and discarded entirely.
 
@@ -11,7 +11,7 @@ All notable changes to this project will be documented in this file.
    gone      vaultwarden   was running
    new       gitea         now running
    replaced  nginx         7d4a91f0aa11 → 91be0322bb22
-   image     jellyfin      jellyfin:10.9.11 → jellyfin:10.10.0
+   replaced  python3       same name, different invocation
    state     7 containers  postgres, redis, grafana, +4
    port      :8080/tcp     vaultwarden → gitea
    disk      /             +2.4 GB since last report


### PR DESCRIPTION
Closes out the `[Unreleased]` set as 0.26.0. Minor rather than patch: `report` answers a question it could not answer before, and three entries land under `⚠️ Behavior changes`.

This is the release the README has been describing since the repository was opened. `Know what changed before you fix it` was the first line of the front page and the diff behind it compared four integers — six containers before and six after was reported as no change whether or not the six were the same six. #58 and #59 close that, and #130 changed the front page to say the half that was always missing: the deciding, not just the diffing.

The sample block in the entry is the real output, pinned by `TestRenderedChangeBlock` against `assets/report-card.svg`, so the changelog, the card and the renderer cannot drift apart quietly.

Worth reading `⚠️ Behavior changes` before tagging:

- `notable_changes` no longer carries the three count lines. The field is still `[]string` and the schema is unchanged, but anything matching on the old strings needs updating
- the human report leads with `Notable Changes` rather than `Current Status`
- snapshots grew from about 2 KB to about 50 KB on a desktop with 639 process identities, which is roughly 1.5 MB at the default `--keep 30`. No cap: the measurement did not call for one, and the number is in `docs/report.md` next to the flag

After this tags, the repository description changes with it — it still sells the chat angle, and directories cache it, so it moves once and in the same window as the release rather than three weeks later.
