### PR TITLE
feat: say what to do and to what, instead of counting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file.
 
 - decide what is worth acting on from what changed, not only from the current reading (#136). `Needs Attention` was filled entirely by thresholds — memory over 85%, a disk over 85%, a count of stopped containers — so a service that stopped being local and started answering on every interface produced two ordinary lines in `Notable Changes` and nothing above them. A port that became publicly reachable, a container that was recreated and did not come back, and a container that stopped since the last report are now named there. They are derived from the snapshots rather than from the rendered change lines, because the detail column is prose and nothing that decides what matters may depend on its wording
 
+- name what to do and to what, instead of counting (#137). `New public port(s) detected — verify these are intentional` became `Verify :8080/tcp should be answering from gitea.`, and a stopped container now comes with the command to look at it. The old actions compared `PublicPortCount` and `StoppedCount`, so they could not name anything — and a port that changed hands without changing the count suggested nothing at all, which is the blind spot #58 closed one section above
+- collapse the attention list when a reboot stops everything at once. Thirty stopped containers were thirty lines in the section a person reads first; they are now one line naming three and counting the rest
+
 ### 🐛 Fixes
 
 - keep a kernel thread's name intact so the filter can recognise it (#59). Only an absolute path is reduced to its base name now — `/usr/bin/node` still becomes `node`, and `kworker/R-rcu_g` stays whole

--- a/docs/report.md
+++ b/docs/report.md
@@ -107,6 +107,19 @@ identities a snapshot is about 50 KB, against 2 KB before. A Linux server
 running a handful of services is well under that. At the default `--keep 30`
 that is roughly 1.5 MB of history in the worst case measured.
 
+## What to do about it
+
+`Suggested Actions` names the thing and the command, and is built from the same
+changes rather than from counts:
+
+```
+→ Verify :8080/tcp should be answering from gitea.
+→ Check why postgres is not running: homebutler docker logs postgres
+```
+
+A count could not say which port or which container, and a port that changed
+hands without changing the count produced no action at all.
+
 ## The window
 
 The header names the snapshot being compared against:
@@ -136,6 +149,14 @@ stopped right now. These fire whether or not anything changed.
 - a container that was recreated or took a new image and is not running — a
   deploy that did not come back
 - a container that was running at the last report and is not now, by name
+
+A public port whose answering process changed lands here too — the same number
+of public ports, a different service behind one of them.
+
+When more containers stopped than a person will read one at a time, the entry
+collapses: `12 containers stopped since the last report: api, redis, web, +9`.
+A reboot stops everything at once, and the section someone reads first must not
+become the longest one on the page.
 
 These are computed from the snapshots, never from the rendered change lines.
 The detail column is prose that is free to change between releases, so nothing

--- a/internal/report/diff.go
+++ b/internal/report/diff.go
@@ -570,12 +570,15 @@ func attentionFromChanges(prev, snap *Snapshot) []string {
 			":"+p.Port+"/"+p.Protocol, who))
 	}
 
