### PR TITLE
feat: watch could be running and telling nobody

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file.
 
 ### ✨ Features
 
+- report a watch list that will tell nobody (#147). Three gates stand between an incident and a message and two are closed by default — `watch.notify.enabled` is false, and `notify_on: flapping` means a single restart is not sent — while `doctor` only checked the third, whether a channel exists at all. The person that failed is the one who did the work: configured Telegram, ran `notify test`, saw it arrive, installed the service, and was covered except for a flag nobody mentioned. When notifications are on, `doctor` now also states what the current `notify_on` will and will not send, because the value alone does not tell an operator which incidents reach them
+
 - report a running container that mounts the Docker socket (#99). A container with `/var/run/docker.sock` mounted can create containers on the host as root — it holds host root however unprivileged it looks — and homebutler installs one itself, since `install portainer` mounts the socket and nothing has mentioned it since. Costs one `docker inspect` per running container and stops at the first collector failure rather than retrying per container
 - report a Proxmox endpoint left on `insecure: true` (#99). #62 settled that it should be "last and loud"; it was last, and loud nowhere — no runtime warning, no `config validate` finding, and no check. A debugging session that was never undone is what a periodic check is for
 - report incident history approaching its limit (#99). #101 bounded the directory; knowing how full it is before the pruning starts discarding history someone wanted is the other half. Explicitly unlimited history is a choice and is not flagged

--- a/cmd/doctor.go
+++ b/cmd/doctor.go
@@ -18,7 +18,7 @@ func newDoctorCmd() *cobra.Command {
 		Short: "Diagnose homelab health, exposure, backups, and readiness",
 		Long: `Run a read-only diagnosis for the things that usually hurt self-hosted servers:
 resource pressure, stopped containers, public bind ports, backup hygiene,
-notification readiness, report baseline status, whether anything is installed
+notification readiness including whether watch will actually send anything, report baseline status, whether anything is installed
 to watch what you asked it to watch, config file permissions, containers that
 mount the Docker socket, Proxmox endpoints that accept any certificate, incident
 history nearing its limit, and configured Proxmox endpoint reachability.`,

--- a/docs/mcp-server.md
+++ b/docs/mcp-server.md
@@ -78,7 +78,7 @@ Restart your AI client — homebutler tools will appear automatically.
 |--------------------------|------------------------------------------------------------------------------------------------------------------------|
 | `system_status`          | CPU, memory, disk, uptime                                                                                              |
 | `report`                 | Butler-style health report with snapshot comparison and suggested actions                                              |
-| `doctor`                 | Read-only diagnosis of resource pressure, stopped containers, public ports, backup hygiene, notification readiness, whether a watch service is installed, config file permissions, containers mounting the Docker socket, Proxmox endpoints accepting any certificate, incident history nearing its limit, and configured Proxmox endpoint reachability |
+| `doctor`                 | Read-only diagnosis of resource pressure, stopped containers, public ports, backup hygiene, notification readiness including whether watch will actually send anything, whether a watch service is installed, config file permissions, containers mounting the Docker socket, Proxmox endpoints accepting any certificate, incident history nearing its limit, and configured Proxmox endpoint reachability |
 | `watch_check`            | One-shot restart check on watched targets; reports systemd and pm2 targets as skipped rather than healthy              |
 | `watch_history`          | Recorded restart incidents, newest first. Captured logs are excluded unless `include_logs` is set                      |
 | `watch_list`             | Targets being watched, with their kind and what the last check recorded                                                |

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -148,6 +148,7 @@ func Run(cfg *config.Config, fns CollectFuncs, opts Options) (*Result, error) {
 	checkProxmoxTrust(r, cfg)
 	checkIncidentRetention(r, cfg, fns.WatchDir)
 	checkWatching(r, fns.WatchDir, fns.WatchServiceFn)
+	checkWatchNotifications(r, cfg, fns.WatchDir)
 	checkConfigPermissions(r, cfg)
 	checkNotifications(r, cfg)
 	checkReportBaseline(r, fns.SnapshotDir)
@@ -460,6 +461,64 @@ func checkWatching(r *Result, dir string, installedFn func() (bool, string)) {
 			"This checks whether a service is installed, not whether it is running.",
 		"Install the watch service so monitoring survives logout and reboot.",
 		"homebutler watch install")
+}
+
+// checkWatchNotifications reports a watch list that will tell nobody.
+//
+// Three gates stand between an incident and a message and two are closed by
+// default: watch.notify.enabled is false, and notify_on is "flapping", under
+// which a single restart is not reported. checkNotifications covers the third
+// — no channel configured at all — so this stays quiet in that case rather
+// than making one gap into two findings.
+//
+// The person this fails is the one who did the work: configured a channel,
+// tested it, installed the service, and is covered except for a flag they
+// were never told about.
+func checkWatchNotifications(r *Result, cfg *config.Config, dir string) {
+	if cfg == nil || len(cfg.Notify.EnabledChannels()) == 0 {
+		return
+	}
+	if dir == "" {
+		d, err := watch.WatchDir()
+		if err != nil {
+			return
+		}
+		dir = d
+	}
+	targets, err := watch.LoadTargets(dir)
+	if err != nil || len(targets) == 0 {
+		return
+	}
+
+	notify := cfg.Watch.Notify
+	if !notify.Enabled {
+		r.add(SeverityWarn, "notifications",
+			"Notifications are configured and switched off for watch",
+			"A channel is set up and reachable, but watch.notify.enabled is false, so an incident is written "+
+				"to disk and printed to the terminal and nothing is sent anywhere.",
+			"Turn it on if you want to hear about incidents away from this machine.",
+			"homebutler notify test")
+		return
+	}
+
+	r.add(SeverityPass, "notifications",
+		"Watch notifications are on",
+		notifyOnMeans(notify.NotifyOn), "", "")
+}
+
+// notifyOnMeans says what the setting will and will not send, because the
+// value alone does not tell an operator which incidents reach them.
+func notifyOnMeans(mode string) string {
+	switch mode {
+	case "all":
+		return "notify_on: all — every incident is sent, including a single restart."
+	case "incident":
+		return "notify_on: incident — every incident is sent; repeated restarts are not sent again as flapping."
+	case "off":
+		return "notify_on: off — nothing is sent, despite notifications being enabled."
+	default:
+		return "notify_on: " + mode + " — repeated restarts are sent as flapping. A single restart is recorded but not sent."
+	}
 }
 
 func watchServiceInstalled() (bool, string) {

--- a/internal/doctor/doctor_watch_test.go
+++ b/internal/doctor/doctor_watch_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Higangssh/homebutler/internal/config"
 	"github.com/Higangssh/homebutler/internal/docker"
 	"github.com/Higangssh/homebutler/internal/inventory"
+	"github.com/Higangssh/homebutler/internal/notify"
 	"github.com/Higangssh/homebutler/internal/watch"
 )
 
@@ -232,5 +233,72 @@ func TestUnlimitedIncidentHistoryIsNotFlagged(t *testing.T) {
 	checkIncidentRetention(r, cfg, dir)
 	if got := findingsFor(r, "watch"); len(got) != 0 {
 		t.Errorf("explicitly unlimited history was flagged: %+v", got)
+	}
+}
+
+func cfgWithChannel() *config.Config {
+	cfg := &config.Config{}
+	cfg.Notify.Telegram = &notify.TelegramConfig{BotToken: "t", ChatID: "c"}
+	return cfg
+}
+
+// The person this fails is the one who did the work: configured a channel,
+// tested it, installed the service, and is covered except for a flag nobody
+// told them about.
+func TestConfiguredChannelWithWatchNotificationsOffIsAWarning(t *testing.T) {
+	dir := watchDirWith(t, watch.Target{Container: "nginx", AddedAt: time.Now()})
+	cfg := cfgWithChannel()
+	cfg.Watch.Notify.Enabled = false
+
+	r := &Result{}
+	checkWatchNotifications(r, cfg, dir)
+
+	got := findingsFor(r, "notifications")
+	if len(got) != 1 || got[0].Severity != SeverityWarn {
+		t.Fatalf("expected one warning, got %+v", got)
+	}
+	if !strings.Contains(got[0].Detail, "nothing is sent anywhere") {
+		t.Errorf("the finding does not say what does not happen: %q", got[0].Detail)
+	}
+}
+
+// notify_on: flapping is the default and means a single restart is silent.
+// Correct behaviour, and not something an operator can infer.
+func TestEnabledNotificationsSayWhatWillNotBeSent(t *testing.T) {
+	dir := watchDirWith(t, watch.Target{Container: "nginx", AddedAt: time.Now()})
+	cfg := cfgWithChannel()
+	cfg.Watch.Notify.Enabled = true
+	cfg.Watch.Notify.NotifyOn = "flapping"
+
+	r := &Result{}
+	checkWatchNotifications(r, cfg, dir)
+
+	got := findingsFor(r, "notifications")
+	if len(got) != 1 || got[0].Severity != SeverityPass {
+		t.Fatalf("expected one pass, got %+v", got)
+	}
+	if !strings.Contains(got[0].Detail, "single restart is recorded but not sent") {
+		t.Errorf("the pass does not say what stays silent: %q", got[0].Detail)
+	}
+}
+
+// checkNotifications already covers "no channel at all". Two findings about
+// one gap is how a report becomes noise.
+func TestNoChannelIsNotReportedTwice(t *testing.T) {
+	dir := watchDirWith(t, watch.Target{Container: "nginx", AddedAt: time.Now()})
+	r := &Result{}
+	checkWatchNotifications(r, &config.Config{}, dir)
+	if got := findingsFor(r, "notifications"); len(got) != 0 {
+		t.Errorf("an unconfigured channel was reported here too: %+v", got)
+	}
+}
+
+// Nothing on the watch list means nothing to be silent about.
+func TestEmptyWatchListSaysNothingAboutNotifications(t *testing.T) {
+	cfg := cfgWithChannel()
+	r := &Result{}
+	checkWatchNotifications(r, cfg, watchDirWith(t))
+	if got := findingsFor(r, "notifications"); len(got) != 0 {
+		t.Errorf("an empty watch list produced %+v", got)
 	}
 }


### PR DESCRIPTION
Closes #147.

`doctor` learned in #144 to say when nothing is installed to watch what you asked to be watched. The state directly next to it was unchecked: watching, and telling nobody.

Three gates stand between an incident and a message, and two are closed by default — `watch.notify.enabled` is `false`, and `notify_on: flapping` means a single restart is not sent. `checkNotifications` only looked at the third, whether a channel exists at all.

So the person it failed is the one who did the work. Configure Telegram, run `homebutler notify test`, watch it arrive, install the watch service — covered, except for a flag nobody mentioned:

```
⚠️ [notifications] Notifications are configured and switched off for watch
   A channel is set up and reachable, but watch.notify.enabled is false, so an incident is
   written to disk and printed to the terminal and nothing is sent anywhere.
   → Turn it on if you want to hear about incidents away from this machine.
   $ homebutler notify test
```

**The pass matters as much as the warning**, and is the part I would have skipped a week ago:

```
✅ [notifications] Watch notifications are on
   notify_on: flapping — repeated restarts are sent as flapping. A single restart is
   recorded but not sent.
```

`flapping` is the default and it is correct — one restart is not a flap — but it is not something an operator can be expected to infer from the word. Saying it once per `doctor` run is how it stops being a discovery made at 3 AM.

Nothing fires when no channel is configured: `checkNotifications` already covers that, and two findings about one gap is how a report becomes noise. `TestNoChannelIsNotReportedTwice` pins it.

Both states verified by running them, not only by their tests.
