### PR TITLE
docs: name the eight words the report speaks, and the window it covers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@ All notable changes to this project will be documented in this file.
 - keep a kernel thread's name intact so the filter can recognise it (#59). Only an absolute path is reduced to its base name now — `/usr/bin/node` still becomes `node`, and `kworker/R-rcu_g` stays whole
 - report one line when one port opens. Docker publishes on both address families, so a single container starting printed `new :8099/tcp` twice with nothing to tell the two lines apart. Changes that render identically are now dropped from both the human output and `--json`; this is not the grouping rule, which collapses different changes and stays human-only
 
+### 🐛 Fixes
+
+- say what happened to a replaced container rather than only which identifiers changed. `replaced nginx — 7d4a91f0aa11 → 91be0322bb22` was two hashes where a sentence belonged; it now reads `recreated, 7d4a91f0aa11 → 91be0322bb22`. The detail column is prose for a person and the identifiers are the evidence behind it — the kind is what anything reading `--json` branches on
+- name the snapshot being compared against in the report header. "What changed" covered the last hour or the last three weeks depending on when `report` last ran, and nothing said which
+
 ### ⚠️ Behavior changes
 
 - **Guest start, reboot, and shutdown fail with `no action credential configured for Proxmox endpoint "..."` until `action_token_id` and `action_token` (or `action_token_file`) are added to the endpoint.** There is no fallback to the read token and no compatibility flag — reusing it defeated the reason this credential is separate in the first place

--- a/README.md
+++ b/README.md
@@ -39,6 +39,36 @@ That is the whole idea. Most homelab tools show you a graph of right now, and le
 time, decides what is worth saying, and says it — six containers before and six after
 is not "no change" when one of them is a different container.
 
+### Reading a change
+
+Every line is three columns: **what kind of change**, **what it happened to**, and
+**what exactly happened**. The kind is one of eight words, and it is the same word in
+`--json`, so an agent branches on it without reading prose:
+
+| Kind | Means | You would see it after |
+| --- | --- | --- |
+| `gone` | it was there last time and is not now | `docker rm`, a service stopping, a port closing |
+| `new` | it was not there last time and is now | starting anything |
+| `replaced` | same name, different thing underneath | `docker compose up -d` — the container is recreated, so the name and the count are unchanged |
+| `image` | same container, different image | pulling a new tag |
+| `state` | same container, running where it was stopped, or the reverse | a crash, or bringing something back up |
+| `port` | same port, a different process answering on it | one service taking over another's port |
+| `disk` | a mount moved by more than half a gigabyte | anything that writes |
+| `skipped` | the comparison could not be made | Docker was down when either snapshot was taken |
+
+`replaced` is the one the rest of this exists for. A container recreated under the
+same name leaves every count identical, which is why a report that compares counts —
+as this one did before 0.26.0 — answers "no significant changes" while the thing you
+were running has been swapped out underneath you.
+
+`skipped` is the second: homebutler says it could not compare rather than reporting
+nothing changed. An all-clear it cannot stand behind is worse than no answer.
+
+The header names the snapshot being compared against, so "what changed" is never
+ambiguous about the window it covers.
+
+📖 **[What earns a line, and what is deliberately suppressed →](docs/report.md)**
+
 HomeButler helps you answer the boring but painful questions every homelab eventually creates:
 
 - What is running on my server right now?

