### PR TITLE
fix: every Linux report filled with kernel threads coming and going

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+**Every Linux report filled with kernel threads appearing and disappearing.** `isKernelThread` looks for the `kworker/` prefix, and `parseProcesses` had already stripped it: the slash in `kworker/0:4-events` is not a directory separator, but it was treated as one, leaving `0:4-events` for the filter to not recognise. Two runs seconds apart on an idle Raspberry Pi reported twelve kernel threads gone and twelve new. macOS has no kernel threads by that name, which is why it took running it on Linux to see.
+
+### 🐛 Fixes
+
+- keep a kernel thread's name intact so the filter can recognise it (#59). Only an absolute path is reduced to its base name now — `/usr/bin/node` still becomes `node`, and `kworker/R-rcu_g` stays whole
+- report one line when one port opens. Docker publishes on both address families, so a single container starting printed `new :8099/tcp` twice with nothing to tell the two lines apart. Changes that render identically are now dropped from both the human output and `--json`; this is not the grouping rule, which collapses different changes and stays human-only
+
 ## [0.26.0](https://github.com/Higangssh/homebutler/compare/v0.25.0...v0.26.0) - 2026-09-03
 
 **`report` compared counts and remembered no processes, so a container replaced by a different container read as no change and "what started running since yesterday" had no path to an answer.** The snapshot on disk held the full container and port lists all along; the diff read four integers off it and threw the lists away. `processes` was collected, rendered, and discarded entirely.

