### PR TITLE
chore: prepare the 0.28.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.28.0](https://github.com/Higangssh/homebutler/compare/v0.27.0...v0.28.0) - 2026-09-05
+**`doctor` knew six things it never said, and the dashboard could show you yesterday's cluster without mentioning that it was yesterday's.** Nothing was installed to poll the watch list; notifications were configured and switched off; a config holding plaintext secrets was readable by everyone; a container held the Docker socket, which is host root wearing a container's clothes; an endpoint had been left accepting any certificate after a debugging session; incident history was one restart from discarding the oldest. Every one of those was already in data homebutler had.
+
+```
+⚠️ [watch] 1 target(s) on the watch list and no service installed to check them
+⚠️ [notifications] Notifications are configured and switched off for watch
+⚠️ [docker] portainer mounts the Docker socket
+❌ [config] Config holds plaintext secrets and is readable by others (0644)
+```
 
 ### ✨ Features
 
@@ -11,7 +19,6 @@ All notable changes to this project will be documented in this file.
 - report a running container that mounts the Docker socket (#99). A container with `/var/run/docker.sock` mounted can create containers on the host as root — it holds host root however unprivileged it looks — and homebutler installs one itself, since `install portainer` mounts the socket and nothing has mentioned it since. Costs one `docker inspect` per running container and stops at the first collector failure rather than retrying per container
 - report a Proxmox endpoint left on `insecure: true` (#99). #62 settled that it should be "last and loud"; it was last, and loud nowhere — no runtime warning, no `config validate` finding, and no check. A debugging session that was never undone is what a periodic check is for
 - report incident history approaching its limit (#99). #101 bounded the directory; knowing how full it is before the pruning starts discarding history someone wanted is the other half. Explicitly unlimited history is a choice and is not flagged
-
 - tell the operator when nothing is installed to watch what they asked to be watched (#99). A watch list with entries and no supervisor is the state that makes every other monitoring feature silent — no incidents recorded, no notifications sent, nothing for `report` to compare against — and it was also the only way to never learn `watch install` exists. The finding says plainly that it checked whether a service is installed rather than whether it is running: a stopped unit is a state this cannot see, and asking systemd or launchd on every `doctor` run is a side effect the command should not grow quietly
 - report a config file that holds plaintext secrets and is readable by others, in `doctor` (#99). The check already existed in `config validate` and in `Load`'s refusal; the decision now lives in one exported function that all three call rather than three copies of `perm&0o077`
 


### PR DESCRIPTION
Closes out the `[Unreleased]` set as 0.28.0. Minor rather than patch: `doctor` answers six questions it could not answer before, and two entries land under `⚠️ Behavior changes`.

Every check added here runs on data homebutler already had. Nothing new is collected, and nothing new is asked of the operator — the whole release is the tool saying what it already knew. The one that started it was a question about whether `watch` actually alerts: three gates stand between an incident and a message and two are closed by default, and `doctor` was only checking the third.

The dashboard half is contributor work, and finishes the Proxmox set: five issues, five PRs, all from @gsaraiva2109.

Worth reading `⚠️ Behavior changes` before tagging:

- `/api/proxmox/status` reports refresh failures as HTTP 200 with a freshness body rather than 500 or 502, which anything health-checking that endpoint needs to know
- `doctor` runs on a config the other commands refuse, because the command whose job is to explain what is wrong should not be the one that will not start

Verified that the 0.27.0 and 0.26.0 sections are byte-identical to their tags and that all ten entries survived the cut.
