### PR TITLE
feat: decide what needs attention from what changed, not only from what is

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ All notable changes to this project will be documented in this file.
 - require a separate credential for Proxmox guest actions (#107). `action_token_id` plus `action_token` or `action_token_file` configures a second, optional token used only for start, reboot, and shutdown; reads, the dashboard, and the read-only MCP tools keep using the existing token. `config validate` warns when the action credential is the same token as the read one, since that defeats the separation. See [Proxmox setup →](docs/proxmox.md) for creating the second token with a least-privilege ACL
 - add the MCP 2026-07-28 `server/discover` RPC, per-request metadata validation, version mismatch errors, result typing, cache hints, and deterministic tool ordering
 
+- decide what is worth acting on from what changed, not only from the current reading (#136). `Needs Attention` was filled entirely by thresholds — memory over 85%, a disk over 85%, a count of stopped containers — so a service that stopped being local and started answering on every interface produced two ordinary lines in `Notable Changes` and nothing above them. A port that became publicly reachable, a container that was recreated and did not come back, and a container that stopped since the last report are now named there. They are derived from the snapshots rather than from the rendered change lines, because the detail column is prose and nothing that decides what matters may depend on its wording
+
 ### 🐛 Fixes
 
 - keep a kernel thread's name intact so the filter can recognise it (#59). Only an absolute path is reduced to its base name now — `/usr/bin/node` still becomes `node`, and `kworker/R-rcu_g` stays whole

--- a/docs/report.md
+++ b/docs/report.md
@@ -120,6 +120,27 @@ The header names the snapshot being compared against:
 `report` hourly and running it once a month produce the same kinds of line about
 very different spans, and the header is what tells them apart.
 
+## What needs attention
+
+`Needs Attention` answers a different question from `Notable Changes`: not what
+moved, but what is worth doing something about. Two kinds of entry land there.
+
+**Thresholds on the current reading** — memory or a disk above 85%, containers
+stopped right now. These fire whether or not anything changed.
+
+**Consequences of what changed**, which no threshold can see:
+
+- a port that is reachable from every interface now and was not before. The
+  move from `127.0.0.1:8080` to `0.0.0.0:8080` is a departure and an arrival in
+  the section below, with nothing correlating them
+- a container that was recreated or took a new image and is not running — a
+  deploy that did not come back
+- a container that was running at the last report and is not now, by name
+
+These are computed from the snapshots, never from the rendered change lines.
+The detail column is prose that is free to change between releases, so nothing
+that decides what matters may depend on its wording.
+
 ## Order
 
 `Needs Attention`, then `Notable Changes`, then `Current Status`, then

--- a/internal/report/diff.go
+++ b/internal/report/diff.go
@@ -549,3 +549,73 @@ func sameHashes(a, b map[string]bool) bool {
 	}
 	return true
 }
+
+// attentionFromChanges derives what to act on from what moved.
+//
+// The threshold checks above it answer "is something wrong right now"; these
+// answer "did something happen that you would want to know about". Both are
+// computed from the snapshots rather than from the rendered change strings —
+// parsing our own prose to decide what matters would make the detail column
+// load-bearing, which is exactly what the column rule says it must not be.
+func attentionFromChanges(prev, snap *Snapshot) []string {
+	var out []string
+
+	for _, p := range newlyPublicListeners(prev.Ports, snap.Ports) {
+		who := owner(p)
+		if who == "" {
+			who = "an unidentified process"
+		}
+		out = append(out, fmt.Sprintf(
+			"Port %s is now reachable from every interface, answered by %s — it was not before",
+			":"+p.Port+"/"+p.Protocol, who))
+	}
+
+	prevByName := indexContainers(prev.Containers)
+	for _, c := range snap.Containers {
+		p, existed := prevByName[c.Name]
+		if !existed || c.State == "running" {
+			continue
+		}
+		switch {
+		case p.ID != c.ID:
+			out = append(out, fmt.Sprintf(
+				"%s was recreated and is %s, not running — the deploy did not come back", c.Name, c.State))
+		case p.Image != c.Image:
+			out = append(out, fmt.Sprintf(
+				"%s took a new image and is %s, not running", c.Name, c.State))
+		case p.State == "running":
+			out = append(out, fmt.Sprintf(
+				"%s stopped since the last report", c.Name))
+		}
+	}
+
+	sort.Strings(out)
+	return out
+}
+
+// newlyPublicListeners reports listeners that are reachable from every
+// interface now and were not before.
+//
+// The comparison is per port and protocol rather than per listener, because
+// the move that matters — 127.0.0.1:8080 becoming 0.0.0.0:8080 — is a
+// departure and an arrival in the change list with nothing correlating them.
+func newlyPublicListeners(prev, curr []ports.PortInfo) []ports.PortInfo {
+	wasPublic := map[string]bool{}
+	for _, p := range prev {
+		if ports.IsPublicBind(p.Address) {
+			wasPublic[p.Port+"/"+p.Protocol] = true
+		}
+	}
+
+	seen := map[string]bool{}
+	var out []ports.PortInfo
+	for _, p := range curr {
+		key := p.Port + "/" + p.Protocol
+		if !ports.IsPublicBind(p.Address) || wasPublic[key] || seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, p)
+	}
+	return out
+}

