### PR TITLE
fix: the unsupported-version error offered back the version it refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ All notable changes to this project will be documented in this file.
 
 ### 🐛 Fixes
 
+- stop offering back the protocol version that was just refused (#133). `UnsupportedProtocolVersionError` listed every revision homebutler implements, including the legacy one the client had put in `_meta` — and the spec asks a client to pick from that list and retry, so an obedient one loops. The error now lists only what may appear in `_meta`; `server/discover` still advertises both eras, because a dual-era server genuinely can be reached either way
+
 - keep a kernel thread's name intact so the filter can recognise it (#59). Only an absolute path is reduced to its base name now — `/usr/bin/node` still becomes `node`, and `kworker/R-rcu_g` stays whole
 - report one line when one port opens. Docker publishes on both address families, so a single container starting printed `new :8099/tcp` twice with nothing to tell the two lines apart. Changes that render identically are now dropped from both the human output and `--json`; this is not the grouping rule, which collapses different changes and stays human-only
 

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -158,6 +158,18 @@ revisions added is either out of scope here — resources, prompts, sampling,
 roots, elicitation, tasks, and everything about Streamable HTTP — or already
 how homebutler behaves.
 
+### Two lists, two questions
+
+`server/discover` advertises every revision this server can be reached by, both
+eras, because a dual-era server genuinely answers an `initialize` handshake as
+well as modern per-request metadata.
+
+`UnsupportedProtocolVersionError` (`-32022`) lists only the revisions that may
+appear in a request's `_meta`. A legacy revision arriving there is a
+contradiction rather than a version the server declined, and offering it back
+would tell a client to retry with the version it was just refused — the spec
+asks the client to pick from that list and try again.
+
 ## Agent Skill
 
 homebutler ships with an [Agent Skill](https://agentskills.io) that works across AI tools:

--- a/internal/mcp/mcp_test.go
+++ b/internal/mcp/mcp_test.go
@@ -712,3 +712,49 @@ func TestToolsListIsCacheableAndDeterministic(t *testing.T) {
 		}
 	}
 }