--- a/docs/report.md
+++ b/docs/report.md
@@ -10,6 +10,22 @@ homebutler report --json     # complete, ungrouped
 homebutler report --no-save  # look without writing a snapshot
 ```
 
+## The three columns
+
+A change is a kind, a subject and a detail, and they have different jobs.
+
+- **Kind** names what sort of change it is. It is one of eight fixed words and it
+  reaches `--json` unchanged, so anything reading the output branches on it. Adding
+  or renaming one is a breaking change after 1.0.
+- **Subject** names what the change happened to — a container name, a listener, a
+  mount, an executable.
+- **Detail** says what exactly happened, in prose meant for a person. It is free to
+  change between releases, and nothing should ever have to parse it.
+
+That split is why `replaced` reads `recreated, 7d4a91f0aa11 → 91be0322bb22` rather
+than the two identifiers alone: the identifiers are the evidence, the sentence is
+what a reader needs.
+
 ## What earns a line
 
 Changes are compared by identity, not by count. Six containers before and six
@@ -90,6 +106,19 @@ before turning `--keep` up: on a desktop macOS with 639 distinct process
 identities a snapshot is about 50 KB, against 2 KB before. A Linux server
 running a handful of services is well under that. At the default `--keep 30`
 that is roughly 1.5 MB of history in the worst case measured.
+
+## The window
+
+The header names the snapshot being compared against:
+
+```
+🏠 Homebutler Report — homelab
+   2026-09-03T11:52:20Z  ·  compared with 2026-09-02T09:14:03Z
+```
+
+"What changed" means since that snapshot, not since any fixed interval. Running
+`report` hourly and running it once a month produce the same kinds of line about
+very different spans, and the header is what tells them apart.
 
 ## Order
 

--- a/internal/report/diff.go
+++ b/internal/report/diff.go
@@ -102,7 +102,10 @@ func diffContainers(prev, curr []docker.Container) []Change {
 		}
 		switch {
 		case p.ID != c.ID:
-			detail := shortID(p.ID) + " → " + shortID(c.ID)
+			// The detail column is prose a person reads; the ID pair is the
+			// evidence, not the sentence. "recreated" is what docker compose
+			// up -d does to a container, which is how most people meet this.
+			detail := "recreated, " + shortID(p.ID) + " → " + shortID(c.ID)
 			if p.Image != c.Image {
 				detail += ", " + p.Image + " → " + c.Image
 			}

--- a/internal/report/diff_test.go
+++ b/internal/report/diff_test.go
@@ -70,7 +70,7 @@ func TestSameNameDifferentContainerIsReplaced(t *testing.T) {
 
 	r := buildReport(curr, prev)
 	got := strings.Join(r.NotableChanges, " | ")
-	if !strings.Contains(got, "replaced: nginx — 7d4a91f0aa11 → 91be0322bb22") {
+	if !strings.Contains(got, "replaced: nginx — recreated, 7d4a91f0aa11 → 91be0322bb22") {
 		t.Errorf("a replaced container was not reported: %s", got)
 	}
 }

--- a/internal/report/render_test.go
+++ b/internal/report/render_test.go
@@ -49,7 +49,7 @@ func TestRenderedChangeBlock(t *testing.T) {
 	want := []string{
 		"gone      vaultwarden   was running",
 		"new       gitea         now running",
-		"replaced  nginx         7d4a91f0aa11 → 91be0322bb22",
+		"replaced  nginx         recreated, 7d4a91f0aa11 → 91be0322bb22",
 		"image     jellyfin      jellyfin:10.9.11 → jellyfin:10.10.0",
 		"state     7 containers  svc-0, svc-1, svc-2, +4",
 		"port      :8080/tcp     vaultwarden → gitea",

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -37,13 +37,17 @@ type Snapshot struct {
 
 // Report is the structured output of a report run.
 type Report struct {
-	Timestamp        string   `json:"timestamp"`
-	ServerName       string   `json:"server_name"`
-	IsBaseline       bool     `json:"is_baseline"`
-	SnapshotSaved    bool     `json:"snapshot_saved"`
-	Status           []string `json:"status"`
-	NeedsAttention   []string `json:"needs_attention"`
-	NotableChanges   []string `json:"notable_changes"`
+	Timestamp      string   `json:"timestamp"`
+	ServerName     string   `json:"server_name"`
+	IsBaseline     bool     `json:"is_baseline"`
+	SnapshotSaved  bool     `json:"snapshot_saved"`
+	Status         []string `json:"status"`
+	NeedsAttention []string `json:"needs_attention"`
+	NotableChanges []string `json:"notable_changes"`
+	// ComparedTo is the timestamp of the snapshot this run was compared
+	// against. Without it a reader cannot tell whether "what changed" covers
+	// the last hour or the last three weeks.
+	ComparedTo       string   `json:"compared_to,omitempty"`
 	SuggestedActions []string `json:"suggested_actions"`
 	Warnings         []string `json:"warnings,omitempty"`
 
@@ -158,6 +162,9 @@ func buildReport(snap *Snapshot, prev *Snapshot) *Report {
 		Timestamp:  snap.Timestamp,
 		ServerName: snap.ServerName,
 		Warnings:   snap.Warnings,
+	}
+	if prev != nil {
+		r.ComparedTo = prev.Timestamp
 	}
 
 	// Status section
@@ -295,7 +302,11 @@ func FormatHuman(r *Report) string {
 	var b strings.Builder
 
 	fmt.Fprintf(&b, "🏠 %s\n", style.Title.Render("Homebutler Report — "+r.ServerName))
-	fmt.Fprintf(&b, "   %s\n\n", style.Dim.Render(r.Timestamp))
+	stamp := r.Timestamp
+	if r.ComparedTo != "" {
+		stamp += "  ·  compared with " + r.ComparedTo
+	}
+	fmt.Fprintf(&b, "   %s\n\n", style.Dim.Render(stamp))
 
 	if r.IsBaseline {
 		if r.SnapshotSaved {


### PR DESCRIPTION
Asked what `gone`, `new` and `replaced` meant, and the honest answer was that we invented them this week and wrote them down nowhere a user would look. They are also in `--json`, and 1.0 freezes that surface, so the vocabulary needs settling before it is frozen rather than after.

**The rule.** A change is three columns with three jobs: the **kind** names what sort of change it is and is a fixed machine token; the **subject** names what it happened to; the **detail** says what exactly happened, in prose, and nothing should ever parse it.

Two things follow from writing that down.

`replaced` violated it — `7d4a91f0aa11 → 91be0322bb22` is machine data sitting in the human column. It now reads `recreated, 7d4a91f0aa11 → 91be0322bb22`: `recreated` is what `docker compose up -d` does and how most people meet this case, and the identifiers stay as the evidence behind the sentence.

The header did not say what it was comparing against, so no line in the section could be interpreted. It now reads `2026-09-03T11:52:20Z · compared with 2026-09-02T09:14:03Z`. Running `report` hourly and running it monthly produce the same kinds of line about very different spans.

The README gains a **Reading a change** table — all eight kinds, what each means, and what you would have done to see it — placed directly under the card, which is where someone looking at the picture asks. `docs/report.md` states the column rule and the window.

The kind vocabulary is unchanged. That was deliberate: renaming `replaced` was on the table, and `recreated` reads as container-shaped while the same kind is used for processes.