### PR TITLE
fix: classify Proxmox configuration failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### ✨ Features
+
+- add `configuration` and `response` Proxmox failure classes (#149). The dashboard distinguishes an unconfigured endpoint, doctor names the configuration fields to check, and watch records the precise class
+
 ## [0.28.0](https://github.com/Higangssh/homebutler/compare/v0.27.0...v0.28.0) - 2026-09-05
 **`doctor` knew six things it never said, and the dashboard could show you yesterday's cluster without mentioning that it was yesterday's.** Nothing was installed to poll the watch list; notifications were configured and switched off; a config holding plaintext secrets was readable by everyone; a container held the Docker socket, which is host root wearing a container's clothes; an endpoint had been left accepting any certificate after a debugging session; incident history was one restart from discarding the oldest. Every one of those was already in data homebutler had.
 
@@ -13,7 +19,6 @@ All notable changes to this project will be documented in this file.
 ```
 
 ### ✨ Features
-
 - report a watch list that will tell nobody (#147). Three gates stand between an incident and a message and two are closed by default — `watch.notify.enabled` is false, and `notify_on: flapping` means a single restart is not sent — while `doctor` only checked the third, whether a channel exists at all. The person that failed is the one who did the work: configured Telegram, ran `notify test`, saw it arrive, installed the service, and was covered except for a flag nobody mentioned. When notifications are on, `doctor` now also states what the current `notify_on` will and will not send, because the value alone does not tell an operator which incidents reach them
 - show whether each Proxmox dashboard snapshot is current, partial, stale, unavailable, or not configured (#106). Refresh timestamps now come from the server with the data, partial collectors keep readable results visible, and a failed refresh retains the last readable snapshot with only its safe failure class
 - report a running container that mounts the Docker socket (#99). A container with `/var/run/docker.sock` mounted can create containers on the host as root — it holds host root however unprivileged it looks — and homebutler installs one itself, since `install portainer` mounts the socket and nothing has mentioned it since. Costs one `docker inspect` per running container and stops at the first collector failure rather than retrying per container

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -217,7 +217,7 @@ func (p ProxmoxConfig) TokenFilePath() string {
 func (p ProxmoxConfig) TokenValue() (string, error) {
 	if p.TokenFile == "" {
 		if p.Token == "" {
-			return "", fmt.Errorf("proxmox token is not configured")
+			return "", proxmox.WithFailureClass(proxmox.FailureConfiguration, fmt.Errorf("proxmox token is not configured"))
 		}
 		return p.Token, nil
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -249,8 +249,8 @@ func TestProxmoxConfigTokenValue(t *testing.T) {
 	if got, err := inline.TokenValue(); err != nil || got != "inline-token" {
 		t.Errorf("TokenValue() = (%q, %v), want (inline-token, nil)", got, err)
 	}
-	if _, err := (ProxmoxConfig{}).TokenValue(); err == nil {
-		t.Error("TokenValue() should fail without a token source")
+	if _, err := (ProxmoxConfig{}).TokenValue(); err == nil || proxmox.Classify(err) != proxmox.FailureConfiguration {
+		t.Errorf("TokenValue() error = %v, want configuration error without a token source", err)
 	}
 
 	if _, err := (ProxmoxConfig{TokenFile: filepath.Join(dir, "missing"), Token: "inline-secret"}).TokenValue(); err == nil {
@@ -337,8 +337,8 @@ func TestProxmoxConfigResolveCredential(t *testing.T) {
 		t.Errorf("ResolveCredential(true) = (%q, %q, %v), want (monitoring@pve!action, action-token, nil)", tokenID, token, err)
 	}
 
-	if _, _, err := (ProxmoxConfig{Name: "pve"}).ResolveCredential(false); err == nil {
-		t.Error("ResolveCredential(false) should fail without a read token source")
+	if _, _, err := (ProxmoxConfig{Name: "pve"}).ResolveCredential(false); err == nil || proxmox.Classify(err) != proxmox.FailureConfiguration {
+		t.Errorf("ResolveCredential(false) error = %v, want configuration error without a read token source", err)
 	}
 }
 

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -574,8 +574,8 @@ func checkReportBaseline(r *Result, snapshotDir string) {
 }
 
 // checkProxmox diagnoses each configured Proxmox endpoint with read-only
-// requests. It reports one finding per endpoint and keeps TLS, authentication,
-// authorization, and transport failures distinguishable rather than
+// requests. It reports one finding per endpoint and keeps configuration, TLS,
+// authentication, authorization, response, and transport failures distinguishable rather than
 // collapsing them into a single "unavailable" result, per #105 and #111.
 func checkProxmox(r *Result, cfg *config.Config, openFn func(config.ProxmoxConfig) (*proxmox.Client, error)) {
 	if cfg == nil || len(cfg.Proxmox) == 0 {
@@ -618,12 +618,16 @@ func checkProxmoxEndpoint(r *Result, name string, client *proxmox.Client, comman
 // token to Administrator just to make a check pass (#105).
 func proxmoxFailureAction(err error) string {
 	switch proxmox.Classify(err) {
+	case proxmox.FailureConfiguration:
+		return "Check the endpoint configuration fields: host, port, timeout, token ID and token, fingerprint, and CA file."
 	case proxmox.FailureTLS:
 		return "Check the configured certificate trust: the fingerprint or CA file against the endpoint's actual certificate."
 	case proxmox.FailureAuthentication:
 		return "Check the token ID, the token value, and the token file's ownership and permissions; the token may be missing, unreadable, or revoked."
 	case proxmox.FailureAuthorization:
 		return "Check that the read-only PVEAuditor role is applied to both the API user and the privilege-separated token. Do not grant Administrator to make this pass."
+	case proxmox.FailureResponse:
+		return "Check that the configured host and port serve the Proxmox API, not a reverse-proxy error page."
 	case proxmox.FailureTransport:
 		return "Check network reachability to the configured host and port, and any firewall rules in between."
 	default:

--- a/internal/doctor/doctor_proxmox_test.go
+++ b/internal/doctor/doctor_proxmox_test.go
@@ -180,6 +180,29 @@ func TestCheckProxmox_TokenFileUnreadableIsFail(t *testing.T) {
 	}
 }
 
+func TestCheckProxmox_ConfigurationFailureNamesFields(t *testing.T) {
+	cfg := &config.Config{Proxmox: []config.ProxmoxConfig{{Name: "home"}}}
+	r := &Result{}
+	checkProxmox(r, cfg, func(config.ProxmoxConfig) (*proxmox.Client, error) {
+		return nil, proxmox.WithFailureClass(proxmox.FailureConfiguration, fmt.Errorf("proxmox host is required"))
+	})
+
+	f := findTitle(r.Findings, `Proxmox endpoint "home" could not be configured`)
+	if f == nil || f.Severity != SeverityFail {
+		t.Fatalf("expected configuration finding, got: %#v", r.Findings)
+	}
+	if !strings.Contains(f.Action, "host, port, timeout") || !strings.Contains(f.Action, "CA file") {
+		t.Fatalf("expected configuration action naming fields, got: %q", f.Action)
+	}
+}
+
+func TestProxmoxFailureAction_Response(t *testing.T) {
+	action := proxmoxFailureAction(proxmox.WithFailureClass(proxmox.FailureResponse, fmt.Errorf("decode Proxmox response")))
+	if !strings.Contains(action, "Proxmox API") || !strings.Contains(action, "reverse-proxy") {
+		t.Fatalf("response action = %q", action)
+	}
+}
+
 func TestCheckProxmox_NoEndpointsIsSilent(t *testing.T) {
 	r := &Result{}
 	checkProxmox(r, &config.Config{}, openProxmoxEndpoint)

--- a/internal/proxmox/client.go
+++ b/internal/proxmox/client.go
@@ -28,6 +28,8 @@ const defaultTimeout = 10 * time.Second
 type FailureClass string
 
 const (
+	FailureConfiguration  FailureClass = "configuration"
+	FailureResponse       FailureClass = "response"
 	FailureTLS            FailureClass = "tls"
 	FailureAuthentication FailureClass = "authentication"
 	FailureAuthorization  FailureClass = "authorization"
@@ -99,27 +101,27 @@ type Client struct {
 // New returns a client configured for one Proxmox endpoint.
 func New(options Options) (*Client, error) {
 	if options.Host == "" {
-		return nil, fmt.Errorf("proxmox host is required")
+		return nil, WithFailureClass(FailureConfiguration, fmt.Errorf("proxmox host is required"))
 	}
 	if options.TokenID == "" || options.Token == "" {
-		return nil, fmt.Errorf("proxmox token ID and token are required")
+		return nil, WithFailureClass(FailureConfiguration, fmt.Errorf("proxmox token ID and token are required"))
 	}
 	if options.Port == 0 {
 		options.Port = 8006
 	}
 	if options.Port < 1 || options.Port > 65535 {
-		return nil, fmt.Errorf("invalid Proxmox port %d", options.Port)
+		return nil, WithFailureClass(FailureConfiguration, fmt.Errorf("invalid Proxmox port %d", options.Port))
 	}
 	if options.Timeout == 0 {
 		options.Timeout = defaultTimeout
 	}
 	if options.Timeout < 0 {
-		return nil, fmt.Errorf("invalid Proxmox timeout %s", options.Timeout)
+		return nil, WithFailureClass(FailureConfiguration, fmt.Errorf("invalid Proxmox timeout %s", options.Timeout))
 	}
 
 	tlsConfig, err := tlsConfig(options)
 	if err != nil {
-		return nil, WithFailureClass(FailureTLS, err)
+		return nil, WithFailureClass(FailureConfiguration, err)
 	}
 
 	return &Client{
@@ -156,7 +158,7 @@ func tlsConfig(options Options) (*tls.Config, error) {
 				return WithFailureClass(FailureTLS, fmt.Errorf("proxmox TLS peer sent no certificate"))
 			}
 			if _, err := x509.ParseCertificate(rawCerts[0]); err != nil {
-				return fmt.Errorf("parse Proxmox TLS certificate: %w", err)
+				return WithFailureClass(FailureTLS, fmt.Errorf("parse Proxmox TLS certificate: %w", err))
 			}
 			actual := sha256.Sum256(rawCerts[0])
 			if subtle.ConstantTimeCompare(actual[:], expected) != 1 {
@@ -170,11 +172,11 @@ func tlsConfig(options Options) (*tls.Config, error) {
 	if options.CAFile != "" {
 		pem, err := os.ReadFile(options.CAFile)
 		if err != nil {
-			return nil, WithFailureClass(FailureTLS, fmt.Errorf("read Proxmox CA file: %w", err))
+			return nil, WithFailureClass(FailureConfiguration, fmt.Errorf("read Proxmox CA file: %w", err))
 		}
 		pool := x509.NewCertPool()
 		if !pool.AppendCertsFromPEM(pem) {
-			return nil, WithFailureClass(FailureTLS, fmt.Errorf("proxmox CA file contains no certificates"))
+			return nil, WithFailureClass(FailureConfiguration, fmt.Errorf("proxmox CA file contains no certificates"))
 		}
 		config.RootCAs = pool
 		return config, nil
@@ -190,7 +192,7 @@ func parseFingerprint(value string) ([]byte, error) {
 	value = strings.ReplaceAll(strings.TrimSpace(value), ":", "")
 	fingerprint, err := hex.DecodeString(value)
 	if err != nil || len(fingerprint) != sha256.Size {
-		return nil, WithFailureClass(FailureTLS, fmt.Errorf("proxmox fingerprint must be a SHA-256 certificate fingerprint"))
+		return nil, WithFailureClass(FailureConfiguration, fmt.Errorf("proxmox fingerprint must be a SHA-256 certificate fingerprint"))
 	}
 	return fingerprint, nil
 }
@@ -220,25 +222,25 @@ func (c *Client) Resources(ctx context.Context) (Resources, error) {
 			Type string `json:"type"`
 		}
 		if err := json.Unmarshal(item, &kind); err != nil {
-			return Resources{}, fmt.Errorf("decode Proxmox resource type: %w", err)
+			return Resources{}, WithFailureClass(FailureResponse, fmt.Errorf("decode Proxmox resource type: %w", err))
 		}
 		switch kind.Type {
 		case "node":
 			var node Node
 			if err := json.Unmarshal(item, &node); err != nil {
-				return Resources{}, fmt.Errorf("decode Proxmox node: %w", err)
+				return Resources{}, WithFailureClass(FailureResponse, fmt.Errorf("decode Proxmox node: %w", err))
 			}
 			resources.Nodes = append(resources.Nodes, node)
 		case "qemu", "lxc":
 			var guest Guest
 			if err := json.Unmarshal(item, &guest); err != nil {
-				return Resources{}, fmt.Errorf("decode Proxmox guest: %w", err)
+				return Resources{}, WithFailureClass(FailureResponse, fmt.Errorf("decode Proxmox guest: %w", err))
 			}
 			resources.Guests = append(resources.Guests, guest)
 		case "storage":
 			var store Store
 			if err := json.Unmarshal(item, &store); err != nil {
-				return Resources{}, fmt.Errorf("decode Proxmox storage: %w", err)
+				return Resources{}, WithFailureClass(FailureResponse, fmt.Errorf("decode Proxmox storage: %w", err))
 			}
 			resources.Storage = append(resources.Storage, store)
 		}
@@ -464,10 +466,10 @@ func (c *Client) request(ctx context.Context, method, path string, query url.Val
 		Data json.RawMessage `json:"data"`
 	}
 	if err := json.Unmarshal(body, &envelope); err != nil {
-		return fmt.Errorf("decode Proxmox response %s: %w", path, err)
+		return WithFailureClass(FailureResponse, fmt.Errorf("decode Proxmox response %s: %w", path, err))
 	}
 	if err := json.Unmarshal(envelope.Data, out); err != nil {
-		return fmt.Errorf("decode Proxmox data %s: %w", path, err)
+		return WithFailureClass(FailureResponse, fmt.Errorf("decode Proxmox data %s: %w", path, err))
 	}
 	return nil
 }

--- a/internal/proxmox/client_test.go
+++ b/internal/proxmox/client_test.go
@@ -531,19 +531,25 @@ func TestTLSModes(t *testing.T) {
 
 func TestFailureClassification(t *testing.T) {
 	t.Run("CA file unreadable", func(t *testing.T) {
-		// A missing or unreadable CA file is a certificate trust problem, not
-		// a credential problem: the token is never even read. Classifying it
-		// FailureAuthentication sent an operator staring at a fine token
-		// while pointing at "the token may be missing, unreadable, or
-		// revoked" instead of the ca_file setting that is actually wrong.
 		_, err := New(Options{Host: "pve.example", TokenID: "id", Token: "secret", CAFile: "missing.pem"})
-		if Classify(err) != FailureTLS {
-			t.Fatalf("Classify(%v) = %q, want %q", err, Classify(err), FailureTLS)
+		if Classify(err) != FailureConfiguration {
+			t.Fatalf("Classify(%v) = %q, want %q", err, Classify(err), FailureConfiguration)
 		}
 	})
 
 	t.Run("fingerprint format", func(t *testing.T) {
 		_, err := New(Options{Host: "pve.example", TokenID: "id", Token: "secret", Fingerprint: "not-hex"})
+		if Classify(err) != FailureConfiguration {
+			t.Fatalf("Classify(%v) = %q, want %q", err, Classify(err), FailureConfiguration)
+		}
+	})
+
+	t.Run("TLS peer certificate parse", func(t *testing.T) {
+		config, err := tlsConfig(Options{Fingerprint: strings.Repeat("00", sha256.Size)})
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = config.VerifyPeerCertificate([][]byte{[]byte("not a certificate")}, nil)
 		if Classify(err) != FailureTLS {
 			t.Fatalf("Classify(%v) = %q, want %q", err, Classify(err), FailureTLS)
 		}
@@ -598,6 +604,25 @@ func TestFailureClassification(t *testing.T) {
 			t.Fatalf("Classify(%v) = %q, want %q", err, Classify(err), FailureTransport)
 		}
 	})
+
+	for _, tt := range []struct {
+		name string
+		body string
+	}{
+		{name: "response decode", body: "<html>not Proxmox</html>"},
+		{name: "data decode", body: `{"data":"not a version"}`},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			defer server.Close()
+			_, err := testClient(t, server.URL).Version(context.Background())
+			if Classify(err) != FailureResponse {
+				t.Fatalf("Classify(%v) = %q, want %q", err, Classify(err), FailureResponse)
+			}
+		})
+	}
 }
 
 type roundTripperFunc func(*http.Request) (*http.Response, error)
@@ -610,17 +635,29 @@ func (errReader) Read([]byte) (int, error) { return 0, errors.New("read failed")
 func (errReader) Close() error             { return nil }
 
 func TestNewValidation(t *testing.T) {
-	for _, options := range []Options{
-		{TokenID: "id", Token: "token"},
-		{Host: "pve.example", Token: "token"},
-		{Host: "pve.example", TokenID: "id"},
-		{Host: "pve.example", TokenID: "id", Token: "token", Port: 70000},
-		{Host: "pve.example", TokenID: "id", Token: "token", Timeout: -time.Second},
-		{Host: "pve.example", TokenID: "id", Token: "token", Fingerprint: "bad"},
+	emptyCAFile := filepath.Join(t.TempDir(), "empty-ca.pem")
+	if err := os.WriteFile(emptyCAFile, nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	for _, tt := range []struct {
+		name    string
+		options Options
+	}{
+		{name: "missing host", options: Options{TokenID: "id", Token: "token"}},
+		{name: "missing token ID", options: Options{Host: "pve.example", Token: "token"}},
+		{name: "missing token", options: Options{Host: "pve.example", TokenID: "id"}},
+		{name: "invalid port", options: Options{Host: "pve.example", TokenID: "id", Token: "token", Port: 70000}},
+		{name: "invalid timeout", options: Options{Host: "pve.example", TokenID: "id", Token: "token", Timeout: -time.Second}},
+		{name: "malformed fingerprint", options: Options{Host: "pve.example", TokenID: "id", Token: "token", Fingerprint: "bad"}},
+		{name: "unreadable CA file", options: Options{Host: "pve.example", TokenID: "id", Token: "token", CAFile: "missing.pem"}},
+		{name: "empty CA file", options: Options{Host: "pve.example", TokenID: "id", Token: "token", CAFile: emptyCAFile}},
 	} {
-		if _, err := New(options); err == nil {
-			t.Errorf("New(%+v) error = nil", options)
-		}
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := New(tt.options)
+			if err == nil || Classify(err) != FailureConfiguration {
+				t.Errorf("Classify(%v) = %q, want %q", err, Classify(err), FailureConfiguration)
+			}
+		})
 	}
 }
 

--- a/internal/server/proxmox_test.go
+++ b/internal/server/proxmox_test.go
@@ -111,15 +111,16 @@ func TestProxmoxStatusSelectsEndpointAndPreservesPartialResults(t *testing.T) {
 	}
 }
 
-func TestProxmoxStatusHidesCredentialPaths(t *testing.T) {
+func TestProxmoxStatusHidesSensitiveDetails(t *testing.T) {
 	tests := []struct {
 		name     string
 		endpoint config.ProxmoxConfig
-		secret   string
+		secrets  []string
 		class    string
 	}{
-		{name: "token file", endpoint: config.ProxmoxConfig{Name: "pve", Host: "pve.example", TokenID: "monitoring@pve!readonly", TokenFile: "/sensitive/proxmox-token"}, secret: "/sensitive/proxmox-token", class: "authentication"},
-		{name: "CA file", endpoint: config.ProxmoxConfig{Name: "pve", Host: "pve.example", TokenID: "monitoring@pve!readonly", Token: "test-token", CAFile: "/sensitive/proxmox-ca.pem"}, secret: "/sensitive/proxmox-ca.pem", class: "tls"},
+		{name: "token file", endpoint: config.ProxmoxConfig{Name: "pve", Host: "pve.example", TokenID: "monitoring@pve!readonly", TokenFile: "/sensitive/proxmox-token"}, secrets: []string{"/sensitive/proxmox-token"}, class: "authentication"},
+		{name: "CA file", endpoint: config.ProxmoxConfig{Name: "pve", Host: "pve.example", TokenID: "monitoring@pve!readonly", Token: "test-token", CAFile: "/sensitive/proxmox-ca.pem"}, secrets: []string{"/sensitive/proxmox-ca.pem"}, class: "configuration"},
+		{name: "missing read token", endpoint: config.ProxmoxConfig{Name: "pve", Host: "pve.example", TokenID: "monitoring@pve!readonly"}, secrets: []string{"proxmox token is not configured", "monitoring@pve!readonly"}, class: "configuration"},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -130,8 +131,10 @@ func TestProxmoxStatusHidesCredentialPaths(t *testing.T) {
 			if recorder.Code != http.StatusOK {
 				t.Fatalf("status = %d, want %d", recorder.Code, http.StatusOK)
 			}
-			if strings.Contains(recorder.Body.String(), test.secret) {
-				t.Fatalf("response leaked credential path %q", test.secret)
+			for _, secret := range test.secrets {
+				if strings.Contains(recorder.Body.String(), secret) {
+					t.Fatalf("response leaked sensitive detail %q", secret)
+				}
 			}
 			if !strings.Contains(recorder.Body.String(), `"status":"unavailable"`) {
 				t.Fatalf("response = %s, want unavailable status", recorder.Body.String())

--- a/internal/watch/proxmox_monitor.go
+++ b/internal/watch/proxmox_monitor.go
@@ -182,10 +182,14 @@ func (pm *ProxmoxMonitor) endpointState(err error) proxmoxEndpointState {
 	switch proxmox.Classify(err) {
 	case proxmox.FailureAuthorization:
 		return proxmoxEndpointState{state: ProxmoxStateACLFiltered, class: string(proxmox.FailureAuthorization)}
+	case proxmox.FailureConfiguration:
+		return proxmoxEndpointState{state: ProxmoxStateUnavailable, class: string(proxmox.FailureConfiguration)}
 	case proxmox.FailureTLS:
 		return proxmoxEndpointState{state: ProxmoxStateUnavailable, class: string(proxmox.FailureTLS)}
 	case proxmox.FailureAuthentication:
 		return proxmoxEndpointState{state: ProxmoxStateUnavailable, class: string(proxmox.FailureAuthentication)}
+	case proxmox.FailureResponse:
+		return proxmoxEndpointState{state: ProxmoxStateUnavailable, class: string(proxmox.FailureResponse)}
 	default:
 		return proxmoxEndpointState{state: ProxmoxStateUnavailable, class: string(proxmox.FailureTransport)}
 	}

--- a/internal/watch/proxmox_monitor_test.go
+++ b/internal/watch/proxmox_monitor_test.go
@@ -236,6 +236,16 @@ func TestProxmoxMonitorAuthorizationFailureIsACLFiltered(t *testing.T) {
 	}
 }
 
+func TestProxmoxMonitorConfigurationAndResponseFailuresKeepTheirClasses(t *testing.T) {
+	pm := &ProxmoxMonitor{}
+	for _, class := range []proxmox.FailureClass{proxmox.FailureConfiguration, proxmox.FailureResponse} {
+		state := pm.endpointState(proxmox.WithFailureClass(class, fmt.Errorf("fixture")))
+		if state.state != ProxmoxStateUnavailable || state.class != string(class) {
+			t.Errorf("state for %q = %+v, want unavailable/%q", class, state, class)
+		}
+	}
+}
+
 func TestProxmoxMonitorSeedDoesNotAlertOnAlreadyStoppedGuest(t *testing.T) {
 	script := &scriptedServer{responses: []scriptedResponse{
 		{body: resourcesResponse(oneNode, guestJSON("pve1", "qemu", 100, "stopped"))},

--- a/internal/watch/store.go
+++ b/internal/watch/store.go
@@ -88,8 +88,8 @@ type Incident struct {
 	// ProxmoxState is the state the incident transitioned into: "unavailable",
 	// "acl_filtered", or "guest_down". Empty outside Source == "proxmox".
 	ProxmoxState string `json:"proxmox_state,omitempty"`
-	// ProxmoxClass is the specific failure behind ProxmoxState — tls,
-	// authentication, authorization, transport, or empty_result — kept
+	// ProxmoxClass is the specific failure behind ProxmoxState: configuration,
+	// tls, authentication, authorization, response, transport, or empty_result, kept
 	// alongside the coarser state per #104.
 	ProxmoxClass string `json:"proxmox_class,omitempty"`
 	// Recovered marks a transition back to healthy rather than into failure.

--- a/web/src/lib/ProxmoxCard.svelte
+++ b/web/src/lib/ProxmoxCard.svelte
@@ -70,6 +70,8 @@
       tls: 'TLS verification failed',
       authentication: 'Authentication failed',
       authorization: 'Authorization/ACL failure',
+      configuration: 'Configuration failed',
+      response: 'Unexpected endpoint response',
       transport: 'Transport failure',
     }[value] || '';
   }
@@ -169,11 +171,13 @@
           Partially readable · Updated <time datetime={data.updated_at} title={formatTimestamp(data.updated_at)}>{formatAge(data.updated_at)}</time>
         {:else if data.status === 'stale'}
           Stale · Last successful update <time datetime={data.updated_at} title={formatTimestamp(data.updated_at)}>{formatAge(data.updated_at)}</time>
+        {:else if data.status === 'unavailable' && data.failure_class === 'configuration'}
+          Proxmox is not configured
         {:else}
           Unavailable
         {/if}
         {#if failureDetails()} · Failed collectors: {failureDetails()}{/if}
-        {#if !failedCollectors() && failureLabel(data.failure_class)} · {failureLabel(data.failure_class)}{/if}
+        {#if !failedCollectors() && failureLabel(data.failure_class) && !(data.status === 'unavailable' && data.failure_class === 'configuration')} · {failureLabel(data.failure_class)}{/if}
         {#if data.message} · {data.message}{/if}
       </p>
 

--- a/web/src/lib/ProxmoxCard.test.js
+++ b/web/src/lib/ProxmoxCard.test.js
@@ -72,6 +72,17 @@ describe('Proxmox freshness states', () => {
     expect(document.body.textContent).not.toContain('monitoring@pve!readonly');
   });
 
+  it('shows configuration failures as not configured without rendering data', async () => {
+    const status = await show({ status: 'unavailable', failure_class: 'configuration' });
+    expect(status.textContent.replace(/\s+/g, ' ').trim()).toBe('Proxmox is not configured');
+    expect(screen.queryByRole('table')).toBeNull();
+  });
+
+  it('labels an unexpected endpoint response', async () => {
+    const status = await show({ status: 'unavailable', failure_class: 'response' });
+    expect(status.textContent.replace(/\s+/g, ' ')).toContain('Unavailable · Unexpected endpoint response');
+  });
+
   it('does not assign a classified collector reason to an unclassified failure', async () => {
     const status = await show({ status: 'unavailable', failed_collectors: ['version', 'cluster'], failure_classes: { cluster: 'authorization' }, failure_class: 'authorization' });
     expect(status.textContent.replace(/\s+/g, ' ')).toContain('version, cluster: Authorization/ACL failure');


### PR DESCRIPTION
## What does this PR do?

Adds `FailureConfiguration` for Proxmox settings rejected before dialing and `FailureResponse` for endpoints that return invalid Proxmox API payloads.

It also keeps peer verification errors under `FailureTLS`, gives doctor actionable guidance, preserves exact classes in watch incidents, and shows missing dashboard configuration without exposing raw errors.

Closes #149

## Testing

- `go test ./... -race` with an isolated HOME
- `go vet ./...`
- `golangci-lint run`
- `go build ./...`
- `npm --prefix web test`
- `npm --prefix web run build`
- `git diff --check`

## Checklist

- [x] `gofmt -w .` code is formatted
- [x] `go build ./...` builds without errors
- [x] `go test ./...` all tests pass
- [x] Tests added for new functionality
- [x] User-visible behavior documented in `CHANGELOG.md`