--- a/internal/report/diff_test.go
+++ b/internal/report/diff_test.go
@@ -501,3 +501,89 @@ func TestOnePortOpeningIsOneLine(t *testing.T) {
 		t.Errorf("one port opening produced %d lines: %v", lines, r.NotableChanges)
 	}
 }
+
+// The case the section exists for: a service that stopped being local. It is
+// a departure and an arrival in Notable Changes with nothing correlating
+// them, and no threshold on the current reading can see it at all.
+func TestPortBecomingPublicNeedsAttention(t *testing.T) {
+	prev := snapshotWith(nil, []ports.PortInfo{
+		{Protocol: "tcp", Address: "127.0.0.1", Port: "8080", Process: "vaultwarden"},
+	})
+	curr := snapshotWith(nil, []ports.PortInfo{
+		{Protocol: "tcp", Address: "0.0.0.0", Port: "8080", Process: "vaultwarden"},
+	})
+
+	r := buildReport(curr, prev)
+	got := strings.Join(r.NeedsAttention, " | ")
+	if !strings.Contains(got, ":8080/tcp is now reachable from every interface") {
+		t.Errorf("a port that became public did not need attention: %v", r.NeedsAttention)
+	}
+	if !strings.Contains(got, "vaultwarden") {
+		t.Errorf("the entry does not name what is answering: %v", r.NeedsAttention)
+	}
+}
+
+// A port that was already public is not news the second time.
+func TestAlreadyPublicPortIsNotFlagged(t *testing.T) {
+	listeners := []ports.PortInfo{{Protocol: "tcp", Address: "0.0.0.0", Port: "8080", Process: "nginx"}}
+	r := buildReport(snapshotWith(nil, listeners), snapshotWith(nil, listeners))
+	if len(r.NeedsAttention) != 0 {
+		t.Errorf("an unchanged public port was flagged: %v", r.NeedsAttention)
+	}
+}
+
+// A redeploy that did not come back is the failure a person most needs told,
+// and it was previously a change line whose detail happened to end in exited.
+func TestRedeployThatDidNotComeBackNeedsAttention(t *testing.T) {
+	prev := snapshotWith([]docker.Container{
+		{ID: "aaa111", Name: "gitea", Image: "gitea:1.23", State: "running"},
+	}, nil)
+	curr := snapshotWith([]docker.Container{
+		{ID: "bbb222", Name: "gitea", Image: "gitea:1.24", State: "exited"},
+	}, nil)
+
+	r := buildReport(curr, prev)
+	got := strings.Join(r.NeedsAttention, " | ")
+	if !strings.Contains(got, "gitea was recreated and is exited, not running") {
+		t.Errorf("a failed redeploy did not need attention: %v", r.NeedsAttention)
+	}
+}
+
+func TestContainerStoppedSinceLastReportIsNamed(t *testing.T) {
+	prev := snapshotWith([]docker.Container{
+		{ID: "same", Name: "postgres", Image: "postgres:16", State: "running"},
+	}, nil)
+	curr := snapshotWith([]docker.Container{
+		{ID: "same", Name: "postgres", Image: "postgres:16", State: "exited"},
+	}, nil)
+
+	r := buildReport(curr, prev)
+	got := strings.Join(r.NeedsAttention, " | ")
+	if !strings.Contains(got, "postgres stopped since the last report") {
+		t.Errorf("the stopped container was not named: %v", r.NeedsAttention)
+	}
+}
+
+// Attention is derived from the snapshots, never from the rendered strings —
+// the detail column is prose and nothing may depend on its wording.
+func TestAttentionDoesNotDependOnDetailWording(t *testing.T) {
+	prev := snapshotWith([]docker.Container{
+		{ID: "aaa", Name: "app", Image: "app:1", State: "running"},
+	}, nil)
+	curr := snapshotWith([]docker.Container{
+		{ID: "bbb", Name: "app", Image: "app:1", State: "exited"},
+	}, nil)
+
+	r := buildReport(curr, prev)
+	if len(r.NeedsAttention) == 0 {
+		t.Fatal("nothing needed attention")
+	}
+	for _, c := range r.changes {
+		c.Detail = "wording that no longer says anything"
+		_ = c
+	}
+	again := buildReport(curr, prev)
+	if len(again.NeedsAttention) != len(r.NeedsAttention) {
+		t.Error("attention changed with the detail wording")
+	}
+}

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -207,6 +207,12 @@ func buildReport(snap *Snapshot, prev *Snapshot) *Report {
 		r.NeedsAttention = append(r.NeedsAttention,
 			fmt.Sprintf("%d container(s) stopped", snap.StoppedCount))
 	}