--- a/docs/report.md
+++ b/docs/report.md
@@ -72,6 +72,13 @@ and counts the rest:
 state     7 containers  postgres, redis, grafana, +4
 ```
 
+Changes that render identically are dropped, in both outputs. Docker publishes
+a port on both address families, so one container starting produces two
+listeners by identity and one sentence by display — one port opening is one
+event. That is not the grouping rule: grouping collapses *different* changes
+into a summary and is human-only, while an exact duplicate carries nothing for
+anything reading the output.
+
 `--json` never groups and never truncates. A person needs the section to stay
 readable; anything reading the output needs all of it, and quietly handing a
 shortened list to an agent is how an agent becomes confidently wrong.

--- a/internal/report/diff.go
+++ b/internal/report/diff.go
@@ -148,6 +148,28 @@ func diffPorts(prev, curr []ports.PortInfo) []Change {
 	return changes
 }
 
+// dedupeChanges drops changes that render identically.
+//
+// Docker publishes a port on both address families, so one container starting
+// produces 0.0.0.0:8099 and [::]:8099 — two listeners by identity, one line
+// by display, and the reader gets the same sentence twice with nothing to
+// tell them apart. One port opening is one event. This is not the grouping
+// rule: grouping collapses different changes into a summary and is left to
+// the human renderer, while an exact duplicate carries no information for
+// anything reading the output, JSON included.
+func dedupeChanges(changes []Change) []Change {
+	seen := make(map[Change]bool, len(changes))
+	out := changes[:0]
+	for _, c := range changes {
+		if seen[c] {
+			continue
+		}
+		seen[c] = true
+		out = append(out, c)
+	}
+	return out
+}
+
 // sortChanges orders by how actionable the kind is, then by subject, so the
 // same two snapshots always produce the same report. Map iteration above is
 // unordered and would otherwise reshuffle the section on every run.

--- a/internal/report/diff_test.go
+++ b/internal/report/diff_test.go
@@ -284,8 +284,9 @@ func TestReplacedContainerAlsoNamesItsState(t *testing.T) {
 }
 
 // df can print the same mountpoint twice. Without a break the join is a cross
-// product and one mount reports four times.
-func TestDuplicateMountDoesNotCrossProduct(t *testing.T) {
+// product and one mount reported four times; the identical rows that survive
+// the join are then collapsed by dedupeChanges, so one mount is one line.
+func TestDuplicateMountReportsOnce(t *testing.T) {
 	prev := snapshotWith(nil, nil)
 	curr := snapshotWith(nil, nil)
 	prev.System = &system.StatusInfo{Disks: []system.DiskInfo{
@@ -302,8 +303,8 @@ func TestDuplicateMountDoesNotCrossProduct(t *testing.T) {
 			diskLines++
 		}
 	}
-	if diskLines != 2 {
-		t.Errorf("two df rows for one mount should report twice, not %d times: %v", diskLines, r.NotableChanges)
+	if diskLines != 1 {
+		t.Errorf("one mount should report once, got %d lines: %v", diskLines, r.NotableChanges)
 	}
 }
 
@@ -477,5 +478,26 @@ func TestFailedProcessCollectorDoesNotEmptyTheMachine(t *testing.T) {
 	}
 	if !strings.Contains(got, "skipped: processes — not compared") {
 		t.Errorf("the skipped comparison is not in notable_changes: %s", got)
+	}
+}
+
+// Found on a Raspberry Pi: docker publishes a port on both address families,
+// so one container starting printed "new :8099/tcp" twice with nothing to
+// tell the two lines apart.
+func TestOnePortOpeningIsOneLine(t *testing.T) {
+	curr := snapshotWith(nil, []ports.PortInfo{
+		{Protocol: "tcp", Address: "0.0.0.0", Port: "8099", Process: "docker-proxy"},
+		{Protocol: "tcp", Address: "[::]", Port: "8099", Process: "docker-proxy"},
+	})
+
+	r := buildReport(curr, snapshotWith(nil, nil))
+	var lines int
+	for _, c := range r.NotableChanges {
+		if strings.Contains(c, ":8099") {
+			lines++
+		}
+	}
+	if lines != 1 {
+		t.Errorf("one port opening produced %d lines: %v", lines, r.NotableChanges)
 	}
 }

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -263,6 +263,7 @@ func buildReport(snap *Snapshot, prev *Snapshot) *Report {
 	}
 
 	sortChanges(changes)
+	changes = dedupeChanges(changes)
 	r.changes = changes
 	for _, c := range changes {
 		r.NotableChanges = append(r.NotableChanges, c.String())

--- a/internal/system/processes.go
+++ b/internal/system/processes.go
@@ -260,6 +260,21 @@ func parseElapsed(value string) time.Duration {
 	return total
 }
 
+// trimExecutablePath reduces a path to its base name, and only a path.
+//
+// The slash in a Linux kernel thread — kworker/0:4-events, kworker/R-rcu_g —
+// is not a directory separator, and treating it as one leaves 0:4-events,
+// which no longer matches the kworker/ prefix isKernelThread looks for. Every
+// such thread then survives the filter, and since they are created and
+// destroyed constantly, a report comparing two runs on Linux fills with them.
+// An executable path is absolute; a thread name is not.
+func trimExecutablePath(name string) string {
+	if strings.HasPrefix(name, "/") {
+		return filepath.Base(name)
+	}
+	return name
+}
+
 // isKernelThread detects common Linux kernel thread names.
 func isKernelThread(name string) bool {
 	kernelPrefixes := []string{
@@ -307,10 +322,7 @@ func parseProcesses(output string, n int) []ProcessInfo {
 				fmt.Sscanf(fields[0], "%d", &pid)
 				fmt.Sscanf(fields[1], "%f", &cpu)
 				fmt.Sscanf(fields[2], "%f", &mem)
-				name := strings.Join(fields[3:], " ")
-				if strings.Contains(name, "/") {
-					name = filepath.Base(name)
-				}
+				name := trimExecutablePath(strings.Join(fields[3:], " "))
 				procs = append(procs, ProcessInfo{PID: pid, Name: name, CPU: cpu, Mem: mem})
 				if n > 0 && len(procs) >= n {
 					break
@@ -329,10 +341,7 @@ func parseProcesses(output string, n int) []ProcessInfo {
 		state := fields[4]
 
 		// comm is the last column and may contain path with spaces
-		name := strings.Join(fields[5:], " ")
-		if strings.Contains(name, "/") {
-			name = filepath.Base(name)
-		}
+		name := trimExecutablePath(strings.Join(fields[5:], " "))
 
 		isZombie := strings.HasPrefix(state, "Z")
 

--- a/internal/system/processes_test.go
+++ b/internal/system/processes_test.go
@@ -1,6 +1,7 @@
 package system
 
 import (
+	"strings"
 	"testing"
 	"time"
 )
@@ -209,6 +210,34 @@ func TestParseElapsed(t *testing.T) {
 	for in, want := range cases {
 		if got := parseElapsed(in); got != want {
 			t.Errorf("parseElapsed(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+// Found by running report twice on a Raspberry Pi: twelve kernel threads
+// appeared and twelve disappeared between two runs seconds apart. The slash
+// in kworker/0:4-events is not a directory separator, and stripping it left
+// a name isKernelThread could not recognise.
+func TestKernelThreadsSurviveToTheFilter(t *testing.T) {
+	output := `  PID  %CPU %MEM   RSS STAT COMMAND
+    4   0.0  0.0     0 I    kworker/R-rcu_g
+   17   0.0  0.0     0 I    kworker/0:4-events
+ 1234  25.0  3.2 51200 S    /usr/bin/node
+`
+	procs := parseProcesses(output, 0)
+	byName := map[string]bool{}
+	for _, p := range procs {
+		byName[p.Name] = true
+	}
+	if !byName["kworker/R-rcu_g"] || !byName["kworker/0:4-events"] {
+		t.Fatalf("a kernel thread lost its prefix and will never be filtered: %+v", procs)
+	}
+	if !byName["node"] {
+		t.Errorf("an executable path was not reduced to its base name: %+v", procs)
+	}
+	for _, p := range procs {
+		if strings.HasPrefix(p.Name, "kworker/") && !isKernelThread(p.Name) {
+			t.Errorf("isKernelThread does not recognise %q", p.Name)
 		}
 	}
 }


### PR DESCRIPTION
Found by running 0.26.0 on the Raspberry Pi rather than on the development machine. Two `report` runs seconds apart on an idle host:

```
gone  12 processes  0:4-events, 1:1-mld, 1:3-events, +9
new   12 processes  0:4-cgroup_free, 1:1-mm_percpu_wq, 1:3+events, +9
```

Those are kernel worker threads. `isKernelThread` looks for the `kworker/` prefix and never saw one, because `parseProcesses` had already run the name through `filepath.Base`: the slash in `kworker/0:4-events` is not a directory separator, and treating it as one leaves `0:4-events`. Every kernel thread on the machine survived the filter, and they are created and destroyed constantly.

Only an absolute path is reduced to its base name now. `/usr/bin/node` still becomes `node`; `kworker/R-rcu_g` stays whole and gets filtered. The basename call has been there since long before #59 — process tracking is what made a latent bug into every Linux user's report.

macOS has no threads named this way, which is the whole reason this needed a Linux host to find. The unit tests passed throughout.

**Also, one port opening printed two lines.** Docker publishes on both address families, so `0.0.0.0:8099` and `[::]:8099` are two listeners by identity and one sentence by display — the reader got `new :8099/tcp` twice with nothing to distinguish them. Changes that render identically are now dropped, in `--json` as well as the human output: one port opening is one event, and an exact duplicate carries nothing for anything reading it. This is not the grouping rule, which collapses *different* changes into a summary and stays human-only.

Verified on the Pi with real containers, covering what the README now claims:

```
replaced  demo-b           ec015c5757b5 → bc1e05ae0243
gone      containerd-shim  1 invocation, others still running
```

and the swap that started this whole line of work — `demo-a` removed, `demo-c` started, two containers running before and after:

```
gone  demo-a  was running
new   demo-c  now running
```

The host is back to zero: containers removed, `~/.homebutler` deleted, test binary deleted, images untouched.