+
+// The error told a client its version was unsupported and handed back a list
+// containing that version. The spec tells the client to pick from the list and
+// retry, so an obedient client loops.
+func TestUnsupportedVersionErrorListsOnlyWhatMetaAccepts(t *testing.T) {
+	s, out := newTestServer()
+	resp := sendAndReceive(t, s, out, `{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"_meta":{`+
+		`"io.modelcontextprotocol/protocolVersion":"2024-11-05",`+
+		`"io.modelcontextprotocol/clientCapabilities":{}}}}`)
+
+	if resp.Error == nil || resp.Error.Code != -32022 {
+		t.Fatalf("expected -32022, got %+v", resp.Error)
+	}
+	data, _ := json.Marshal(resp.Error.Data)
+	var payload struct {
+		Supported []string `json:"supported"`
+		Requested string   `json:"requested"`
+	}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("unmarshal error data: %v", err)
+	}
+	if len(payload.Supported) == 0 {
+		t.Fatal("the supported list is empty")
+	}
+	for _, v := range payload.Supported {
+		if v == payload.Requested {
+			t.Errorf("the refused version %q is offered back in %v", v, payload.Supported)
+		}
+		for _, legacy := range legacyProtocolVersions {
+			if v == legacy {
+				t.Errorf("legacy version %q is offered as usable in _meta", v)
+			}
+		}
+	}
+}
+
+// server/discover still advertises both eras: a dual-era server genuinely can
+// be reached by an initialize handshake, and the spec's own example mixes them.
+func TestDiscoverStillAdvertisesBothEras(t *testing.T) {
+	s, out := newTestServer()
+	sendAndReceive(t, s, out, `{"jsonrpc":"2.0","id":1,"method":"server/discover"}`)
+	body := out.String()
+	if !strings.Contains(body, "2026-07-28") || !strings.Contains(body, "2024-11-05") {
+		t.Errorf("discover no longer advertises both eras: %s", body)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -108,7 +108,23 @@ var supportedProtocolVersions = []string{
 	"2024-11-05",
 }
 
-var legacyProtocolVersions = supportedProtocolVersions[1:]
+// The two slices answer different questions and must not be used for each
+// other's.
+//
+//   - supportedProtocolVersions is what this server can be reached by, both
+//     eras, and is what server/discover advertises.
+//   - modernProtocolVersions is what may appear in a request's _meta. By the
+//     revision's own terminology a modern version is one that carries the
+//     version as per-request metadata, so a legacy revision arriving there is
+//     a contradiction rather than a version this server declined.
+//
+// Answering UnsupportedProtocolVersionError with the combined list told a
+// client its version was unsupported and handed it a list containing that
+// version, and the spec tells the client to pick from that list and retry.
+var (
+	modernProtocolVersions = supportedProtocolVersions[:1]
+	legacyProtocolVersions = supportedProtocolVersions[1:]
+)
 
 // toolsListTTLMS is a freshness hint, not a promise that the tool registry is
 // immutable. Change it if the registry becomes dynamic or a shorter polling
@@ -822,7 +838,7 @@ func (s *Server) writeUnsupportedProtocolError(id json.RawMessage, requested str
 	resp := jsonRPCResponse{JSONRPC: "2.0", ID: id, Error: &rpcError{
 		Code:    -32022,
 		Message: "Unsupported protocol version",
-		Data:    map[string]any{"supported": supportedProtocolVersions, "requested": requested},
+		Data:    map[string]any{"supported": modernProtocolVersions, "requested": requested},
 	}}
 	data, _ := json.Marshal(resp)
 	fmt.Fprintf(s.out, "%s\n", data)
@@ -860,22 +876,9 @@ type unsupportedProtocolError struct{ requested string }
 
 func (e *unsupportedProtocolError) Error() string { return "Unsupported protocol version" }
 
-func isSupportedProtocolVersion(version string) bool {
-	for _, supported := range supportedProtocolVersions {
-		if version == supported {
-			return true
-		}
-	}
-	return false
-}
-
 func isModernProtocolVersion(version string) bool {
-	return isSupportedProtocolVersion(version) && !isLegacyProtocolVersion(version)
-}
-
-func isLegacyProtocolVersion(version string) bool {
-	for _, legacy := range legacyProtocolVersions {
-		if version == legacy {
+	for _, modern := range modernProtocolVersions {
+		if version == modern {
 			return true
 		}
 	}


### PR DESCRIPTION
Closes #133.

`UnsupportedProtocolVersionError` listed every revision homebutler implements, including the one it had just refused:

```
"error":{"code":-32022,"data":{"requested":"2024-11-05",
  "supported":["2026-07-28","2025-11-25","2025-06-18","2025-03-26","2024-11-05"]}}
```

Both halves were individually true — this server does implement `2024-11-05`, through `initialize` — and together they told a client its version was unsupported while handing back a list containing it. The spec asks the client to "select a mutually supported version from the `supported` list and retry", so an obedient client picks the legacy one and gets the same error again.

The two lists answer different questions and were the same variable:

- **`server/discover`** advertises what this server can be *reached by*. Both eras, unchanged — the spec's own example mixes them, and a dual-era server genuinely answers an `initialize` handshake.
- **`-32022`** answers what may appear in a request's `_meta`. By the revision's own terminology that is the modern versions, so a legacy revision arriving there is a contradiction rather than something the server declined.

```
$ ... '"protocolVersion":"2024-11-05"' ... tools/list
{"error":{"code":-32022,"data":{"requested":"2024-11-05","supported":["2026-07-28"]}}}

$ ... server/discover
{"result":{"supportedVersions":["2026-07-28","2025-11-25","2025-06-18","2025-03-26","2024-11-05"],...}}
```

Both verified over stdio against a build of this branch, along with a modern request still succeeding.

`isModernProtocolVersion` now reads the modern list directly instead of subtracting the legacy one from the combined one, and `isSupportedProtocolVersion` went with it — nothing called it once the subtraction was gone.

Found while reviewing #128 and deliberately kept out of that PR: it is a question about what a dual-era server should say, not a defect in the work that surfaced it, and 1.0 freezes the answer.
