### PR TITLE
feat: doctor did not know when nothing was watching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### ✨ Features
+
+- tell the operator when nothing is installed to watch what they asked to be watched (#99). A watch list with entries and no supervisor is the state that makes every other monitoring feature silent — no incidents recorded, no notifications sent, nothing for `report` to compare against — and it was also the only way to never learn `watch install` exists. The finding says plainly that it checked whether a service is installed rather than whether it is running: a stopped unit is a state this cannot see, and asking systemd or launchd on every `doctor` run is a side effect the command should not grow quietly
+- report a config file that holds plaintext secrets and is readable by others, in `doctor` (#99). The check already existed in `config validate` and in `Load`'s refusal; the decision now lives in one exported function that all three call rather than three copies of `perm&0o077`
+
+### ⚠️ Behavior changes
+
+- **`doctor` runs on a config the other commands refuse.** A config holding plaintext secrets with open permissions is refused by `Load`, which meant the one command whose job is to explain what is wrong was also the one that would not start. `doctor` now parses it anyway and reports the permissions as a failure; every other command refuses exactly as before
+
 ### 🐛 Fixes
 
 - redraw the report card, which had stopped matching the command it illustrates. It showed `New public port(s) detected — verify these are intentional.`, a sentence removed in #137, and had no `Needs Attention` section at all — so the picture at the top of the README showed the diff without the judgement that decides which of it matters. `TestRenderedChangeBlock` now pins every section the card shows rather than only the change block, which is why the drift went a release unnoticed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,13 @@ All notable changes to this project will be documented in this file.
 - tell the operator when nothing is installed to watch what they asked to be watched (#99). A watch list with entries and no supervisor is the state that makes every other monitoring feature silent — no incidents recorded, no notifications sent, nothing for `report` to compare against — and it was also the only way to never learn `watch install` exists. The finding says plainly that it checked whether a service is installed rather than whether it is running: a stopped unit is a state this cannot see, and asking systemd or launchd on every `doctor` run is a side effect the command should not grow quietly
 - report a config file that holds plaintext secrets and is readable by others, in `doctor` (#99). The check already existed in `config validate` and in `Load`'s refusal; the decision now lives in one exported function that all three call rather than three copies of `perm&0o077`
 
-### ⚠️ Behavior changes
-
-- **`doctor` runs on a config the other commands refuse.** A config holding plaintext secrets with open permissions is refused by `Load`, which meant the one command whose job is to explain what is wrong was also the one that would not start. `doctor` now parses it anyway and reports the permissions as a failure; every other command refuses exactly as before
-
 ### 🐛 Fixes
 
 - redraw the report card, which had stopped matching the command it illustrates. It showed `New public port(s) detected — verify these are intentional.`, a sentence removed in #137, and had no `Needs Attention` section at all — so the picture at the top of the README showed the diff without the judgement that decides which of it matters. `TestRenderedChangeBlock` now pins every section the card shows rather than only the change block, which is why the drift went a release unnoticed
+
+### ⚠️ Behavior changes
+
+- **`doctor` runs on a config the other commands refuse.** A config holding plaintext secrets with open permissions is refused by `Load`, which meant the one command whose job is to explain what is wrong was also the one that would not start. `doctor` now parses it anyway and reports the permissions as a failure; every other command refuses exactly as before
 
 ## [0.27.0](https://github.com/Higangssh/homebutler/compare/v0.26.0...v0.27.0) - 2026-09-03
 **`report` learned what changed and then said nothing about which of it mattered.** `Needs Attention` was filled entirely from thresholds on the current reading — memory over 85%, a disk over 85% — so a service that stopped being local and started answering on every interface produced two ordinary lines in the section below it and nothing above. The suggested actions still compared counts, so they could not name the port or the container, and a port that changed hands without changing the count suggested nothing at all.

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Higangssh/homebutler/internal/config"
 	"github.com/Higangssh/homebutler/internal/doctor"
 	"github.com/spf13/cobra"
 )
@@ -17,11 +18,20 @@ func newDoctorCmd() *cobra.Command {
 		Short: "Diagnose homelab health, exposure, backups, and readiness",
 		Long: `Run a read-only diagnosis for the things that usually hurt self-hosted servers:
 resource pressure, stopped containers, public bind ports, backup hygiene,
-notification readiness, report baseline status, and configured Proxmox
-endpoint reachability.`,
+notification readiness, report baseline status, whether anything is installed
+to watch what you asked it to watch, config file permissions, and configured
+Proxmox endpoint reachability.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := loadConfig(); err != nil {
-				return err
+				// doctor is the command that explains what is wrong, so a
+				// refusal it can name has to reach the checks rather than the
+				// exit code. LoadForDiagnosis differs from Load only in the
+				// permission refusal, so succeeding here means that was it.
+				permissive, perr := config.LoadForDiagnosis(config.Resolve(cfgPath))
+				if perr != nil {
+					return err
+				}
+				cfg = permissive
 			}
 			if handled, err := maybeRouteRemote(); handled {
 				return err

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -78,7 +78,7 @@ Restart your AI client — homebutler tools will appear automatically.
 |--------------------------|------------------------------------------------------------------------------------------------------------------------|
 | `system_status`          | CPU, memory, disk, uptime                                                                                              |
 | `report`                 | Butler-style health report with snapshot comparison and suggested actions                                              |
-| `doctor`                 | Read-only diagnosis of resource pressure, stopped containers, public ports, backup hygiene, notification readiness, and configured Proxmox endpoint reachability |
+| `doctor`                 | Read-only diagnosis of resource pressure, stopped containers, public ports, backup hygiene, notification readiness, whether a watch service is installed, config file permissions, and configured Proxmox endpoint reachability |
 | `watch_check`            | One-shot restart check on watched targets; reports systemd and pm2 targets as skipped rather than healthy              |
 | `watch_history`          | Recorded restart incidents, newest first. Captured logs are excluded unless `include_logs` is set                      |
 | `watch_list`             | Targets being watched, with their kind and what the last check recorded                                                |

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -383,6 +383,10 @@ func newDefaultConfig() *Config {
 }
 
 func Load(path string) (*Config, error) {
+	return load(path, true)
+}
+
+func load(path string, refuseOpenPermissions bool) (*Config, error) {
 	cfg := newDefaultConfig()
 
 	if path == "" {
@@ -406,17 +410,41 @@ func Load(path string) (*Config, error) {
 
 	cfg.Path = path
 
-	// Refuse unsafe config permissions when plaintext secrets are present (non-Windows).
-	if runtime.GOOS != "windows" && hasSecrets(cfg) {
-		if info, err := os.Stat(path); err == nil {
-			perm := info.Mode().Perm()
-			if perm&0o077 != 0 {
-				return nil, fmt.Errorf("config file %s contains plaintext secrets but permissions are too open (%04o); run: chmod 600 %s", path, perm, path)
-			}
-		}
+	// Refuse unsafe config permissions when plaintext secrets are present.
+	if perm, tooOpen := PermissionProblem(path, cfg); refuseOpenPermissions && tooOpen {
+		return nil, fmt.Errorf("config file %s contains plaintext secrets but permissions are too open (%04o); run: chmod 600 %s", path, perm, path)
 	}
 
 	return cfg, nil
+}
+
+// LoadForDiagnosis parses a config without refusing it for open permissions.
+//
+// Only doctor should call this. The command whose job is to explain what is
+// wrong with a machine cannot be the one command that will not start because
+// something is wrong — a user whose config is 0644 currently meets a refusal
+// they read as homebutler being broken, from every command including the one
+// that would have named the problem.
+func LoadForDiagnosis(path string) (*Config, error) {
+	return load(path, false)
+}
+
+// PermissionProblem reports whether a config file is more open than one
+// holding plaintext secrets should be, and the permissions it found.
+//
+// One decision, three renderings: Load refuses, config validate reports it as
+// an error, and doctor surfaces it before either has to. #47 and #65 were both
+// about the version of this where each caller kept its own copy of the rule.
+func PermissionProblem(path string, cfg *Config) (os.FileMode, bool) {
+	if runtime.GOOS == "windows" || !hasSecrets(cfg) {
+		return 0, false
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, false
+	}
+	perm := info.Mode().Perm()
+	return perm, perm&0o077 != 0
 }
 
 // FindServer returns the server config by name, or nil if not found.

--- a/internal/config/validate.go
+++ b/internal/config/validate.go
@@ -426,14 +426,7 @@ func plural(n int, noun string) string {
 // checkPermissions mirrors the guard in Load so that validate reports the
 // same refusal instead of the user meeting it later mid-command.
 func (r *ValidationResult) checkPermissions(path string, cfg *Config) {
-	if runtime.GOOS == "windows" || !hasSecrets(cfg) {
-		return
-	}
-	info, err := os.Stat(path)
-	if err != nil {
-		return
-	}
-	if perm := info.Mode().Perm(); perm&0o077 != 0 {
+	if perm, tooOpen := PermissionProblem(path, cfg); tooOpen {
 		r.add(SeverityError, "",
 			fmt.Sprintf("Config contains plaintext secrets but permissions are too open (%04o).", perm),
 			fmt.Sprintf("Run: chmod 600 %s", path))

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -14,7 +14,9 @@ import (
 	"github.com/Higangssh/homebutler/internal/inventory"
 	"github.com/Higangssh/homebutler/internal/ports"
 	"github.com/Higangssh/homebutler/internal/proxmox"
+	"github.com/Higangssh/homebutler/internal/service"
 	"github.com/Higangssh/homebutler/internal/style"
+	"github.com/Higangssh/homebutler/internal/watch"
 	"github.com/charmbracelet/lipgloss"
 )
 
@@ -68,6 +70,13 @@ type CollectFuncs struct {
 	BackupListFn  func(string) ([]backup.ListEntry, error)
 	SnapshotDir   string
 	ProxmoxOpenFn func(config.ProxmoxConfig) (*proxmox.Client, error)
+
+	// WatchDir holds the watch list. Empty takes the real one.
+	WatchDir string
+	// WatchServiceFn reports whether a supervisor unit for watch is installed
+	// and where it is. Injected so the check is testable without a systemd or
+	// launchd on the machine running the tests.
+	WatchServiceFn func() (bool, string)
 }
 
 // DefaultCollectFuncs returns real doctor data sources.
@@ -128,6 +137,8 @@ func Run(cfg *config.Config, fns CollectFuncs, opts Options) (*Result, error) {
 	checkContainers(r, inv)
 	checkPublicPorts(r, inv.Ports)
 	checkBackups(r, cfg, fns.BackupListFn, opts)
+	checkWatching(r, fns.WatchDir, fns.WatchServiceFn)
+	checkConfigPermissions(r, cfg)
 	checkNotifications(r, cfg)
 	checkReportBaseline(r, fns.SnapshotDir)
 	checkProxmox(r, cfg, fns.ProxmoxOpenFn)
@@ -302,6 +313,80 @@ func formatBytes(b int64) string {
 		exp++
 	}
 	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGT"[exp])
+}
+
+// checkWatching reports a watch list that nothing is installed to poll.
+//
+// A list with entries and no supervisor is the state that makes every other
+// monitoring feature silent: no incidents recorded, no notifications sent,
+// nothing to compare a report against. It is also the only place a user finds
+// out that `watch install` exists.
+//
+// It checks whether a unit is installed, not whether it is running. A stopped
+// unit is a state this cannot see, and claiming otherwise would be worse than
+// saying less — asking systemd or launchd on every doctor run is a side
+// effect this command should not grow quietly.
+func checkWatching(r *Result, dir string, installedFn func() (bool, string)) {
+	if installedFn == nil {
+		installedFn = watchServiceInstalled
+	}
+	if dir == "" {
+		d, err := watch.WatchDir()
+		if err != nil {
+			return
+		}
+		dir = d
+	}
+
+	targets, err := watch.LoadTargets(dir)
+	if err != nil || len(targets) == 0 {
+		return
+	}
+
+	installed, where := installedFn()
+	if installed {
+		r.add(SeverityPass, "watch",
+			fmt.Sprintf("%d target(s) watched by an installed service", len(targets)),
+			"Unit: "+where, "", "")
+		return
+	}
+
+	r.add(SeverityWarn, "watch",
+		fmt.Sprintf("%d target(s) on the watch list and no service installed to check them", len(targets)),
+		"Nothing is polling them, so a restart records no incident and sends no notification. "+
+			"This checks whether a service is installed, not whether it is running.",
+		"Install the watch service so monitoring survives logout and reboot.",
+		"homebutler watch install")
+}
+
+func watchServiceInstalled() (bool, string) {
+	kind, err := service.Detect()
+	if err != nil {
+		return false, ""
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false, ""
+	}
+	path := service.UnitPath(kind, home)
+	return service.Installed(path), path
+}
+
+// checkConfigPermissions surfaces the refusal Load would make, before the
+// user meets it as homebutler appearing to be broken.
+func checkConfigPermissions(r *Result, cfg *config.Config) {
+	if cfg == nil || cfg.Path == "" {
+		return
+	}
+	perm, tooOpen := config.PermissionProblem(cfg.Path, cfg)
+	if !tooOpen {
+		return
+	}
+	r.add(SeverityFail, "config",
+		fmt.Sprintf("Config holds plaintext secrets and is readable by others (%04o)", perm),
+		cfg.Path+" can be read by any user on this machine, and homebutler will refuse to load it.",
+		"Restrict it to your account.",
+		"chmod 600 "+cfg.Path)
 }
 
 func checkNotifications(r *Result, cfg *config.Config) {

--- a/internal/doctor/doctor_watch_test.go
+++ b/internal/doctor/doctor_watch_test.go
@@ -1,0 +1,112 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Higangssh/homebutler/internal/config"
+	"github.com/Higangssh/homebutler/internal/watch"
+)
+
+func watchDirWith(t *testing.T, targets ...watch.Target) string {
+	t.Helper()
+	dir := t.TempDir()
+	if len(targets) > 0 {
+		if err := watch.SaveTargets(dir, targets); err != nil {
+			t.Fatalf("SaveTargets: %v", err)
+		}
+	}
+	return dir
+}
+
+func findingsFor(r *Result, category string) []Finding {
+	var out []Finding
+	for _, f := range r.Findings {
+		if f.Category == category {
+			out = append(out, f)
+		}
+	}
+	return out
+}
+
+// The state that makes every other monitoring feature silent, and the only
+// place a user finds out that watch install exists.
+func TestWatchListWithNoServiceIsAWarning(t *testing.T) {
+	dir := watchDirWith(t, watch.Target{Container: "nginx", AddedAt: time.Now()})
+	r := &Result{}
+	checkWatching(r, dir, func() (bool, string) { return false, "" })
+
+	got := findingsFor(r, "watch")
+	if len(got) != 1 || got[0].Severity != SeverityWarn {
+		t.Fatalf("expected one warning, got %+v", got)
+	}
+	if got[0].Command != "homebutler watch install" {
+		t.Errorf("the finding does not name the command that fixes it: %q", got[0].Command)
+	}
+	if !strings.Contains(got[0].Detail, "not whether it is running") {
+		t.Errorf("the finding overstates what it checked: %q", got[0].Detail)
+	}
+}
+
+func TestInstalledServiceIsAPass(t *testing.T) {
+	dir := watchDirWith(t, watch.Target{Container: "nginx", AddedAt: time.Now()})
+	r := &Result{}
+	checkWatching(r, dir, func() (bool, string) { return true, "/home/u/.config/systemd/user/homebutler-watch.service" })
+
+	got := findingsFor(r, "watch")
+	if len(got) != 1 || got[0].Severity != SeverityPass {
+		t.Fatalf("expected one pass, got %+v", got)
+	}
+}
+
+// An empty watch list is not a problem. Someone who has not asked for
+// monitoring is not being told they are missing it.
+func TestEmptyWatchListSaysNothing(t *testing.T) {
+	r := &Result{}
+	checkWatching(r, watchDirWith(t), func() (bool, string) { return false, "" })
+	if got := findingsFor(r, "watch"); len(got) != 0 {
+		t.Errorf("an empty watch list produced %+v", got)
+	}
+}
+
+func TestOpenConfigPermissionsAreAFailure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("permission bits are not enforced the same way on Windows")
+	}
+	path := filepath.Join(t.TempDir(), "homebutler.yaml")
+	if err := os.WriteFile(path, []byte("servers: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{Path: path, Servers: []config.ServerConfig{{Name: "pi", Password: "hunter2"}}}
+
+	r := &Result{}
+	checkConfigPermissions(r, cfg)
+
+	got := findingsFor(r, "config")
+	if len(got) != 1 || got[0].Severity != SeverityFail {
+		t.Fatalf("expected one failure, got %+v", got)
+	}
+	if !strings.Contains(got[0].Command, "chmod 600") {
+		t.Errorf("the finding does not name the command that fixes it: %q", got[0].Command)
+	}
+	if strings.Contains(got[0].Detail+got[0].Title, "hunter2") {
+		t.Errorf("the finding leaked the secret it is about: %+v", got[0])
+	}
+}
+
+// A config with no secrets is not a permissions problem, whatever its mode.
+func TestOpenConfigWithoutSecretsIsFine(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "homebutler.yaml")
+	if err := os.WriteFile(path, []byte("servers: []\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r := &Result{}
+	checkConfigPermissions(r, &config.Config{Path: path})
+	if got := findingsFor(r, "config"); len(got) != 0 {
+		t.Errorf("a config with no secrets was flagged: %+v", got)
+	}
+}


### PR DESCRIPTION
First two of the five in #99.

**Nothing is watching.** A watch list with entries and no supervisor installed is the state that makes every other monitoring feature silent: no incidents recorded, no notifications sent, nothing for `report` to compare against. It is also the only way a user never learns `watch install` exists.

```
⚠️ [watch] 1 target(s) on the watch list and no service installed to check them
   Nothing is polling them, so a restart records no incident and sends no notification.
   This checks whether a service is installed, not whether it is running.
   → Install the watch service so monitoring survives logout and reboot.
   $ homebutler watch install
```

The second sentence is deliberate. A unit that is installed and stopped is a state this cannot see, and querying systemd or launchd on every `doctor` run is a side effect the command should not grow quietly — #123 already made `doctor` reach the network, and that needed a behaviour note. An empty watch list produces nothing: someone who never asked for monitoring is not told they are missing it.

**Config permissions**, and the part of it the issue's table does not show. The check itself is small — the issue asked for the same code `config validate` uses rather than a second copy, so the decision is now one exported `config.PermissionProblem` that `Load`, `config validate` and `doctor` all call.

But adding the check was not enough, and running it is what showed why:

```
$ homebutler doctor --config ./homebutler.yaml
error: config error: config file ... permissions are too open (0644); run: chmod 600 ...
```

`Load` refuses, so `doctor` never started and the finding could never fire. The command whose job is to explain what is wrong was the one command that would not run because something was wrong — which is exactly the experience #99 describes, from the direction it did not mention. `doctor` now falls back to `config.LoadForDiagnosis`, which differs from `Load` only in that refusal, and reports the permissions as a failure. Every other command refuses exactly as before; verified both.

Remaining for the second PR: the Docker socket mount, `insecure: true` on a Proxmox endpoint, and the incident directory approaching its cap.
