### PR TITLE
feat: doctor now checks the five things it already knew

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### ✨ Features
 
+- report a running container that mounts the Docker socket (#99). A container with `/var/run/docker.sock` mounted can create containers on the host as root — it holds host root however unprivileged it looks — and homebutler installs one itself, since `install portainer` mounts the socket and nothing has mentioned it since. Costs one `docker inspect` per running container and stops at the first collector failure rather than retrying per container
+- report a Proxmox endpoint left on `insecure: true` (#99). #62 settled that it should be "last and loud"; it was last, and loud nowhere — no runtime warning, no `config validate` finding, and no check. A debugging session that was never undone is what a periodic check is for
+- report incident history approaching its limit (#99). #101 bounded the directory; knowing how full it is before the pruning starts discarding history someone wanted is the other half. Explicitly unlimited history is a choice and is not flagged
+
 - tell the operator when nothing is installed to watch what they asked to be watched (#99). A watch list with entries and no supervisor is the state that makes every other monitoring feature silent — no incidents recorded, no notifications sent, nothing for `report` to compare against — and it was also the only way to never learn `watch install` exists. The finding says plainly that it checked whether a service is installed rather than whether it is running: a stopped unit is a state this cannot see, and asking systemd or launchd on every `doctor` run is a side effect the command should not grow quietly
 - report a config file that holds plaintext secrets and is readable by others, in `doctor` (#99). The check already existed in `config validate` and in `Load`'s refusal; the decision now lives in one exported function that all three call rather than three copies of `perm&0o077`
 

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -19,8 +19,9 @@ func newDoctorCmd() *cobra.Command {
 		Long: `Run a read-only diagnosis for the things that usually hurt self-hosted servers:
 resource pressure, stopped containers, public bind ports, backup hygiene,
 notification readiness, report baseline status, whether anything is installed
-to watch what you asked it to watch, config file permissions, and configured
-Proxmox endpoint reachability.`,
+to watch what you asked it to watch, config file permissions, containers that
+mount the Docker socket, Proxmox endpoints that accept any certificate, incident
+history nearing its limit, and configured Proxmox endpoint reachability.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if err := loadConfig(); err != nil {
 				// doctor is the command that explains what is wrong, so a

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -78,7 +78,7 @@ Restart your AI client — homebutler tools will appear automatically.
 |--------------------------|------------------------------------------------------------------------------------------------------------------------|
 | `system_status`          | CPU, memory, disk, uptime                                                                                              |
 | `report`                 | Butler-style health report with snapshot comparison and suggested actions                                              |
-| `doctor`                 | Read-only diagnosis of resource pressure, stopped containers, public ports, backup hygiene, notification readiness, whether a watch service is installed, config file permissions, and configured Proxmox endpoint reachability |
+| `doctor`                 | Read-only diagnosis of resource pressure, stopped containers, public ports, backup hygiene, notification readiness, whether a watch service is installed, config file permissions, containers mounting the Docker socket, Proxmox endpoints accepting any certificate, incident history nearing its limit, and configured Proxmox endpoint reachability |
 | `watch_check`            | One-shot restart check on watched targets; reports systemd and pm2 targets as skipped rather than healthy              |
 | `watch_history`          | Recorded restart incidents, newest first. Captured logs are excluded unless `include_logs` is set                      |
 | `watch_list`             | Targets being watched, with their kind and what the last check recorded                                                |

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/Higangssh/homebutler/internal/backup"
 	"github.com/Higangssh/homebutler/internal/config"
+	"github.com/Higangssh/homebutler/internal/docker"
 	"github.com/Higangssh/homebutler/internal/inventory"
 	"github.com/Higangssh/homebutler/internal/ports"
 	"github.com/Higangssh/homebutler/internal/proxmox"
@@ -73,6 +74,9 @@ type CollectFuncs struct {
 
 	// WatchDir holds the watch list. Empty takes the real one.
 	WatchDir string
+	// InspectFn returns a container's details. Injected so the socket check
+	// is testable without a docker daemon.
+	InspectFn func(string) (*docker.InspectResult, error)
 	// WatchServiceFn reports whether a supervisor unit for watch is installed
 	// and where it is. Injected so the check is testable without a systemd or
 	// launchd on the machine running the tests.
@@ -117,6 +121,9 @@ func Run(cfg *config.Config, fns CollectFuncs, opts Options) (*Result, error) {
 	if fns.SnapshotDir == "" {
 		fns.SnapshotDir = defaultSnapshotDir()
 	}
+	if fns.InspectFn == nil {
+		fns.InspectFn = docker.Inspect
+	}
 	if fns.ProxmoxOpenFn == nil {
 		fns.ProxmoxOpenFn = openProxmoxEndpoint
 	}
@@ -137,6 +144,9 @@ func Run(cfg *config.Config, fns CollectFuncs, opts Options) (*Result, error) {
 	checkContainers(r, inv)
 	checkPublicPorts(r, inv.Ports)
 	checkBackups(r, cfg, fns.BackupListFn, opts)
+	checkDockerSocketMounts(r, inv, fns.InspectFn)
+	checkProxmoxTrust(r, cfg)
+	checkIncidentRetention(r, cfg, fns.WatchDir)
 	checkWatching(r, fns.WatchDir, fns.WatchServiceFn)
 	checkConfigPermissions(r, cfg)
 	checkNotifications(r, cfg)
@@ -313,6 +323,99 @@ func formatBytes(b int64) string {
 		exp++
 	}
 	return fmt.Sprintf("%.1f %cB", float64(b)/float64(div), "KMGT"[exp])
+}
+
+// dockerSocket is the path that turns a container into a host-root shell.
+const dockerSocket = "/var/run/docker.sock"
+
+// checkDockerSocketMounts reports a running container that can create
+// containers on the host as root.
+//
+// homebutler installs one of these itself — the README says `install portainer`
+// mounts the socket — and then never mentions it again. This costs one
+// `docker inspect` per running container, which is why it stops at the first
+// collector failure rather than retrying per container.
+func checkDockerSocketMounts(r *Result, inv *inventory.Inventory, inspectFn func(string) (*docker.InspectResult, error)) {
+	if inv == nil || inspectFn == nil {
+		return
+	}
+	for _, c := range inv.Containers {
+		if c.State != "running" {
+			continue
+		}
+		details, err := inspectFn(c.Name)
+		if err != nil {
+			return
+		}
+		for _, m := range details.Mounts {
+			if m.Source != dockerSocket {
+				continue
+			}
+			r.add(SeverityWarn, "docker",
+				fmt.Sprintf("%s mounts the Docker socket", c.Name),
+				"A container with "+dockerSocket+" mounted can create containers on the host as root, "+
+					"so it holds host root however unprivileged it looks. Some images need it; most do not.",
+				"Confirm this container is one that needs it, and remove the mount if it is not.",
+				"homebutler docker inspect "+c.Name)
+			break
+		}
+	}
+}
+
+// checkProxmoxTrust reports an endpoint left on insecure: true.
+//
+// #62 settled that insecure should be "last and loud". It is last — the trust
+// order is fingerprint, then CA file, then insecure — and it was loud nowhere:
+// no runtime warning, no config validate finding, and until now no doctor
+// check. A debugging session that was never undone is exactly what a periodic
+// check is for.
+func checkProxmoxTrust(r *Result, cfg *config.Config) {
+	if cfg == nil {
+		return
+	}
+	for _, p := range cfg.Proxmox {
+		if !p.Insecure {
+			continue
+		}
+		r.add(SeverityWarn, "proxmox",
+			fmt.Sprintf("Proxmox endpoint %q accepts any certificate", p.Name),
+			"insecure: true disables certificate verification entirely, so anything on the network path "+
+				"can read the API token and answer for the endpoint.",
+			"Pin the certificate with fingerprint, or trust its issuer with ca_file, and remove insecure.",
+			"homebutler proxmox status --endpoint "+p.Name)
+	}
+}
+
+// incidentDirNearCap is the fraction of the retention limit at which the
+// directory is worth mentioning. Pruning is not a failure — it is the setting
+// working — but history disappearing is worth knowing about before it is the
+// history someone wanted.
+const incidentDirNearCap = 0.8
+
+func checkIncidentRetention(r *Result, cfg *config.Config, dir string) {
+	if cfg == nil {
+		return
+	}
+	keep := cfg.Watch.Retention.MaxIncidents
+	if keep <= 0 {
+		return // unlimited by explicit request
+	}
+	if dir == "" {
+		d, err := watch.WatchDir()
+		if err != nil {
+			return
+		}
+		dir = d
+	}
+	refs, err := watch.ListIncidentRefs(dir)
+	if err != nil || len(refs) < int(float64(keep)*incidentDirNearCap) {
+		return
+	}
+	r.add(SeverityWarn, "watch",
+		fmt.Sprintf("%d of %d incidents kept", len(refs), keep),
+		"The oldest incidents are discarded once the limit is reached, so history from before that point is gone.",
+		"Raise the limit if you want to keep more, or leave it if the recent history is enough.",
+		"homebutler watch history")
 }
 
 // checkWatching reports a watch list that nothing is installed to poll.

--- a/internal/doctor/doctor_watch_test.go
+++ b/internal/doctor/doctor_watch_test.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -9,6 +10,8 @@ import (
 	"time"
 
 	"github.com/Higangssh/homebutler/internal/config"
+	"github.com/Higangssh/homebutler/internal/docker"
+	"github.com/Higangssh/homebutler/internal/inventory"
 	"github.com/Higangssh/homebutler/internal/watch"
 )
 
@@ -108,5 +111,126 @@ func TestOpenConfigWithoutSecretsIsFine(t *testing.T) {
 	checkConfigPermissions(r, &config.Config{Path: path})
 	if got := findingsFor(r, "config"); len(got) != 0 {
 		t.Errorf("a config with no secrets was flagged: %+v", got)
+	}
+}
+
+func TestDockerSocketMountIsAWarning(t *testing.T) {
+	inv := &inventory.Inventory{Containers: []docker.Container{
+		{Name: "portainer", State: "running"},
+		{Name: "nginx", State: "running"},
+	}}
+	inspect := func(name string) (*docker.InspectResult, error) {
+		if name == "portainer" {
+			return &docker.InspectResult{Mounts: []docker.Mount{
+				{Source: "/var/run/docker.sock", Destination: "/var/run/docker.sock"},
+			}}, nil
+		}
+		return &docker.InspectResult{Mounts: []docker.Mount{{Source: "/srv/data", Destination: "/data"}}}, nil
+	}
+
+	r := &Result{}
+	checkDockerSocketMounts(r, inv, inspect)
+
+	got := findingsFor(r, "docker")
+	if len(got) != 1 || got[0].Severity != SeverityWarn {
+		t.Fatalf("expected one warning, got %+v", got)
+	}
+	if !strings.Contains(got[0].Title, "portainer") {
+		t.Errorf("the finding does not name the container: %q", got[0].Title)
+	}
+	if !strings.Contains(got[0].Detail, "host root") {
+		t.Errorf("the finding does not say what the mount grants: %q", got[0].Detail)
+	}
+}
+
+// A stopped container cannot do anything with a socket it is not running on.
+func TestStoppedContainerWithTheSocketIsNotFlagged(t *testing.T) {
+	inv := &inventory.Inventory{Containers: []docker.Container{{Name: "old", State: "exited"}}}
+	called := 0
+	r := &Result{}
+	checkDockerSocketMounts(r, inv, func(string) (*docker.InspectResult, error) {
+		called++
+		return &docker.InspectResult{Mounts: []docker.Mount{{Source: "/var/run/docker.sock"}}}, nil
+	})
+	if len(findingsFor(r, "docker")) != 0 || called != 0 {
+		t.Errorf("a stopped container was inspected or flagged (calls=%d)", called)
+	}
+}
+
+// Docker being unavailable is not a finding, and must not become N of them.
+func TestInspectFailureStopsAtTheFirstContainer(t *testing.T) {
+	inv := &inventory.Inventory{Containers: []docker.Container{
+		{Name: "a", State: "running"}, {Name: "b", State: "running"}, {Name: "c", State: "running"},
+	}}
+	calls := 0
+	r := &Result{}
+	checkDockerSocketMounts(r, inv, func(string) (*docker.InspectResult, error) {
+		calls++
+		return nil, errors.New("docker daemon is not running")
+	})
+	if calls != 1 {
+		t.Errorf("a failing collector was retried per container: %d calls", calls)
+	}
+	if len(findingsFor(r, "docker")) != 0 {
+		t.Error("a collector failure produced a finding")
+	}
+}
+
+func TestInsecureProxmoxEndpointIsAWarning(t *testing.T) {
+	cfg := &config.Config{Proxmox: []config.ProxmoxConfig{
+		{Name: "pve", Insecure: true},
+		{Name: "pve2", Fingerprint: "aa:bb"},
+	}}
+	r := &Result{}
+	checkProxmoxTrust(r, cfg)
+
+	got := findingsFor(r, "proxmox")
+	if len(got) != 1 {
+		t.Fatalf("expected one warning, got %+v", got)
+	}
+	if !strings.Contains(got[0].Title, "pve") || strings.Contains(got[0].Title, "pve2") {
+		t.Errorf("the wrong endpoint was named: %q", got[0].Title)
+	}
+}
+
+func TestIncidentDirectoryNearItsCap(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 9; i++ {
+		at := time.Now().Add(time.Duration(i) * time.Second)
+		if err := watch.SaveIncident(dir, &watch.Incident{
+			ID: watch.GenerateIncidentID("nginx", at), Container: "nginx", DetectedAt: at,
+		}, 0); err != nil {
+			t.Fatalf("SaveIncident: %v", err)
+		}
+	}
+	cfg := &config.Config{}
+	cfg.Watch.Retention.MaxIncidents = 10
+
+	r := &Result{}
+	checkIncidentRetention(r, cfg, dir)
+	got := findingsFor(r, "watch")
+	if len(got) != 1 {
+		t.Fatalf("nine of ten kept should be worth mentioning, got %+v", got)
+	}
+	if !strings.Contains(got[0].Title, "9 of 10") {
+		t.Errorf("the finding does not say how full it is: %q", got[0].Title)
+	}
+}
+
+// Unlimited history is a choice, not a problem.
+func TestUnlimitedIncidentHistoryIsNotFlagged(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 5; i++ {
+		at := time.Now().Add(time.Duration(i) * time.Second)
+		_ = watch.SaveIncident(dir, &watch.Incident{ID: watch.GenerateIncidentID("n", at), Container: "n", DetectedAt: at}, 0)
+	}
+	cfg := &config.Config{}
+	cfg.Watch.Retention.MaxIncidents = -1
+	cfg.Watch.Retention.Normalize()
+
+	r := &Result{}
+	checkIncidentRetention(r, cfg, dir)
+	if got := findingsFor(r, "watch"); len(got) != 0 {
+		t.Errorf("explicitly unlimited history was flagged: %+v", got)
 	}
 }


### PR DESCRIPTION
Closes #99. The remaining three, after #144 did the first two.

**A running container that mounts the Docker socket.** It can create containers on the host as root, so it holds host root however unprivileged it looks — and homebutler installs one itself: the README says `install portainer` mounts the socket, and nothing has mentioned it since. Verified against real Docker on a Raspberry Pi rather than a fixture:

```
⚠️ [docker] sock-test mounts the Docker socket
   A container with /var/run/docker.sock mounted can create containers on the host as root,
   so it holds host root however unprivileged it looks. Some images need it; most do not.
   → Confirm this container is one that needs it, and remove the mount if it is not.
   $ homebutler docker inspect sock-test
```

with a second container on the same host not flagged. The host is back to zero afterwards: containers removed, `~/.homebutler` deleted, binary deleted, images untouched.

This costs one `docker inspect` per running container. It skips stopped ones, and stops at the first collector failure rather than turning a docker outage into one finding per container — `TestInspectFailureStopsAtTheFirstContainer` pins that.

**`insecure: true` on a Proxmox endpoint.** #62 settled that it should be "last and loud". It was last — the trust order is fingerprint, then CA file, then insecure — and loud nowhere: no runtime warning, no `config validate` finding, no check. A debugging session that was never undone is exactly what a periodic check is for.

**Incident history approaching its limit.** #101 bounded the directory; this says how full it is before the pruning starts discarding history someone wanted. Explicitly unlimited history is a choice and is not flagged.

All three run from data homebutler already had. Both config-driven checks were verified by running them, not only by their tests.