+	// What moved is the other half of what needs attention. The checks above
+	// answer "is something wrong right now"; a port that stopped being local
+	// is wrong because of what changed, and no threshold can see it.
+	if prev != nil {
+		r.NeedsAttention = append(r.NeedsAttention, attentionFromChanges(prev, snap)...)
+	}
 
 	if prev == nil {
 		r.IsBaseline = true


### PR DESCRIPTION
Closes #136.

`Needs Attention` was filled entirely from thresholds on the current reading. Nothing in it came from the diff, so this is what a report looked like when a service quietly became reachable from the whole network:

```
── Notable Changes ───────────────────────────────────────────
   gone  127.0.0.1:8080/tcp  was vaultwarden
   new   :8080/tcp           now vaultwarden
   disk  /                   +2.4 GB since last report

── Needs Attention ───────────────────────────────────────────
   (nothing)
```

Three lines of equal weight and the one that matters indistinguishable from the one that means it is Tuesday. Verified after the change by moving a real listener from loopback to every interface:

```
── Needs Attention ───────────────────────────────────────────
   ⚠️  Port :9994/tcp is now reachable from every interface, answered by Python — it was not before
```

Three consequences are named: a port reachable from every interface that was not before, a container recreated or re-imaged that is not running, and a container that was running at the last report and is not now. The first is the one no threshold can see — it is a departure and an arrival in the section below with nothing correlating them, which is why it is computed per port and protocol rather than per listener.

**All of it is derived from the snapshots, never from the rendered change lines.** #135 settled that the detail column is prose which is free to change between releases; letting the decision about what matters depend on its wording would have made it load-bearing the day after saying it must not be. `TestAttentionDoesNotDependOnDetailWording` pins that.

The threshold checks are untouched. `needs_attention` is still `[]string` and the schema is unchanged, which matters because 1.0 freezes it — what had to settle before then is that the section is fed by changes at all.

#137 and #138 are the rest of the same gap: the suggested actions still count rather than name, and the change ordering is by kind rather than by consequence.