-	prevByName := indexContainers(prev.Containers)
-	for _, c := range snap.Containers {
-		p, existed := prevByName[c.Name]
-		if !existed || c.State == "running" {
-			continue
-		}
+	for _, p := range publicPortsChangedHands(prev.Ports, snap.Ports) {
+		out = append(out, fmt.Sprintf(
+			"Port %s is answered by %s now, and was not at the last report",
+			":"+p.Port+"/"+p.Protocol, owner(p)))
+	}
+
+	var stopped []string
+	for _, c := range containersNeedingAttention(prev, snap) {
+		p := indexContainers(prev.Containers)[c.Name]
 		switch {
 		case p.ID != c.ID:
 			out = append(out, fmt.Sprintf(
@@ -583,13 +586,96 @@ func attentionFromChanges(prev, snap *Snapshot) []string {
 		case p.Image != c.Image:
 			out = append(out, fmt.Sprintf(
 				"%s took a new image and is %s, not running", c.Name, c.State))
-		case p.State == "running":
-			out = append(out, fmt.Sprintf(
-				"%s stopped since the last report", c.Name))
+		default:
+			stopped = append(stopped, c.Name)
+		}
+	}
+
+	// A reboot stops everything at once. Naming thirty containers one per
+	// line turns the section a person reads first into the longest one on the
+	// page, which is the failure this whole feature is trying to avoid.
+	if len(stopped) > groupThreshold {
+		out = append(out, fmt.Sprintf("%d containers stopped since the last report: %s, +%d",
+			len(stopped), strings.Join(stopped[:groupNamed], ", "), len(stopped)-groupNamed))
+	} else {
+		for _, name := range stopped {
+			out = append(out, name+" stopped since the last report")
 		}
 	}
 
 	sort.Strings(out)
+	return out
+}
+
+// containersNeedingAttention returns containers that were present at the last
+// report and are not running now, in a stable order.
+func containersNeedingAttention(prev, snap *Snapshot) []docker.Container {
+	prevByName := indexContainers(prev.Containers)
+	var out []docker.Container
+	for _, c := range snap.Containers {
+		p, existed := prevByName[c.Name]
+		if !existed || c.State == "running" || p.State != "running" && p.ID == c.ID && p.Image == c.Image {
+			continue
+		}
+		out = append(out, c)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out
+}
+
+// actionsFromChanges names what to do and to what.
+//
+// The old actions compared counts, so they could not say which port or which
+// container, and a port that changed hands without changing the count
+// produced no action at all — the same blind spot #58 closed one section
+// above, still sitting here.
+func actionsFromChanges(prev, snap *Snapshot) []string {
+	var out []string
+
+	for _, p := range newlyPublicListeners(prev.Ports, snap.Ports) {
+		who := owner(p)
+		if who == "" {
+			who = "whatever is answering"
+		}
+		out = append(out, fmt.Sprintf("Verify %s should be reachable from every interface, answered by %s.",
+			":"+p.Port+"/"+p.Protocol, who))
+	}
+
+	for _, p := range publicPortsChangedHands(prev.Ports, snap.Ports) {
+		out = append(out, fmt.Sprintf("Verify %s should be answering from %s.",
+			":"+p.Port+"/"+p.Protocol, owner(p)))
+	}
+
+	stopped := containersNeedingAttention(prev, snap)
+	if len(stopped) > groupNamed {
+		stopped = stopped[:groupNamed]
+	}
+	for _, c := range stopped {
+		out = append(out, fmt.Sprintf("Check why %s is not running: homebutler docker logs %s", c.Name, c.Name))
+	}
+
+	return out
+}
+
+// publicPortsChangedHands reports listeners reachable from every interface
+// whose answering process changed.
+//
+// The count-based action went silent here: the same number of public ports,
+// a different service behind one of them. That is the blind spot #58 closed
+// for the change list, and it sat one section lower until #137.
+func publicPortsChangedHands(prev, curr []ports.PortInfo) []ports.PortInfo {
+	before := indexPorts(prev)
+	var out []ports.PortInfo
+	for key, c := range indexPorts(curr) {
+		p, existed := before[key]
+		if !existed || !ports.IsPublicBind(c.Address) {
+			continue
+		}
+		if owner(p) != "" && owner(c) != "" && owner(p) != owner(c) {
+			out = append(out, c)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Port < out[j].Port })
 	return out
 }
 

--- a/internal/report/diff_test.go
+++ b/internal/report/diff_test.go
@@ -2,6 +2,7 @@ package report
 
 import (
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -585,5 +586,83 @@ func TestAttentionDoesNotDependOnDetailWording(t *testing.T) {
 	again := buildReport(curr, prev)
 	if len(again.NeedsAttention) != len(r.NeedsAttention) {
 		t.Error("attention changed with the detail wording")
+	}
+}
+
+func TestActionNamesThePortAndTheProcess(t *testing.T) {
+	prev := snapshotWith(nil, []ports.PortInfo{
+		{Protocol: "tcp", Address: "127.0.0.1", Port: "8080", Process: "vaultwarden"},
+	})
+	curr := snapshotWith(nil, []ports.PortInfo{
+		{Protocol: "tcp", Address: "0.0.0.0", Port: "8080", Process: "gitea"},
+	})
+
+	r := buildReport(curr, prev)
+	got := strings.Join(r.SuggestedActions, " | ")
+	if !strings.Contains(got, ":8080/tcp") || !strings.Contains(got, "gitea") {
+		t.Errorf("the action names neither the port nor the process: %v", r.SuggestedActions)
+	}
+	if strings.Contains(got, "port(s)") {
+		t.Errorf("the action still speaks in counts: %v", r.SuggestedActions)
+	}
+}
+
+// The count-based action went silent here: same number of public ports, a
+// different process answering. It is the blind spot #58 closed one section up.
+func TestPortChangingHandsStillSuggestsSomething(t *testing.T) {
+	prev := snapshotWith(nil, []ports.PortInfo{
+		{Protocol: "tcp", Address: "0.0.0.0", Port: "8080", Process: "vaultwarden"},
+	})
+	curr := snapshotWith(nil, []ports.PortInfo{
+		{Protocol: "tcp", Address: "0.0.0.0", Port: "8080", Process: "gitea"},
+	})
+
+	r := buildReport(curr, prev)
+	if len(r.SuggestedActions) == 0 {
+		t.Error("a port that changed hands suggested nothing")
+	}
+}
+
+func TestActionNamesTheContainerAndTheCommand(t *testing.T) {
+	prev := snapshotWith([]docker.Container{
+		{ID: "same", Name: "postgres", Image: "postgres:16", State: "running"},
+	}, nil)
+	curr := snapshotWith([]docker.Container{
+		{ID: "same", Name: "postgres", Image: "postgres:16", State: "exited"},
+	}, nil)
+
+	r := buildReport(curr, prev)
+	got := strings.Join(r.SuggestedActions, " | ")
+	if !strings.Contains(got, "homebutler docker logs postgres") {
+		t.Errorf("the action does not name the command to run: %v", r.SuggestedActions)
+	}
+}
+
+// A reboot stops everything at once. The section a person reads first must
+// not become the longest one on the page.
+func TestManyStoppedContainersCollapse(t *testing.T) {
+	var prevList, currList []docker.Container
+	for i := 0; i < 30; i++ {
+		n := fmt.Sprintf("svc-%02d", i)
+		prevList = append(prevList, docker.Container{ID: n, Name: n, Image: "img", State: "running"})
+		currList = append(currList, docker.Container{ID: n, Name: n, Image: "img", State: "exited"})
+	}
+
+	r := buildReport(snapshotWith(currList, nil), snapshotWith(prevList, nil))
+
+	var stoppedLines int
+	for _, a := range r.NeedsAttention {
+		if strings.Contains(a, "stopped since the last report") {
+			stoppedLines++
+		}
+	}
+	if stoppedLines != 1 {
+		t.Errorf("thirty stopped containers produced %d attention lines: %v", stoppedLines, r.NeedsAttention)
+	}
+	if !strings.Contains(strings.Join(r.NeedsAttention, " "), "30 containers stopped") {
+		t.Errorf("the collapsed line does not count what it collapsed: %v", r.NeedsAttention)
+	}
+	if len(r.SuggestedActions) > groupNamed {
+		t.Errorf("thirty stopped containers produced %d actions", len(r.SuggestedActions))
 	}
 }

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -286,15 +286,10 @@ func buildReport(snap *Snapshot, prev *Snapshot) *Report {
 		r.NotableChanges = append(r.NotableChanges, "No significant changes since last report.")
 	}
 
-	// Suggested actions
-	if snap.PublicPortCount > prev.PublicPortCount {
-		r.SuggestedActions = append(r.SuggestedActions,
-			"New public port(s) detected — verify these are intentional.")
-	}
-	if snap.StoppedCount > prev.StoppedCount {
-		r.SuggestedActions = append(r.SuggestedActions,
-			"Container(s) stopped since last report — check logs with 'homebutler docker logs'.")
-	}
+	// Suggested actions, built from what changed rather than from counts. A
+	// count cannot say which port or which container, and a port that changed
+	// hands without changing the count produced no action at all.
+	r.SuggestedActions = append(r.SuggestedActions, actionsFromChanges(prev, snap)...)
 	if len(r.NeedsAttention) > 0 && len(r.SuggestedActions) == 0 {
 		r.SuggestedActions = append(r.SuggestedActions,
 			"Address items in 'Needs attention' above.")


### PR DESCRIPTION
Closes #137.

The suggested actions were still built from the counts the rest of `report` stopped using in 0.26.0, so they could not name anything:

```
→ New public port(s) detected — verify these are intentional.
```

and went silent in the case that matters most — a port whose owner changes leaves `PublicPortCount` identical, so nothing was suggested at all. That is the blind spot #58 closed one section above, still sitting one section lower. `TestPortChangingHandsStillSuggestsSomething` is that case; it failed on the first implementation here, because I had only covered listeners that became public and not ones that changed hands.

Now:

```
→ Verify :9993/tcp should be reachable from every interface, answered by Python.
→ Check why postgres is not running: homebutler docker logs postgres
```

Verified by moving a real listener from loopback to every interface, which produces the attention line, the two change lines and the action together.

**Also caps the attention list, which #139 left unbounded.** A reboot stops everything at once, and thirty stopped containers were thirty lines in the section a person reads first — the exact failure the whole feature exists to avoid, reintroduced one section higher. They collapse to `30 containers stopped since the last report: svc-00, svc-01, svc-02, +27`, and the actions stop at three.

A public port that changed hands is now an attention entry as well as an action. It is the same computation, and a different service answering on a port that is open to the network is the more alarming half.

#138 — ranking changes by consequence rather than by kind — I am closing rather than building. #139 put "read this first" in `Needs Attention`, which is where it belongs; teaching the change list a second notion of consequence would put the same judgement in two places.
